### PR TITLE
Refactoring: Replace printStackTrace() calls using logger output

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -16,11 +16,15 @@ import artofillusion.ui.*;
 import java.io.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class keeps track of program-wide user preferences. */
 
 public class ApplicationPreferences
 {
+    private static final Logger logger = Logger.getLogger(ApplicationPreferences.class.getName());
+
   private Properties properties;
   private int defaultDisplayMode, undoLevels;
   private double interactiveTol;
@@ -58,7 +62,7 @@ public class ApplicationPreferences
       }
     catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
   }
 
@@ -76,7 +80,7 @@ public class ApplicationPreferences
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -112,7 +116,7 @@ public class ApplicationPreferences
       }
     catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
   }
 

--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -31,6 +31,8 @@ import java.net.*;
 import java.util.*;
 import java.util.List;
 import java.lang.reflect.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -41,6 +43,8 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 public class ArtOfIllusion
 {
+    private static final Logger logger = Logger.getLogger(ArtOfIllusion.class.getName());
+
   public static final String APP_DIRECTORY, PLUGIN_DIRECTORY;
   public static final String TOOL_SCRIPT_DIRECTORY, OBJECT_SCRIPT_DIRECTORY, STARTUP_SCRIPT_DIRECTORY;
   public static final ImageIcon APP_ICON;
@@ -210,7 +214,7 @@ public class ArtOfIllusion
       }
       catch (Throwable tx)
       {
-        tx.printStackTrace();
+        logger.log(Level.INFO, "Exception", tx);
         String name = plugins.get(i).getClass().getName();
         name = name.substring(name.lastIndexOf('.')+1);
         new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginInitError", name)), BStandardDialog.ERROR).showMessageDialog(null);
@@ -224,7 +228,7 @@ public class ArtOfIllusion
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     runStartupScripts();
@@ -293,7 +297,7 @@ public class ArtOfIllusion
           }
           catch (Throwable tx)
           {
-            tx.printStackTrace();
+            logger.log(Level.INFO, "Exception", tx);
             String name = plugins.get(i).getClass().getName();
             name = name.substring(name.lastIndexOf('.')+1);
             new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginNotifyError", name)), BStandardDialog.ERROR).showMessageDialog(null);
@@ -341,7 +345,7 @@ public class ArtOfIllusion
             }
             catch (Throwable tx)
             {
-              tx.printStackTrace();
+              logger.log(Level.INFO, "Exception", tx);
               String name = plugins.get(i).getClass().getName();
               name = name.substring(name.lastIndexOf('.')+1);
               new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginNotifyError", name)), BStandardDialog.ERROR).showMessageDialog(null);
@@ -380,7 +384,7 @@ public class ArtOfIllusion
       }
       catch (Throwable tx)
       {
-        tx.printStackTrace();
+        logger.log(Level.INFO, "Exception", tx);
         String name = plugins.get(i).getClass().getName();
         name = name.substring(name.lastIndexOf('.')+1);
         new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginNotifyError", name)), BStandardDialog.ERROR).showMessageDialog(null);
@@ -408,7 +412,7 @@ public class ArtOfIllusion
           }
           catch (IOException ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
           }
         }
         catch (IllegalArgumentException ex)
@@ -502,7 +506,7 @@ public class ArtOfIllusion
         }
         catch (Throwable tx)
         {
-          tx.printStackTrace();
+          logger.log(Level.INFO, "Exception", tx);
           String name = plugins.get(i).getClass().getName();
           name = name.substring(name.lastIndexOf('.')+1);
           new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginNotifyError", name)), BStandardDialog.ERROR).showMessageDialog(null);

--- a/ArtOfIllusion/src/artofillusion/CameraFilterDialog.java
+++ b/ArtOfIllusion/src/artofillusion/CameraFilterDialog.java
@@ -20,11 +20,14 @@ import buoy.widget.*;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This is dialog in which the user can edit the list of filters attached to a camera. */
 
 public class CameraFilterDialog extends BDialog implements RenderListener
 {
+    private static final Logger logger = Logger.getLogger(CameraFilterDialog.class.getName());
   private SceneCamera theCamera;
   private Scene theScene;
   private CoordinateSystem cameraCoords;
@@ -343,7 +346,7 @@ public class CameraFilterDialog extends BDialog implements RenderListener
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
       rebuildFilterList();
@@ -400,7 +403,7 @@ public class CameraFilterDialog extends BDialog implements RenderListener
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
       updateComponents();
       filterChangedCallback.run();

--- a/ArtOfIllusion/src/artofillusion/MaterialMappingDialog.java
+++ b/ArtOfIllusion/src/artofillusion/MaterialMappingDialog.java
@@ -18,6 +18,8 @@ import buoy.widget.*;
 import java.awt.Insets;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class implements the dialog box which is used to choose material mappings for objects. 
     It presents a list of all mappings which can be used with the current object and material,
@@ -25,6 +27,8 @@ import java.util.*;
 
 public class MaterialMappingDialog extends BDialog
 {
+    private static final Logger logger = Logger.getLogger(MaterialMappingDialog.class.getName());
+
   private BFrame fr;
   private Object3D obj;
   private Vector mappings;
@@ -84,7 +88,7 @@ public class MaterialMappingDialog extends BDialog
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     mapChoice.addEventLink(ValueChangedEvent.class, this, "mappingChanged");
@@ -128,7 +132,7 @@ public class MaterialMappingDialog extends BDialog
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
   

--- a/ArtOfIllusion/src/artofillusion/ObjectPropertiesPanel.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectPropertiesPanel.java
@@ -24,6 +24,8 @@ import java.util.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This is a panel which displays information about the currently selected objects, and allows them
@@ -32,6 +34,8 @@ import java.util.List;
 
 public class ObjectPropertiesPanel extends ColumnContainer
 {
+    private static final Logger logger = Logger.getLogger(ObjectPropertiesPanel.class.getName());
+
   private LayoutWindow window;
   private BTextField nameField;
   private ValueField xPosField, yPosField, zPosField, xRotField, yRotField, zRotField;
@@ -208,7 +212,7 @@ public class ObjectPropertiesPanel extends ColumnContainer
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
         }
       }
       textureChoice.setModel(new DefaultComboBoxModel(names));
@@ -255,7 +259,7 @@ public class ObjectPropertiesPanel extends ColumnContainer
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
       materialChoice.setModel(new DefaultComboBoxModel(names));
@@ -484,7 +488,7 @@ public class ObjectPropertiesPanel extends ColumnContainer
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
     }
@@ -536,7 +540,7 @@ public class ObjectPropertiesPanel extends ColumnContainer
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     if (noMaterial || mat != null)

--- a/ArtOfIllusion/src/artofillusion/ObjectTextureDialog.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectTextureDialog.java
@@ -20,6 +20,8 @@ import buoy.widget.*;
 import java.awt.*;
 import java.lang.reflect.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class implements the dialog box which is used to choose textures for objects.
     It presents a list of all available textures from which the user can select one.
@@ -28,6 +30,7 @@ import java.util.List;
 
 public class ObjectTextureDialog extends BDialog implements ListChangeListener
 {
+    private static final Logger logger = Logger.getLogger(ObjectTextureDialog.class.getName());
   private LayoutWindow window;
   private Scene scene;
   private ObjectInfo obj[], editObj;
@@ -151,7 +154,7 @@ public class ObjectTextureDialog extends BDialog implements ListChangeListener
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     newTextureChoice.addEventLink(ValueChangedEvent.class, this, "doNewTexture");
@@ -184,7 +187,7 @@ public class ObjectTextureDialog extends BDialog implements ListChangeListener
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     newMaterialChoice.addEventLink(ValueChangedEvent.class, this, "doNewMaterial");
@@ -518,7 +521,7 @@ public class ObjectTextureDialog extends BDialog implements ListChangeListener
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -547,7 +550,7 @@ public class ObjectTextureDialog extends BDialog implements ListChangeListener
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/PluginRegistry.java
+++ b/ArtOfIllusion/src/artofillusion/PluginRegistry.java
@@ -21,6 +21,8 @@ import java.lang.reflect.*;
 
 import artofillusion.ui.*;
 import artofillusion.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.*;
 
@@ -28,6 +30,8 @@ import org.w3c.dom.*;
 
 public class PluginRegistry
 {
+    private static final Logger logger = Logger.getLogger(PluginRegistry.class.getName());
+
   private static final ArrayList<ClassLoader> pluginLoaders = new ArrayList<ClassLoader>();
   private static final HashSet<Class> categories = new HashSet<Class>();
   private static final HashMap<Class, List<Object>> categoryClasses = new HashMap<Class, List<Object>>();
@@ -206,8 +210,7 @@ public class PluginRegistry
     catch (Exception ex)
     {
       new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginLoadError", jar.file.getName())), BStandardDialog.ERROR).showMessageDialog(null);
-      System.err.println("*** Exception while initializing plugin "+jar.file.getName()+":");
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception while initializing plugin " + jar.file.getName() + ": ", ex);
     }
   }
 
@@ -587,8 +590,7 @@ public class PluginRegistry
       }
       catch (Exception ex)
       {
-        System.err.println("*** Exception while parsing extensions.xml for plugin "+file.getName()+":");
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception while parsing extensions.xml for plugin " + file.getName() + ": ", ex);
         throw new IOException();
       }
     }

--- a/ArtOfIllusion/src/artofillusion/RenderingDialog.java
+++ b/ArtOfIllusion/src/artofillusion/RenderingDialog.java
@@ -18,11 +18,15 @@ import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class implements the dialog box in which the user can watch a scene being rendered. */
 
 public class RenderingDialog extends BDialog implements RenderListener
 {
+    private static final Logger logger = Logger.getLogger(RenderingDialog.class.getName());
+
   private CustomWidget canvas;
   private Image previewImage;
   private ComplexImage originalImage, filteredImage;
@@ -352,7 +356,7 @@ public class RenderingDialog extends BDialog implements RenderListener
     {
       // This generally means the thread has been interrupted, which we can just ignore.
 
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/Scene.java
+++ b/ArtOfIllusion/src/artofillusion/Scene.java
@@ -25,12 +25,17 @@ import java.util.*;
 import java.util.List;
 import java.util.zip.*;
 import java.beans.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** The Scene class describes a collection of objects, arranged relative to each other to
     form a scene, as well as the available textures and materials, environment options, etc. */
 
 public class Scene
 {
+
+    private static final Logger logger = Logger.getLogger(Scene.class.getName());
+
   private Vector<ObjectInfo> objects;
   private Vector<Material> materials;
   private Vector<Texture> textures;
@@ -1255,7 +1260,7 @@ public class Scene
               }
             catch (Exception ex)
               {
-                ex.printStackTrace();
+                  logger.log(Level.INFO, "Exception", ex);
                 if (ex instanceof ClassNotFoundException)
                   loadingErrors.append(Translate.text("errorFindingClass", classname)).append('\n');
                 else
@@ -1268,7 +1273,7 @@ public class Scene
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
             throw new IOException();
           }
       }
@@ -1295,7 +1300,7 @@ public class Scene
               }
             catch (Exception ex)
               {
-                ex.printStackTrace();
+                logger.log(Level.INFO, "Exception", ex);
                 if (ex instanceof ClassNotFoundException)
                   loadingErrors.append(Translate.text("errorFindingClass", classname)).append('\n');
                 else
@@ -1308,7 +1313,7 @@ public class Scene
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
             throw new IOException();
           }
       }
@@ -1403,7 +1408,7 @@ public class Scene
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
           // Nothing more we can do about it.
         }
       }
@@ -1443,9 +1448,9 @@ public class Scene
             catch (Exception ex)
               {
                 if (ex instanceof InvocationTargetException)
-                  ((InvocationTargetException) ex).getTargetException().printStackTrace();
+                    logger.log(Level.INFO, "Exception", ((InvocationTargetException)ex).getTargetException());
                 else
-                  ex.printStackTrace();
+                    logger.log(Level.INFO, "Exception", ex);
                 if (ex instanceof ClassNotFoundException)
                   loadingErrors.append(info.getName()).append(": ").append(Translate.text("errorFindingClass", classname)).append('\n');
                 else
@@ -1458,7 +1463,7 @@ public class Scene
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
             throw new IOException();
           }
       }
@@ -1505,7 +1510,7 @@ public class Scene
       }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new IOException();
       }
     return info;
@@ -1630,9 +1635,9 @@ public class Scene
     ExceptionListener exceptionListener = new ExceptionListener()
       {
         @Override
-        public void exceptionThrown(Exception e)
+        public void exceptionThrown(Exception ex)
         {
-          e.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       };
     for (Map.Entry<String, Object> entry : metadataMap.entrySet())

--- a/ArtOfIllusion/src/artofillusion/TextureMappingDialog.java
+++ b/ArtOfIllusion/src/artofillusion/TextureMappingDialog.java
@@ -20,6 +20,8 @@ import java.awt.*;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class implements the dialog box which is used to choose texture mappings for objects. 
     It presents a list of all mappings which can be used with the current object and material,
@@ -27,6 +29,7 @@ import java.util.List;
 
 public class TextureMappingDialog extends BDialog
 {
+    private static final Logger logger = Logger.getLogger(TextureMappingDialog.class.getName());
   private BFrame fr;
   private FormContainer content;
   private Object3D origObj, editObj;
@@ -102,7 +105,7 @@ public class TextureMappingDialog extends BDialog
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     mapChoice.addEventLink(ValueChangedEvent.class, this, "mappingChanged");
@@ -147,7 +150,7 @@ public class TextureMappingDialog extends BDialog
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
   

--- a/ArtOfIllusion/src/artofillusion/TexturesAndMaterialsDialog.java
+++ b/ArtOfIllusion/src/artofillusion/TexturesAndMaterialsDialog.java
@@ -27,9 +27,13 @@ import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TexturesAndMaterialsDialog extends BDialog
 {
+    private static final Logger logger = Logger.getLogger(TexturesAndMaterialsDialog.class.getName());
+
   Scene theScene;
   EditingWindow parentFrame;
   BTree libraryList;
@@ -605,7 +609,7 @@ public class TexturesAndMaterialsDialog extends BDialog
       }
       catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     ((SceneTreeModel) libraryList.getModel()).rebuildScenes(saveFile);
@@ -646,7 +650,7 @@ public class TexturesAndMaterialsDialog extends BDialog
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -664,7 +668,7 @@ public class TexturesAndMaterialsDialog extends BDialog
         }
         catch (IOException ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
         ((SceneTreeModel) libraryList.getModel()).rebuildLibrary();
       }
@@ -797,7 +801,7 @@ public class TexturesAndMaterialsDialog extends BDialog
         }
         catch (IOException ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
     }
@@ -1050,7 +1054,7 @@ public class TexturesAndMaterialsDialog extends BDialog
         }
         catch (IOException ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
           return false;
         }
         if (insertLocation == -1 || insertLocation == current)
@@ -1097,7 +1101,7 @@ public class TexturesAndMaterialsDialog extends BDialog
       }
       catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
       return true;
     }

--- a/ArtOfIllusion/src/artofillusion/UndoRecord.java
+++ b/ArtOfIllusion/src/artofillusion/UndoRecord.java
@@ -21,12 +21,16 @@ import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** The UndoRecord class records a series of commands, allowing the user to undo a previous
     action. */
 
 public class UndoRecord
 {
+    private static final Logger logger = Logger.getLogger(UndoRecord.class.getName());
+
   private ArrayList<Integer> command;
   private ArrayList<Object[]> data;
   private ArrayList<SoftReference[]> dataRef;
@@ -139,7 +143,7 @@ public class UndoRecord
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
       return redoRecord;
     }
     for (int i = 0; i < command.size(); i++)

--- a/ArtOfIllusion/src/artofillusion/animation/Actor.java
+++ b/ArtOfIllusion/src/artofillusion/animation/Actor.java
@@ -19,12 +19,15 @@ import artofillusion.ui.*;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** An Actor is an object with a set of predefined gestures.  Gestures can be blended in arbitrary
     combinations to form poses. */
 
 public class Actor extends ObjectWrapper
 {
+    private static final Logger logger = Logger.getLogger(Actor.class.getName());
   Gesture gesture[];
   String gestureName[];
   int gestureID[], nextPoseID;
@@ -433,12 +436,12 @@ public class Actor extends ObjectWrapper
       }
     catch (InvocationTargetException ex)
       {
-        ex.getTargetException().printStackTrace();
+        logger.log(Level.INFO, "Exception", ex.getTargetException());
         throw new IOException();
       }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new IOException();
       }
   }

--- a/ArtOfIllusion/src/artofillusion/animation/AnimationPreviewer.java
+++ b/ArtOfIllusion/src/artofillusion/animation/AnimationPreviewer.java
@@ -22,6 +22,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
 
@@ -29,6 +31,8 @@ import javax.imageio.ImageIO;
 
 public class AnimationPreviewer implements Runnable
 {
+    private static final Logger logger = Logger.getLogger(AnimationPreviewer.class.getName());
+
   private LayoutWindow window;
   private double originalTime;
   private ValueField widthField, heightField, startField, endField, fpsField;
@@ -252,7 +256,7 @@ public class AnimationPreviewer implements Runnable
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/animation/PoseTrack.java
+++ b/ArtOfIllusion/src/artofillusion/animation/PoseTrack.java
@@ -17,11 +17,15 @@ import artofillusion.ui.*;
 import buoy.widget.*;
 import java.io.*;
 import java.lang.reflect.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This is a Track which controls the pose of an object. */
 
 public class PoseTrack extends Track
 {
+    private static final Logger logger = Logger.getLogger(PoseTrack.class.getName());
+
   private ObjectInfo info;
   private Timecourse tc;
   private int smoothingMethod;
@@ -354,7 +358,7 @@ public class PoseTrack extends Track
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
             throw new InvalidObjectException("");
           }
       }

--- a/ArtOfIllusion/src/artofillusion/animation/Score.java
+++ b/ArtOfIllusion/src/artofillusion/animation/Score.java
@@ -21,12 +21,16 @@ import java.awt.*;
 import java.lang.reflect.*;
 import java.text.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This is a Widget which displays all the tracks for objects in a scene, and shows
     where their keyframes are. */
 
 public class Score extends BorderContainer implements EditingWindow, PopupMenuManager
 {
+
+    private static final Logger logger = Logger.getLogger(Score.class.getName());
   LayoutWindow window;
   TreeList theList;
   TimeAxis theAxis;
@@ -1028,7 +1032,7 @@ public class Score extends BorderContainer implements EditingWindow, PopupMenuMa
       }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     window.setUndoRecord(undo);
     if (deselectOthers)

--- a/ArtOfIllusion/src/artofillusion/image/ComplexImage.java
+++ b/ArtOfIllusion/src/artofillusion/image/ComplexImage.java
@@ -4,14 +4,16 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.image;
 
 import java.awt.*;
 import java.awt.image.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class stores an image, with optional additional floating point values for each pixel.
     It is intended to be extensible, so that as features are added to the renderers, the amount
@@ -19,11 +21,13 @@ import java.awt.image.*;
 
 public class ComplexImage
 {
+    private static final Logger logger = Logger.getLogger(ComplexImage.class.getName());
+
   private Image img;
   private float pixelData[][];
   private int intImage[];
   private int width, height;
-  
+
   public static final int BLUE = 1;
   public static final int GREEN = 2;
   public static final int RED = 4;
@@ -33,7 +37,7 @@ public class ComplexImage
   public static final int NOISE = 64;
 
   /** Construct a ComplexImage which wraps an Image object. */
-  
+
   public ComplexImage(Image image)
   {
     img = image;
@@ -44,42 +48,42 @@ public class ComplexImage
 
   /** Set the floating point values of a particular component for each pixel.  The length of the value array
       should be equal to the number of pixels in the image, and the values should be ordered by rows. */
-  
+
   public void setComponentValues(int component, float values[])
   {
     pixelData[getComponentIndex(component)] = values;
   }
-  
+
   /** Get the width of the image. */
-  
+
   public int getWidth()
   {
     return width;
   }
-  
+
   /** Get the height of the image. */
-  
+
   public int getHeight()
   {
     return height;
   }
-  
+
   /** Get the Image object. */
-  
+
   public Image getImage()
   {
     return img;
   }
-  
+
   /** Determine whether floating point data is available for a particular component. */
-  
+
   public boolean hasFloatData(int component)
   {
     return (pixelData[getComponentIndex(component)] != null);
   }
-  
+
   /** Get the floating point value of a component for a pixel. */
-  
+
   public float getPixelComponent(int x, int y, int component)
   {
     int index = getComponentIndex(component);
@@ -95,15 +99,15 @@ public class ComplexImage
       }
       catch (InterruptedException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     return ((intImage[x+y*width]>>(index*8))&0xFF)*(1.0f/255.0f);
   }
-  
+
   /** Create a duplicate of this object.  The new ComplexImage will refer to the same Image object as the
       other, but all other fields will be cloned. */
-  
+
   public ComplexImage duplicate()
   {
     ComplexImage ci = new ComplexImage(img.getScaledInstance(img.getWidth(null), -1, Image.SCALE_REPLICATE));
@@ -116,10 +120,10 @@ public class ComplexImage
       }
     return ci;
   }
-  
+
   /** Rebuild the Image from the floating point components.  This should be called after the components have
       been modified. */
-  
+
   public void rebuildImage()
   {
     int newimage[] = new int [width*height];
@@ -146,9 +150,9 @@ public class ComplexImage
       index++;
     return index;
   }
-  
+
   /** Convert a floating point value to an appropriate int value.  This is used by rebuildImage(). */
-  
+
   private int floatToInt(float f)
   {
     int i = (int) (f*255.0f);

--- a/ArtOfIllusion/src/artofillusion/image/ImageMap.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImageMap.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.image;
@@ -13,6 +13,8 @@ package artofillusion.image;
 import artofillusion.math.*;
 import java.awt.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** ImageMap represents an image which can be used for texturing an object.  The number of
 components can range from one (monochrome) to four (ARGB).  It also provides a scaled down
@@ -22,8 +24,10 @@ This is an abstract class.  Subclasses implement specific ways of storing images
 
 public abstract class ImageMap
 {
+    private static final Logger logger = Logger.getLogger(ImageMap.class.getName());
+
   private int id;
-  
+
   public static final int PREVIEW_WIDTH = 50;
   public static final int PREVIEW_HEIGHT = 50;
 
@@ -47,67 +51,67 @@ public abstract class ImageMap
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
           }
       }
     if (name.endsWith(".svg"))
       return new SVGImage(file);
     return new MIPMappedImage(file);
   }
-  
+
   /** Get the width of the image. */
-  
+
   public abstract int getWidth();
-  
+
   /** Get the height of the image. */
-  
+
   public abstract int getHeight();
 
   /** Get the number of components in the image. */
-  
+
   public abstract int getComponentCount();
 
   /** Get the value of a single component at a particular location in the image.  The value
       is represented as a float between 0.0 and 1.0.  The components are:
-      
+
       0: Red
       1: Green
       2: Blue
       3: Alpha
-      
+
       The location is specified by x and y, which must lie between 0 and 1.  The value is
-      averaged over a region of width (xsize, ysize).  wrapx and wrapy specify whether, for 
-      purposes of interpolation, the image should be treated as wrapping around so that 
+      averaged over a region of width (xsize, ysize).  wrapx and wrapy specify whether, for
+      purposes of interpolation, the image should be treated as wrapping around so that
       opposite edges touch each other. */
-  
+
   public abstract float getComponent(int component, boolean wrapx, boolean wrapy, double x, double y, double xsize, double ysize);
 
   /** Get the average value for a particular component, over the entire image. */
-  
+
   public abstract float getAverageComponent(int component);
 
-  /** Get the color at a particular location.  The location is specified by x and y, 
-      which must lie between 0 and 1.  The color is averaged over a region of width 
-      (xsize, ysize).  wrapx and wrapy specify whether, for purposes of interpolation, the 
+  /** Get the color at a particular location.  The location is specified by x and y,
+      which must lie between 0 and 1.  The color is averaged over a region of width
+      (xsize, ysize).  wrapx and wrapy specify whether, for purposes of interpolation, the
       image should be treated as wrapping around so that opposite edges touch each other. */
 
   public abstract void getColor(RGBColor theColor, boolean wrapx, boolean wrapy, double x, double y, double xsize, double ysize);
-  
-  /** Get the gradient of a single component at a particular location in the image.  
+
+  /** Get the gradient of a single component at a particular location in the image.
       The location is specified by x and y, which must lie between 0 and 1.  The value is
-      averaged over a region of width (xsize, ysize) before the gradient is calculated.  
-      wrapx and wrapy specify whether, for purposes of interpolation, the image should be 
+      averaged over a region of width (xsize, ysize) before the gradient is calculated.
+      wrapx and wrapy specify whether, for purposes of interpolation, the image should be
       treated as wrapping around so that opposite edges touch each other. */
-  
+
   public abstract void getGradient(Vec2 grad, int component, boolean wrapx, boolean wrapy, double x, double y, double xsize, double ysize);
 
   /** Get a scaled down copy of the image, to use for previews.  This Image will be no larger
       (but may be smaller) than PREVIEW_WIDTH by PREVIEW_HEIGHT. */
-  
+
   public abstract Image getPreview();
 
   /** Get an ID number which is unique (within this session) for this image. */
-  
+
   public int getID()
   {
     return id;
@@ -115,9 +119,9 @@ public abstract class ImageMap
 
   /** Write out the object's representation to an output stream.  Every ImageMap subclass must also
       define a constructor of the form
-      
+
       public ImageMapSubclass(DataInputStream in) throws IOException, InvalidObjectException
-      
+
       which reconstructs an image from its serialized representation. */
 
   public abstract void writeToStream(DataOutputStream out) throws IOException;

--- a/ArtOfIllusion/src/artofillusion/image/ImageSaver.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImageSaver.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.image;
@@ -20,6 +20,8 @@ import java.awt.*;
 import java.awt.image.*;
 import java.io.*;
 import java.text.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.imageio.*;
 import javax.imageio.stream.*;
 
@@ -27,6 +29,8 @@ import javax.imageio.stream.*;
 
 public class ImageSaver
 {
+    private static final Logger logger = Logger.getLogger(ImageSaver.class.getName());
+
   private int format, index;
   private String name, directory;
   private boolean ok, premultiply;
@@ -40,19 +44,19 @@ public class ImageSaver
   public static final int FORMAT_BMP = 3;
   public static final int FORMAT_HDR = 4;
   public static final int FORMAT_QUICKTIME = 5;
-  
+
   private static final String FORMAT_NAME[] = new String [] {
     "JPEG", "TIFF", "PNG", "BMP", "HDR", "Quicktime"
   };
   private static final String FORMAT_EXTENSION[] = new String [] {
     "jpg", "tif", "png", "bmp", "hdr", "mov"
   };
-  
+
   private static boolean premultiplyDefault = true;
   private static double qualityDefault = 90.0;
   private static int lastImageFormat = FORMAT_JPEG;
   private static int lastMovieFormat = FORMAT_QUICKTIME;
-  
+
   /** Create an ImageSaver object which will be used for saving a single images.
       The constructor displays a dialog in which the user can select the name, location,
       and format.  The saveImage() method can then be used to save individual frames of the
@@ -171,21 +175,21 @@ public class ImageSaver
   }
 
   /** Determine whether the user canceled saving the image. */
-  
+
   public boolean clickedOk()
   {
     return ok;
   }
-  
+
   /** Save the next image to disk.  Returns false if an error occurs.*/
-  
+
   public boolean saveImage(Image im) throws IOException
   {
     return saveImage(new ComplexImage(im));
   }
-  
+
   /** Save the next image to disk.  Returns false if an error occurs.*/
-  
+
   public boolean saveImage(ComplexImage img) throws IOException
   {
     String filename = name;
@@ -201,7 +205,7 @@ public class ImageSaver
     if (index != Integer.MIN_VALUE)
     {
       // Insert the image number into the filename.
-      
+
       NumberFormat nf = NumberFormat.getNumberInstance();
       nf.setMinimumIntegerDigits(4);
       nf.setGroupingUsed(false);
@@ -219,25 +223,25 @@ public class ImageSaver
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
       new BStandardDialog("", Translate.text("errorSavingFile", ex.getMessage() == null ? "" : ex.getMessage()), BStandardDialog.ERROR).showMessageDialog(parent);
     }
     return false;
   }
-  
+
   /** Save an image to disk in the specified format.  Returns true if the image was
       successfully saved, false if an error occurred.  For JPEG, quality should be
       between 0 and 100.  For other formats, it is ignored. */
-  
+
   public static boolean saveImage(Image im, File f, int format, int quality) throws IOException, InterruptedException
   {
     return saveImage(new ComplexImage(im), f, format, quality);
   }
-  
+
   /** Save an image to disk in the specified format.  Returns true if the image was
       successfully saved, false if an error occurred.  For JPEG, quality should be
       between 0 and 100.  For other formats, it is ignored. */
-  
+
   public static boolean saveImage(ComplexImage img, File f, int format, int quality) throws IOException, InterruptedException
   {
     BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(f));
@@ -305,14 +309,14 @@ public class ImageSaver
     if (qt != null)
       qt.close();
   }
-  
+
   /** Determine whether this image is partially transparent, and if so, create a new image
       in which the color components are premultiplied by the transparency. */
-  
+
   private static Image premultiplyTransparency(Image im)
   {
     int i, data[];
-    
+
     try
     {
       PixelGrabber pg = new PixelGrabber(im, 0, 0, -1, -1, true);
@@ -326,9 +330,9 @@ public class ImageSaver
     for (i = 0; i < data.length && (data[i] & 0xFF000000) == 0xFF000000; i++);
     if (i == data.length)
       return im;
-    
+
     // The image is partially transparent.  Premultiply by the transparency.
-    
+
     for (i = 0; i < data.length; i++)
     {
       int alpha = (data[i]>>24) & 0xFF;
@@ -340,17 +344,17 @@ public class ImageSaver
       blue = (blue*(alpha+1))>>8;
       data[i] = (alpha<<24) + (red<<16) + (green<<8) + blue;
     }
-    
+
     // Create the new image.
-    
-    MemoryImageSource source = new MemoryImageSource(im.getWidth(null), im.getHeight(null), 
+
+    MemoryImageSource source = new MemoryImageSource(im.getWidth(null), im.getHeight(null),
       data, 0, im.getWidth(null));
     return Toolkit.getDefaultToolkit().createImage(source);
   }
-  
+
   /** Get a BufferedImage containing the image from a ComplexImage.  This is necessary
       for using the ImageIO classes, which only work on BufferedImages. */
-  
+
   private static BufferedImage getBufferedImage(Image im, boolean hasAlpha)
   {
     if (im instanceof BufferedImage)

--- a/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.image;
@@ -16,11 +16,15 @@ import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** ImagesDialog is a dialog box for editing the list of ImageMaps used in a scene. */
 
 public class ImagesDialog extends BDialog
 {
+    private static final Logger logger = Logger.getLogger(ImagesDialog.class.getName());
+
   private Scene theScene;
   private BFrame parent;
   private int selection;
@@ -71,7 +75,7 @@ public class ImagesDialog extends BDialog
     b[1].setEnabled(selection >= 0);
     b[2].setEnabled(selection >= 0);
   }
-  
+
   private void doLoad()
   {
     BFileChooser fc = new ImageFileChooser(Translate.text("selectImagesToLoad"));
@@ -89,7 +93,7 @@ public class ImagesDialog extends BDialog
       catch (Exception ex)
       {
         new BStandardDialog("", Translate.text("errorLoadingImage", files[i].getName()), BStandardDialog.ERROR).showMessageDialog(this);
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         setCursor(Cursor.getDefaultCursor());
         return;
       }
@@ -100,7 +104,7 @@ public class ImagesDialog extends BDialog
     ic.scrollToSelection();
     hilightButtons();
   }
-  
+
   private void doDelete()
   {
     String options[] = new String [] {Translate.text("button.ok"), Translate.text("button.cancel")};
@@ -117,7 +121,7 @@ public class ImagesDialog extends BDialog
     ic.imagesChanged();
     hilightButtons();
   }
-  
+
   private void doSelectNone()
   {
     selection = -1;
@@ -127,7 +131,7 @@ public class ImagesDialog extends BDialog
 
   /** ImagesCanvas is an inner class which displays the loaded images and allows the user
       to select one by clicking on it. */
-  
+
   private class ImagesCanvas extends CustomWidget
   {
     private int w, h, gridw, gridh;
@@ -154,19 +158,19 @@ public class ImagesDialog extends BDialog
     {
       return gridw;
     }
-    
+
     public int getGridHeight()
     {
       return gridh;
     }
-    
+
     public void scrollToSelection()
     {
       if (selection < 0)
         return;
       sp.getVerticalScrollBar().setValue((selection/w)*gridh);
     }
-    
+
     private void paint(RepaintEvent ev)
     {
       Graphics2D g = ev.getGraphics();
@@ -196,4 +200,3 @@ public class ImagesDialog extends BDialog
     }
   }
 }
-

--- a/ArtOfIllusion/src/artofillusion/image/SVGImage.java
+++ b/ArtOfIllusion/src/artofillusion/image/SVGImage.java
@@ -21,9 +21,13 @@ import java.io.*;
 import java.lang.ref.*;
 import java.net.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SVGImage extends ImageMap
 {
+    private static final Logger logger = Logger.getLogger(SVGImage.class.getName());
+
   private final byte xml[];
   private SVGDiagram svg;
   private BufferedImage preview;
@@ -125,7 +129,7 @@ public class SVGImage extends ImageMap
         }
         catch (SVGException ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
           tile = new int[TILE_SIZE*TILE_SIZE];
         }
         tiles.put(key.clone(), new SoftReference<int[]>(tile));

--- a/ArtOfIllusion/src/artofillusion/image/filter/ImageFilter.java
+++ b/ArtOfIllusion/src/artofillusion/image/filter/ImageFilter.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.image.filter;
@@ -21,6 +21,8 @@ import buoy.widget.*;
 import javax.swing.border.*;
 import java.awt.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class defines an object which can filter rendered images.  It is an abstract class, whose subclasses implement
     specific types of filters.  An ImageFilter may present a user interface for configuring filtering options,
@@ -28,12 +30,13 @@ import java.io.*;
 
 public abstract class ImageFilter
 {
+    private static final Logger logger = Logger.getLogger(ImageFilter.class.getName());
   @Deprecated
   protected double paramValue[];
   private Object propertyValue[];
-  
+
   /** Every ImageFilter subclass must provide a constructor which takes no arguments. */
-  
+
   public ImageFilter()
   {
     Property[] properties = getProperties();
@@ -51,33 +54,33 @@ public abstract class ImageFilter
   }
 
   /** Get the name of this filter. */
-  
+
   public abstract String getName();
-  
+
   /** Get a list of all the image components required by this filter.  This should be a sum of the constants
       defined in ComplexImage.  The renderer will attempt to provide all requested components, but some renderers
       may not support all components.  The filter should therefore be prepared for the possibility that some
       components may be null (aside from the basic red, green, blue, and alpha components, which are always
       available). */
-  
+
   public int getDesiredComponents()
   {
     // The default implementation requests red, green, and blue.  Subclasses with other needs should override this.
-    
+
     return ComplexImage.RED+ComplexImage.GREEN+ComplexImage.BLUE;
   }
-  
+
   /** Apply the filter to an image.
       @param image      the image to filter
       @param scene      the Scene which was rendered to create the image
       @param camera     the camera from which the Scene was rendered
       @param cameraPos  the position of the camera in the scene
   */
-  
+
   public abstract void filterImage(ComplexImage image, Scene scene, SceneCamera camera, CoordinateSystem cameraPos);
-  
+
   /** Create an exact duplicate of this filter. */
-  
+
   public ImageFilter duplicate()
   {
     try
@@ -88,17 +91,17 @@ public abstract class ImageFilter
       }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     return null;
   }
-  
+
   /** Given another ImageFilter (of the same class as this one), make this one identical to it. */
-  
+
   public void copy(ImageFilter f)
   {
     // Subclasses should override this if necessary to copy any additional information.
-    
+
     paramValue = new double [f.paramValue.length];
     for (int i = 0; i < paramValue.length; i++)
       paramValue[i] = f.paramValue[i];
@@ -107,15 +110,15 @@ public abstract class ImageFilter
       propertyValue[i] = f.propertyValue[i];
 
   }
-  
+
   /** This method is deprecated.  Call getProperties() instead. */
-  
+
   @Deprecated
   public TextureParameter [] getParameters()
   {
     return new TextureParameter [0];
   }
-  
+
   /** This method is deprecated.  Call getPropertyValue() instead. */
 
   @Deprecated
@@ -125,7 +128,7 @@ public abstract class ImageFilter
     System.arraycopy(paramValue, 0, val, 0, val.length);
     return val;
   }
-  
+
   /** This method is deprecated.  Call setPropertyValue() instead. */
 
   @Deprecated
@@ -184,11 +187,11 @@ public abstract class ImageFilter
   }
 
   /** Write a serialized description of this filter to a stream. */
-  
+
   public abstract void writeToStream(DataOutputStream out, Scene theScene) throws IOException;
 
   /** Reconstruct this filter from its serialized representation. */
-  
+
   public abstract void initFromStream(DataInputStream in, Scene theScene) throws IOException;
 
   /**
@@ -202,12 +205,12 @@ public abstract class ImageFilter
   {
     // The default implementation simply allows the Properties to be edited.  Subclasses may override
     // this to provide more complex configuration panels.
-    
+
     final Property properties[] = getProperties();
     FormContainer form = new FormContainer(2, properties.length);
-    
+
     // Define an inner class to act as a listener on a PropertyEditors.
-    
+
     class EditorListener
     {
       private int which;
@@ -218,7 +221,7 @@ public abstract class ImageFilter
         this.which = which;
         this.editor = editor;
       }
-      
+
       void processEvent()
       {
         setPropertyValue(which, editor.getValue());
@@ -227,7 +230,7 @@ public abstract class ImageFilter
     }
 
     // Create the editing components.
-    
+
     LayoutInfo leftLayout = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(0, 0, 0, 5), null);
     LayoutInfo rightLayout = new LayoutInfo(LayoutInfo.WEST, LayoutInfo.NONE, null, null);
     for (int i = 0; i < properties.length; i++)

--- a/ArtOfIllusion/src/artofillusion/keystroke/KeystrokeManager.java
+++ b/ArtOfIllusion/src/artofillusion/keystroke/KeystrokeManager.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.keystroke;
@@ -17,6 +17,8 @@ import artofillusion.*;
 import java.util.*;
 import java.awt.event.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.*;
 import javax.xml.transform.*;
@@ -32,6 +34,7 @@ import org.w3c.dom.Node;
 
 public class KeystrokeManager
 {
+    private static final Logger logger = Logger.getLogger(KeystrokeManager.class.getName());
   private static ArrayList<KeystrokeRecord> records = new ArrayList<KeystrokeRecord>();
   private static HashMap<Integer, ArrayList<KeystrokeRecord>> keyIndex = new HashMap<Integer, ArrayList<KeystrokeRecord>>();
 
@@ -151,7 +154,7 @@ public class KeystrokeManager
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/math/SimplexNoise.java
+++ b/ArtOfIllusion/src/artofillusion/math/SimplexNoise.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.math;
@@ -527,7 +527,7 @@ public class SimplexNoise {  // Simplex noise in 2D, 3D and 4D
     // To find out which of the 24 possible simplices we're in, we need to
     // determine the magnitude ordering of x0, y0, z0 and w0.
     // The method below is a good way of finding the ordering of x,y,z,w and
-    // then find the correct traversal order for the simplex we’re in.
+    // then find the correct traversal order for the simplex we are in.
     // First, six pair-wise comparisons are performed between each possible pair
     // of the four coordinates, and the results are used to add up binary bits
     // for an integer index.

--- a/ArtOfIllusion/src/artofillusion/object/CSGObject.java
+++ b/ArtOfIllusion/src/artofillusion/object/CSGObject.java
@@ -19,12 +19,16 @@ import artofillusion.ui.*;
 import java.io.*;
 import java.lang.ref.*;
 import java.lang.reflect.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** A CSGObject is an Object3D that represents the union, intersection, or difference of
     two component objects. */
 
 public class CSGObject extends Object3D
 {
+    private static final Logger logger = Logger.getLogger(CSGObject.class.getName());
+
   ObjectInfo obj1, obj2;
   int operation;
   SoftReference<RenderingMesh> cachedMesh;
@@ -376,12 +380,12 @@ public class CSGObject extends Object3D
       }
     catch (InvocationTargetException ex)
       {
-        ex.getTargetException().printStackTrace();
+          logger.log(Level.INFO, "Exception", ex.getTargetException());
         throw new IOException();
       }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new IOException();
       }
     obj1.getObject().setTexture(getTexture(), getTextureMapping());
@@ -689,7 +693,7 @@ public class CSGObject extends Object3D
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new InvalidObjectException("");
       }
     }

--- a/ArtOfIllusion/src/artofillusion/object/CompoundImplicitObject.java
+++ b/ArtOfIllusion/src/artofillusion/object/CompoundImplicitObject.java
@@ -18,9 +18,13 @@ import artofillusion.ui.*;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class CompoundImplicitObject extends ImplicitObject
 {
+    private static final Logger logger = Logger.getLogger(CompoundImplicitObject.class.getName());
+
   private ArrayList<ImplicitObject> objects;
   private ArrayList<CoordinateSystem> objectCoords;
   private BoundingBox bounds;
@@ -515,7 +519,7 @@ public class CompoundImplicitObject extends ImplicitObject
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new InvalidObjectException(ex.getMessage());
       }
     }

--- a/ArtOfIllusion/src/artofillusion/object/ExternalObject.java
+++ b/ArtOfIllusion/src/artofillusion/object/ExternalObject.java
@@ -16,11 +16,15 @@ import artofillusion.math.*;
 import artofillusion.ui.*;
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** ExternalObject is an Object3D that is stored in a separate file. */
 
 public class ExternalObject extends ObjectWrapper
 {
+    private static final Logger logger = Logger.getLogger(ExternalObject.class.getName());
+
   private File externalFile;
   private int objectId;
   private String objectName;
@@ -158,8 +162,7 @@ public class ExternalObject extends ObjectWrapper
     catch (Exception ex)
     {
       // If anything goes wrong, use a null object and return an error message.
-
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
       loadingError = ex.getMessage();
     }
   }

--- a/ArtOfIllusion/src/artofillusion/object/Object3D.java
+++ b/ArtOfIllusion/src/artofillusion/object/Object3D.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.object;
@@ -20,11 +20,15 @@ import artofillusion.ui.*;
 import buoy.widget.*;
 import java.io.*;
 import java.lang.reflect.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Object3D is the abstract superclass of any object which can be placed into a Scene. */
 
 public abstract class Object3D
 {
+    private static final Logger logger = Logger.getLogger(Object3D.class.getName());
+
   protected Texture theTexture;
   protected Material theMaterial;
   protected TextureMapping texMapping;
@@ -40,14 +44,14 @@ public abstract class Object3D
   public Object3D()
   {
   }
-  
+
   /** Create a new object which is an exact duplicate of this one. */
-  
+
   public abstract Object3D duplicate();
-  
+
   /** Copy all the properties of another object, to make this one identical to it.  If the
       two objects are of different classes, this will throw a ClassCastException. */
-  
+
   public abstract void copyObject(Object3D obj);
 
   /** Get a BoundingBox which just encloses the object. */
@@ -67,22 +71,22 @@ public abstract class Object3D
   {
     return true;
   }
-  
+
   /** Tells whether the object can be converted to a TriangleMesh.  It should return one
       of the following values:
-      
+
       CANT_CONVERT: The object cannot be converted to a TriangleMesh.
       EXACTLY: The object can be represented exactly by a TriangleMesh.
       APPROXIMATELY: The object can be converted to a TriangleMesh.  However, the resulting
       mesh will not be exactly the same shape as the original object.
-      
+
       If a class overrides this method, it must also override convertToTriangleMesh(). */
 
   public int canConvertToTriangleMesh()
   {
     return CANT_CONVERT;
   }
-  
+
   /** Return a TriangleMesh which reproduces the shape of this object.  If
       canConvertToTriangleMesh() returned APPROXIMATELY, this method should return a
       TriangleMesh which reproduces the object to within the specified tolerance.  That is,
@@ -94,35 +98,35 @@ public abstract class Object3D
   {
     return null;
   }
-  
+
   /** This will be called whenever this object is moved, or the time changes.  Most objects
       will do nothing here, and do not need to override this.  It is available for those
       cases where an object's internal properties depend explicitly on time or on the
       object's position within the scene. */
-  
+
   public void sceneChanged(ObjectInfo info, Scene scene)
   {
   }
-  
+
   /** If the object can be edited by the user, isEditable() should be overridden to return true.
       edit() should then create a window and allow the user to edit the object. */
-  
+
   public boolean isEditable()
   {
     return false;
   }
-  
+
   /** Display a window in which the user can edit this object.
       @param parent   the window from which this command is being invoked
       @param info     the ObjectInfo corresponding to this object
       @param cb       a callback which will be executed when editing is complete.  If the user
                       cancels the operation, it will not be called.
   */
-  
+
   public void edit(EditingWindow parent, ObjectInfo info, Runnable cb)
   {
   }
-  
+
   /** Edit an object which represents a gesture for an Actor object.  realObject
       specifies the object in the scene which this is a gesture for. */
 
@@ -134,21 +138,21 @@ public abstract class Object3D
   /** This method tells whether textures can be assigned to the object.  Objects for which
       it makes no sense to assign a texture (curves, lights, etc.) should override this
       method to return false. */
-  
+
   public boolean canSetTexture()
   {
     return true;
   }
-  
+
   /** This method tells whether materials can be assigned to the object.  The default
       implementation will give the correct result for most objects, but subclasses
       can override this if necessary. */
-  
+
   public boolean canSetMaterial()
   {
     return (canSetTexture() && isClosed());
   }
-  
+
   /** Set the Texture and TextureMapping for this object. */
 
   public void setTexture(Texture tex, TextureMapping map)
@@ -157,9 +161,9 @@ public abstract class Object3D
     texMapping = map;
     if (map instanceof LayeredMapping)
       theTexture = ((LayeredMapping) map).getTexture();
-    
+
     // Update the texture parameters.
-    
+
     if (map == null)
       {
         setParameters(new TextureParameter [0]);
@@ -192,67 +196,67 @@ public abstract class Object3D
         setParameterValues(newVal);
       }
   }
-  
+
   /** Get this object's Texture. */
-  
+
   public Texture getTexture()
   {
     return theTexture;
   }
-  
+
   /** Get this object's TextureMapping. */
-  
+
   public TextureMapping getTextureMapping()
   {
     return texMapping;
   }
-  
+
   /** Set the Material and MaterialMapping for this object.  Pass null for both arguments to
       specify that the object does not have a Material. */
-  
+
   public void setMaterial(Material mat, MaterialMapping map)
   {
     theMaterial = mat;
     matMapping = map;
   }
-  
+
   /** Get this object's Material. */
-  
+
   public Material getMaterial()
   {
     return theMaterial;
   }
-  
+
   /** Get this object's MaterialMapping. */
-  
+
   public MaterialMapping getMaterialMapping()
   {
     return matMapping;
   }
-  
+
   /** Get the list of texture parameters for this object. */
-  
+
   public TextureParameter [] getParameters()
   {
     return texParam;
   }
-  
+
   /** Set the list of texture parameters for this object. */
-  
+
   public void setParameters(TextureParameter param[])
   {
     texParam = param;
   }
-  
+
   /** Get the list of objects defining the values of texture parameters. */
-  
+
   public ParameterValue [] getParameterValues()
   {
     return paramValue;
   }
-  
+
   /** Get the average value of each texture parameter. */
-  
+
   public double [] getAverageParameterValues()
   {
     if (paramValue == null)
@@ -262,18 +266,18 @@ public abstract class Object3D
       d[i] = paramValue[i].getAverageValue();
     return d;
   }
-  
+
   /** Set the list of objects defining the values of texture parameters. */
-  
+
   public void setParameterValues(ParameterValue val[])
   {
     paramValue = val;
     parametersChanged = true;
   }
-  
+
   /** Get the object defining the value of a particular texture parameter.  If the parameter is not
       defined for this object, this returns null. */
-  
+
   public ParameterValue getParameterValue(TextureParameter param)
   {
     for (int i = 0; i < texParam.length; i++)
@@ -281,9 +285,9 @@ public abstract class Object3D
         return paramValue[i];
     return null;
   }
-  
+
   /** Set the object defining the value of a particular texture parameter. */
-  
+
   public void setParameterValue(TextureParameter param, ParameterValue val)
   {
     for (int i = 0; i < texParam.length; i++)
@@ -321,16 +325,16 @@ public abstract class Object3D
       setParameterValues(thisValue);
     }
   }
-  
+
   /** Get the skeleton for this object, or null if it does not have one. */
-  
+
   public Skeleton getSkeleton()
   {
     return null;
   }
 
   /** Objects which can be rendered as part of a scene should override this method to return
-      a RenderingMesh which describes the appearance of the object.  All points on the 
+      a RenderingMesh which describes the appearance of the object.  All points on the
       RenderingMesh should be within a distance tol of the true surface.  The interactive flag
       tells whether the resulting Mesh will be rendered in interactive mode.  When interactive
       is set to true, the RenderingMesh should be cached for future use, so that it may be
@@ -346,11 +350,11 @@ public abstract class Object3D
   {
     return null;
   }
-  
+
   /** Every object should override this method to return a WireframeMesh.  This will be used
       for drawing the object in wireframe mode, and also for drawing "nonrenderable" objects
       in other rendering modes. */
-  
+
   public abstract WireframeMesh getWireframeMesh();
 
   /**
@@ -409,15 +413,15 @@ public abstract class Object3D
 
   /** The following method writes the object's data to an output stream.  Subclasses should
       override this method, but also call super.writeToFile() to save information about
-      materials, etc.  In addition to this method, every Object3D must include a constructor 
+      materials, etc.  In addition to this method, every Object3D must include a constructor
       with the signature
 
       public Classname(DataInputStream in, Scene theScene) throws IOException, InvalidObjectException
-      
-      which reconstructs the object by reading its data from an input stream.  This 
+
+      which reconstructs the object by reading its data from an input stream.  This
       constructor, similarly, should call the overridden constructor to read information
       about materials, etc. */
-  
+
   public void writeToFile(DataOutputStream out, Scene theScene) throws IOException
   {
     out.writeShort(1);
@@ -449,7 +453,7 @@ public abstract class Object3D
         }
       }
   }
-  
+
   public Object3D(DataInputStream in, Scene theScene) throws IOException, InvalidObjectException
   {
     short version = in.readShort();
@@ -486,14 +490,14 @@ public abstract class Object3D
           }
         catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
             throw new IOException(ex.getMessage());
           }
       }
     else
       {
         // This is a layered texture.
-        
+
         LayeredTexture tex = new LayeredTexture(this);
         LayeredMapping map = (LayeredMapping) tex.getDefaultMapping(this);
         map.readFromFile(in, theScene);
@@ -505,9 +509,9 @@ public abstract class Object3D
         paramValue[i] = readParameterValue(in);
     setParameterValues(paramValue);
   }
-  
+
   /** Read in the value of a texture parameter from a stream. */
-  
+
   public static ParameterValue readParameterValue(DataInputStream in) throws IOException
   {
     try
@@ -518,7 +522,7 @@ public abstract class Object3D
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
       throw new IOException(ex.getMessage());
     }
   }
@@ -547,41 +551,41 @@ public abstract class Object3D
   public void setPropertyValue(int index, Object value)
   {
   }
-  
+
   /** Return a Keyframe which describes the current pose of this object. */
-  
+
   public abstract Keyframe getPoseKeyframe();
-  
+
   /** Modify this object based on a pose keyframe. */
-  
+
   public abstract void applyPoseKeyframe(Keyframe k);
-  
+
   /** This will be called whenever a new pose track is created for this object.  It allows
       the object to configure the track by setting its graphable values, subtracks, etc. */
-  
+
   public void configurePoseTrack(PoseTrack track)
   {
     track.setGraphableValues(new String [0], new double [0], new double [0][2]);
   }
-  
+
   /** Allow the user to edit a keyframe returned by getPoseKeyframe(). */
-  
+
   public void editKeyframe(EditingWindow parent, Keyframe k, ObjectInfo info)
   {
     new BStandardDialog("", Translate.text("noParamsForKeyframe"), BStandardDialog.INFORMATION).showMessageDialog((Widget) parent);
   }
-  
+
   /** Determine whether the user should be allowed to convert this object to an Actor. */
-  
+
   public boolean canConvertToActor()
   {
     return false;
   }
-  
+
   /** Get a version of this object to which a pose track can be attached.  For most objects,
       this simply returns itself.  Some objects, however, need to be converted to Actors
       to have pose tracks.  If this method returns null, no pose track will be attached. */
-  
+
   public Object3D getPosableObject()
   {
     return this;

--- a/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
+++ b/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
@@ -19,12 +19,16 @@ import artofillusion.ui.*;
 import buoy.widget.*;
 import java.awt.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** SceneCamera is a type of Object3D.  It represents a camera which the user can position
     within a scene.  It should not be confused with the Camera class. */
 
 public class SceneCamera extends Object3D
 {
+    private static final Logger logger = Logger.getLogger(SceneCamera.class.getName());
+
   private double fov, depthOfField, focalDist;
   private boolean perspective;
   private ImageFilter filter[];
@@ -533,7 +537,7 @@ public class SceneCamera extends Object3D
       }
       catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         throw new IOException();
       }
     }

--- a/ArtOfIllusion/src/artofillusion/procedural/ModuleMenu.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ModuleMenu.java
@@ -21,6 +21,8 @@ import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This is the menu that appears in the procedure editor window.  It displays modules organized into categories,
@@ -29,6 +31,8 @@ import java.util.List;
 
 public class ModuleMenu extends CustomWidget
 {
+    private static final Logger logger = Logger.getLogger(ModuleMenu.class.getName());
+
   private final ProcedureEditor editor;
   private final ArrayList<Category> categories;
   private final double expandedFraction[];
@@ -129,7 +133,7 @@ public class ModuleMenu extends CustomWidget
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
     }
@@ -237,7 +241,7 @@ public class ModuleMenu extends CustomWidget
           }
           catch (Exception ex)
           {
-            ex.printStackTrace();
+            logger.log(Level.INFO, "Exception", ex);
           }
           return;
         }

--- a/ArtOfIllusion/src/artofillusion/procedural/ProcedureEditor.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ProcedureEditor.java
@@ -18,6 +18,8 @@ import java.awt.*;
 import java.awt.geom.*;
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This is the editor for editing procedures.  It subclasses CustomWidget, but you should never
     add it to any Container.  Instead, it will automatically create a BFrame and add itself
@@ -25,6 +27,7 @@ import java.util.*;
 
 public class ProcedureEditor extends CustomWidget
 {
+    private static final Logger logger = Logger.getLogger(ProcedureEditor.class.getName());
   private BFrame parent;
   private Procedure proc;
   private ProcedureOwner owner;
@@ -91,7 +94,7 @@ public class ProcedureEditor extends CustomWidget
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
 
     // Create the buttons at the top of the window.
@@ -492,7 +495,7 @@ public class ProcedureEditor extends CustomWidget
       }
     catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
   }
   
@@ -513,7 +516,7 @@ public class ProcedureEditor extends CustomWidget
       }
     catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     if (redoStack.size() == ArtOfIllusion.getPreferences().getUndoLevels())
       redoStack.remove(0);
@@ -542,7 +545,7 @@ public class ProcedureEditor extends CustomWidget
       }
     catch (IOException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     if (undoStack.size() == ArtOfIllusion.getPreferences().getUndoLevels())
       undoStack.remove(0);

--- a/ArtOfIllusion/src/artofillusion/script/ScriptRunner.java
+++ b/ArtOfIllusion/src/artofillusion/script/ScriptRunner.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.script;
@@ -16,11 +16,14 @@ import buoy.widget.*;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This class is used for executing scripts. */
 
 public class ScriptRunner
 {
+    private static final Logger logger = Logger.getLogger(ScriptRunner.class.getName());
   public static final String LANGUAGES[] = {"Groovy", "BeanShell"};
   private static SearchlistClassLoader parentLoader;
   private static PrintStream output;
@@ -30,7 +33,7 @@ public class ScriptRunner
       "artofillusion.ui.*", "buoy.event.*", "buoy.widget.*"};
 
   /** Get the ScriptEngine for running scripts written in a particular language. */
-  
+
   public static ScriptEngine getScriptEngine(String language)
   {
     if (!engines.containsKey(language))
@@ -54,18 +57,18 @@ public class ScriptRunner
             for (String packageName : IMPORTS)
               engine.addImport(packageName);
           }
-        catch (Exception e)
+        catch (Exception ex)
           {
-            e.printStackTrace();
+              logger.log(Level.INFO, "Exception", ex);
           }
         output = new PrintStream(new ScriptOutputWindow());
         engine.setOutput(output);
       }
     return engines.get(language);
   }
-  
+
   /** Execute a script. */
-  
+
   public static void executeScript(String language, String script, Map<String, Object> variables)
   {
     try
@@ -77,16 +80,16 @@ public class ScriptRunner
         System.out.println("Error in line "+e.getLineNumber()+": "+e.getMessage());
       }
   }
-  
+
   /** Parse a Tool script. */
-  
+
   public static ToolScript parseToolScript(String language, String script) throws Exception
   {
     return getScriptEngine(language).createToolScript(script);
   }
-  
+
   /** Parse an Object script. */
-  
+
   public static ObjectScript parseObjectScript(String language, String script) throws Exception
   {
     return getScriptEngine(language).createObjectScript(script);
@@ -122,7 +125,7 @@ public class ScriptRunner
     }
     catch (Exception ex2)
     {
-      ex2.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex2);
     }
     ArrayList<String> v = new ArrayList<String>();
     v.add(head);

--- a/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
@@ -18,6 +18,8 @@ import javax.imageio.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class displays a set of curves and handles around a selection in a ViewerCanvas.  It processes
@@ -28,6 +30,8 @@ import java.io.*;
 
 public class Compound3DManipulator extends EventSource implements Manipulator
 {
+    private static final Logger logger = Logger.getLogger(Compound3DManipulator.class.getName());
+
   private Rectangle bounds;
   private Rectangle[] boxes;
   private Rectangle extraUVBox;
@@ -122,7 +126,7 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
     return null;
   }

--- a/ArtOfIllusion/src/artofillusion/ui/NinePointManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/NinePointManipulator.java
@@ -17,6 +17,8 @@ import java.io.*;
 
 import artofillusion.math.*;
 import artofillusion.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.imageio.*;
 
@@ -29,6 +31,8 @@ import javax.imageio.*;
 
 public class NinePointManipulator extends EventSource implements Manipulator
 {
+    private static final Logger logger = Logger.getLogger(NinePointManipulator.class.getName());
+
   private final Image images[];
   private Rectangle screenBounds;
   private BoundingBox selectionBounds;
@@ -75,7 +79,7 @@ public class NinePointManipulator extends EventSource implements Manipulator
     }
     catch (IOException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
     return null;
   }

--- a/ArtOfIllusion/src/artofillusion/ui/ThemeManager.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ThemeManager.java
@@ -35,6 +35,8 @@ import org.xml.sax.SAXException;
 
 import artofillusion.*;
 import artofillusion.math.RGBColor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class holds GUI customization information. Customization consists of
@@ -46,6 +48,7 @@ import artofillusion.math.RGBColor;
  */
 public class ThemeManager {
 
+    private static final Logger logger = Logger.getLogger(ThemeManager.class.getName());
 
     /**
      * This class hold all the colors used by a theme. A theme can propose several color sets.
@@ -195,8 +198,8 @@ public class ThemeManager {
               Method m = cls.getMethod("readPropertiesFromXMLNode", Node.class);
                 properties = m.invoke(className, node);
             } catch (NoSuchMethodException ex) {
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception ex) {
+                logger.log(Level.INFO, "Exception", ex);
             }
 
             // parse the button styles for this theme
@@ -730,7 +733,7 @@ public class ThemeManager {
         }
         catch (Exception ex)
         {
-          ex.printStackTrace();
+          logger.log(Level.INFO, "Exception", ex);
         }
       }
       themeList = list.toArray(new ThemeInfo[list.size()]);

--- a/ArtOfIllusion/src/artofillusion/ui/ToolButton.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ToolButton.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007 by François Guillet
+/* Copyright (C) 2007 by Francois Guillet
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software

--- a/ArtOfIllusion/src/artofillusion/util/ThreadManager.java
+++ b/ArtOfIllusion/src/artofillusion/util/ThreadManager.java
@@ -12,6 +12,8 @@ package artofillusion.util;
 
 import java.util.concurrent.atomic.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class coordinates threads for multi-threaded operations.  The execution model
@@ -29,6 +31,8 @@ import java.util.*;
 
 public class ThreadManager
 {
+    private static final Logger logger = Logger.getLogger(ThreadManager.class.getName());
+
   private int numIndices;
   private AtomicInteger nextIndex;
   private Thread thread[];
@@ -101,7 +105,7 @@ public class ThreadManager
             catch (Exception ex)
             {
               cancel();
-              ex.printStackTrace();
+              logger.log(Level.INFO, "Exception", ex);
             }
           }
         }

--- a/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
@@ -27,10 +27,16 @@ import com.jogamp.opengl.awt.*;
 
 import buoy.event.*;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
 /** This is a CanvasDrawer which uses OpenGL to render the contents of a ViewerCanvas. */
 
 public class GLCanvasDrawer implements CanvasDrawer
 {
+    private static final Logger logger = Logger.getLogger(GLCanvasDrawer.class.getName());
+
   private ViewerCanvas view;
   private GLCanvas canvas;
   private GL2 gl;
@@ -84,7 +90,7 @@ public class GLCanvasDrawer implements CanvasDrawer
     }
     catch (InterruptedException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -692,7 +698,7 @@ public class GLCanvasDrawer implements CanvasDrawer
       }
       catch (InterruptedException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         return;
       }
       textImageMap.put(text, new SoftReference<GLImage>(image));
@@ -711,7 +717,7 @@ public class GLCanvasDrawer implements CanvasDrawer
     }
     catch (InterruptedException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -736,7 +742,7 @@ public class GLCanvasDrawer implements CanvasDrawer
     }
     catch (InterruptedException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
       return;
     }
     prepareView3D(camera);

--- a/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
@@ -19,11 +19,15 @@ import java.awt.*;
 import java.awt.image.*;
 import java.util.*;
 import java.lang.ref.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** This is a CanvasDrawer which implements a software renderer for generating the contents of a ViewerCanvas. */
 
 public class SoftwareCanvasDrawer implements CanvasDrawer
 {
+    private static final Logger logger = Logger.getLogger(SoftwareCanvasDrawer.class.getName());
+
   protected ViewerCanvas view;
   protected BufferedImage theImage;
   protected Graphics2D imageGraphics;
@@ -66,7 +70,7 @@ public class SoftwareCanvasDrawer implements CanvasDrawer
     }
     catch (InterruptedException ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
   }
 
@@ -1762,7 +1766,7 @@ public class SoftwareCanvasDrawer implements CanvasDrawer
       }
       catch (InterruptedException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         return null;
       }
     }
@@ -1787,7 +1791,7 @@ public class SoftwareCanvasDrawer implements CanvasDrawer
       }
       catch (InterruptedException ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
   }

--- a/OSSpecific/src/artofillusion/osspecific/MacOSPlugin.java
+++ b/OSSpecific/src/artofillusion/osspecific/MacOSPlugin.java
@@ -17,6 +17,8 @@ import buoy.widget.*;
 import java.awt.*;
 import java.io.*;
 import java.lang.reflect.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.*;
 import javax.swing.*;
 
@@ -25,6 +27,8 @@ import javax.swing.*;
 
 public class MacOSPlugin implements Plugin, InvocationHandler
 {
+    private static final Logger logger = Logger.getLogger(MacOSPlugin.class.getName());
+
   private boolean usingAppMenu;
 
   @Override
@@ -55,7 +59,7 @@ public class MacOSPlugin implements Plugin, InvocationHandler
         // An error occured trying to set up the application menu, so just stick with the standard
         // Quit and Preferences menu items in the File and Edit menus.
 
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
       usingAppMenu = true;
     }
@@ -174,7 +178,7 @@ public class MacOSPlugin implements Plugin, InvocationHandler
       {
         // Nothing we can really do about it...
 
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
       }
     }
     else
@@ -191,7 +195,7 @@ public class MacOSPlugin implements Plugin, InvocationHandler
     {
       // Nothing we can really do about it...
 
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
     return null;
   }

--- a/Tools/src/artofillusion/tools/TextTool.java
+++ b/Tools/src/artofillusion/tools/TextTool.java
@@ -20,12 +20,16 @@ import java.awt.*;
 import java.awt.font.*;
 import java.awt.geom.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * TextTool creates meshes or curves that represent text.
  */
 public class TextTool implements ModellingTool
 {
+    private static final Logger logger = Logger.getLogger(TextTool.class.getName());
+
   public static enum TextType {Outline, Tube, Surface, Solid}
 
   public TextTool()
@@ -213,9 +217,9 @@ public class TextTool implements ModellingTool
                     fullLetterOI.object = TriangleMesh.optimizeMesh((TriangleMesh) fullLetterOI.object);
                     fullLetterOI.clearCachedMeshes();
                   }
-                  catch (Exception e)
+                  catch (Exception ex)
                   {
-                    e.printStackTrace();
+                    logger.log(Level.INFO, "Exception", ex);
                   }
                 }
                 firstCurveOfGlyph = false;
@@ -257,9 +261,9 @@ public class TextTool implements ModellingTool
               fullLetterOI.object = TriangleMesh.optimizeMesh(mesh);
               fullLetterOI.clearCachedMeshes();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-              e.printStackTrace();
+              logger.log(Level.INFO, "Exception", ex);
             }
           }
           if (type == TextType.Solid)
@@ -286,7 +290,7 @@ public class TextTool implements ModellingTool
     }
     catch (Exception ex)
     {
-      ex.printStackTrace();
+      logger.log(Level.INFO, "Exception", ex);
     }
     return objects;
   }

--- a/Translators/src/artofillusion/translators/OBJExporter.java
+++ b/Translators/src/artofillusion/translators/OBJExporter.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion.translators;
@@ -20,17 +20,21 @@ import buoy.widget.*;
 import java.io.*;
 import java.text.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** OBJExporter contains the actual routines for exporting OBJ files. */
 
 public class OBJExporter
 {
+    private static final Logger logger = Logger.getLogger(OBJExporter.class.getName());
+
   /** Display a dialog which allows the user to export a scene to an OBJ file. */
-  
+
   public static void exportFile(BFrame parent, Scene theScene)
   {
     // Display a dialog box with options on how to export the scene.
-    
+
     ValueField errorField = new ValueField(0.05, ValueField.POSITIVE);
     final ValueField widthField = new ValueField(200.0, ValueField.INTEGER+ValueField.POSITIVE);
     final ValueField heightField = new ValueField(200.0, ValueField.INTEGER+ValueField.POSITIVE);
@@ -53,11 +57,11 @@ public class OBJExporter
     mtlBox.dispatchEvent(new ValueChangedEvent(mtlBox));
     ComponentsDialog dlg;
     if (theScene.getSelection().length > 0)
-      dlg = new ComponentsDialog(parent, Translate.text("exportToOBJ"), 
+      dlg = new ComponentsDialog(parent, Translate.text("exportToOBJ"),
 	  new Widget [] {exportChoice, errorField, smoothBox, normalsBox, mtlBox, Translate.label("imageSizeForTextures"), widthField, heightField, qualitySlider},
 	  new String [] {null, Translate.text("maxSurfaceError"), null, null, null, null, Translate.text("Width"), Translate.text("Height"), Translate.text("imageQuality")});
     else
-      dlg = new ComponentsDialog(parent, Translate.text("exportToOBJ"), 
+      dlg = new ComponentsDialog(parent, Translate.text("exportToOBJ"),
 	  new Widget [] {errorField, smoothBox, normalsBox, mtlBox, Translate.label("imageSizeForTextures"), widthField, heightField, qualitySlider},
 	  new String [] {Translate.text("maxSurfaceError"), null, null, null, null, Translate.text("Width"), Translate.text("Height"), Translate.text("imageQuality")});
     if (!dlg.clickedOk())
@@ -76,7 +80,7 @@ public class OBJExporter
     String name = f.getName();
     String baseName = (name.endsWith(".obj") ? name.substring(0, name.length()-4) : name);
     ArtOfIllusion.setCurrentDirectory(dir.getAbsolutePath());
-    
+
     // Create the output files.
 
     try
@@ -100,7 +104,7 @@ public class OBJExporter
     }
     catch (Exception ex)
       {
-        ex.printStackTrace();
+        logger.log(Level.INFO, "Exception", ex);
         new BStandardDialog("", new String [] {Translate.text("errorExportingScene"), ex.getMessage() == null ? "" : ex.getMessage()}, BStandardDialog.ERROR).showMessageDialog(parent);
       }
   }
@@ -126,7 +130,7 @@ public class OBJExporter
     for (int i = 0; i < theScene.getNumObjects(); i++)
       {
         // Get a rendering mesh for the object.
-        
+
         ObjectInfo info = theScene.getObject(i);
         if (!wholeScene && !info.selected)
           continue;
@@ -198,18 +202,18 @@ public class OBJExporter
               out.println("s 1"); // The mesh is fully smoothed, so we can simply use a smoothing group
           }
         }
-        
+
         // Select a name for the group.
-        
+
         String baseName = info.getName().replace(' ', '_');
         String name = baseName;
         int append = 1;
         while (groupNames.get(name) != null)
           name = baseName+"_"+(append++);
         groupNames.put(name, "");
-        
+
         // Write out the object.
-        
+
         out.println("g "+name);
         TextureImageInfo ti = null;
         if (textureExporter != null)
@@ -238,7 +242,7 @@ public class OBJExporter
         if (ti != null && ((Object3D) mesh).getTextureMapping() instanceof UVMapping && ((UVMapping) ((Object3D) mesh).getTextureMapping()).isPerFaceVertex(mesh))
         {
           // A per-face-vertex texture mapping.
-          
+
           Vec2 coords[][] = ((UVMapping) ((Object3D) mesh).getTextureMapping()).findFaceTextureCoordinates(mesh);
           double uscale = (ti.maxu == ti.minu ? 1.0 : 1.0/(ti.maxu-ti.minu));
           double vscale = (ti.maxv == ti.minv ? 1.0 : 1.0/(ti.maxv-ti.minv));
@@ -273,7 +277,7 @@ public class OBJExporter
         else if (ti != null && ((Object3D) mesh).getTextureMapping() instanceof Mapping2D)
         {
           // A per-vertex texture mapping.
-          
+
           Vec2 coords[] = ((Mapping2D) ((Object3D) mesh).getTextureMapping()).findTextureCoordinates(mesh);
           double uscale = (ti.maxu == ti.minu ? 1.0 : 1.0/(ti.maxu-ti.minu));
           double vscale = (ti.maxv == ti.minv ? 1.0 : 1.0/(ti.maxv-ti.minv));
@@ -307,7 +311,7 @@ public class OBJExporter
         else
         {
           // No texture coordinates.
-          
+
           for (int j = 0; j < mesh.getFaceCount(); j++)
           {
             out.print("f ");
@@ -331,13 +335,13 @@ public class OBJExporter
           numNorm += norm.length;
       }
   }
-  
+
   /** Write out the .mtl file describing the textures. */
-  
+
   private static void writeTextures(Scene theScene, PrintWriter out, boolean wholeScene, TextureImageExporter textureExporter)
   {
     // Find all the textures.
-    
+
     for (int i = 0; i < theScene.getNumObjects(); i++)
       {
         ObjectInfo info = theScene.getObject(i);
@@ -345,9 +349,9 @@ public class OBJExporter
           continue;
         textureExporter.addObject(info);
       }
-    
+
     // Write out the .mtl file.
-    
+
     out.println("#Produced by Art of Illusion "+ArtOfIllusion.getVersion()+", "+(new Date()).toString());
     Enumeration textures = textureExporter.getTextures();
     Hashtable<String, TextureImageInfo> names = new Hashtable<String, TextureImageInfo>();
@@ -357,9 +361,9 @@ public class OBJExporter
     while (textures.hasMoreElements())
       {
         TextureImageInfo info = (TextureImageInfo) textures.nextElement();
-        
+
         // Select a name for the texture.
-        
+
         String baseName = info.texture.getName().replace(' ', '_');
         if (names.get(baseName) == null)
           info.name = baseName;
@@ -371,9 +375,9 @@ public class OBJExporter
             info.name = baseName+i;
           }
         names.put(info.name, info);
-        
+
         // Write the texture.
-        
+
         out.println("newmtl "+info.name);
         info.texture.getAverageSpec(spec, 0.0, info.paramValue);
         if (info.diffuseFilename == null)


### PR DESCRIPTION
This change, originally proposed in PR #3, requires some more thought. While using a logging framework vs. `System.out.println()` is arguably a more flexible option, we need to consider what we want logging in AOI to look like. As is, this PR will require additional configuration to log to anywhere useful - it currently will not even print to stdout.

If we want to go this route, some further conversion is in order. Some of the standard translators, at least, use `System.out.Printerr()` and were missed in the original conversion. @peastman, your input would be appreciated.
