### PR TITLE
Makiam's changes - need clarification

### DIFF
--- a/ArtOfIllusion/src/artofillusion/CurveEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/CurveEditorWindow.java
@@ -20,7 +20,7 @@ import java.awt.*;
 
 /** The CurveEditorWindow class represents the window for editing Curve objects. */
 
-public class CurveEditorWindow extends MeshEditorWindow implements EditingWindow
+public class CurveEditorWindow extends MeshEditorWindow
 {
   protected BMenu editMenu, meshMenu, smoothMenu;
   protected BMenuItem editMenuItem[], meshMenuItem[];

--- a/ArtOfIllusion/src/artofillusion/ExternalObjectEditingWindow.java
+++ b/ArtOfIllusion/src/artofillusion/ExternalObjectEditingWindow.java
@@ -4,8 +4,8 @@
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
    PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
 
 package artofillusion;
@@ -33,14 +33,14 @@ public class ExternalObjectEditingWindow extends BDialog
   private String objectName;
   private int objectId;
   private Runnable onClose;
-  
+
   /** Display a window for editing an ExternalObject.
       @param parent     the parent window
       @param obj        the object to edit
       @param info       the ObjectInfo for the ExternalObject
       @param onClose    a callback to invoke when the user clicks OK (may be null)
   */
-  
+
   public ExternalObjectEditingWindow(EditingWindow parent, ExternalObject obj, ObjectInfo info, Runnable onClose)
   {
     super(parent.getFrame(), info.getName(), true);
@@ -80,9 +80,9 @@ public class ExternalObjectEditingWindow extends BDialog
     UIUtilities.centerDialog(this, parentWindow.getFrame());
     setVisible(true);
   }
-  
+
   /** Allow the user to select a file. */
-  
+
   private void doBrowseFile()
   {
     BFileChooser fc = new BFileChooser(BFileChooser.OPEN_FILE, Translate.text("externalObject.selectScene"));
@@ -124,8 +124,7 @@ public class ExternalObjectEditingWindow extends BDialog
       new BStandardDialog("", new String [] {Translate.text("errorLoadingFile"), ex.getMessage() == null ? "" : ex.getMessage()}, BStandardDialog.ERROR).showMessageDialog(this);
     }
     setCursor(Cursor.getDefaultCursor());
-    if (scene == null)
-      return;
+
   }
 
   /** Build the list of objects for the user to select from. */
@@ -170,7 +169,7 @@ public class ExternalObjectEditingWindow extends BDialog
   }
 
   /** Save the changes and reload the object. */
-  
+
   private void doOk()
   {
     setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
@@ -190,4 +189,3 @@ public class ExternalObjectEditingWindow extends BDialog
     parentWindow.updateMenus();
   }
 }
-

--- a/ArtOfIllusion/src/artofillusion/MeshEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/MeshEditorWindow.java
@@ -24,7 +24,7 @@ import java.util.*;
 /** The MeshEditorWindow class represents the window for editing Mesh objects.  This is an
     abstract class, with subclasses for various types of objects. */
 
-public abstract class MeshEditorWindow extends ObjectEditorWindow implements MeshEditController, EditingWindow
+public abstract class MeshEditorWindow extends ObjectEditorWindow implements MeshEditController
 {
   protected Mesh oldMesh;
   protected BMenu viewMenu, colorSurfaceMenu;

--- a/ArtOfIllusion/src/artofillusion/ObjectTextureDialog.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectTextureDialog.java
@@ -714,7 +714,7 @@ public class ObjectTextureDialog extends BDialog implements ListChangeListener
       pack();
       UIUtilities.centerDialog(this, window);
       resetParameters();
-      return;
+
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/SplineMeshEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/SplineMeshEditorWindow.java
@@ -22,7 +22,7 @@ import java.awt.*;
 
 /** The SplineMeshEditorWindow class represents the window for editing SplineMesh objects. */
 
-public class SplineMeshEditorWindow extends MeshEditorWindow implements EditingWindow
+public class SplineMeshEditorWindow extends MeshEditorWindow
 {
   private ToolPalette modes;
   private BMenu editMenu, meshMenu, skeletonMenu;

--- a/ArtOfIllusion/src/artofillusion/TriMeshEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/TriMeshEditorWindow.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 /** The TriMeshEditorWindow class represents the window for editing TriangleMesh objects. */
 
-public class TriMeshEditorWindow extends MeshEditorWindow implements EditingWindow
+public class TriMeshEditorWindow extends MeshEditorWindow
 {
   private ToolPalette modes;
   private BMenuItem editMenuItem[], selectMenuItem[], meshMenuItem[], skeletonMenuItem[];

--- a/ArtOfIllusion/src/artofillusion/animation/distortion/SkeletonShapeEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/animation/distortion/SkeletonShapeEditorWindow.java
@@ -22,7 +22,7 @@ import java.awt.*;
 
 /** The SkeletonShapeEditorWindow class represents the window for editing SkeletonShapeKeyframes. */
 
-public class SkeletonShapeEditorWindow extends MeshEditorWindow implements MeshEditController
+public class SkeletonShapeEditorWindow extends MeshEditorWindow
 {
   private SkeletonShapeTrack track;
   private SkeletonShapeKeyframe keyframe;

--- a/ArtOfIllusion/src/artofillusion/math/PerlinNoise.java
+++ b/ArtOfIllusion/src/artofillusion/math/PerlinNoise.java
@@ -171,6 +171,7 @@ public class PerlinNoise
 
   /** Add the gradient of the wavelet at node (i, j, k) for the point (u, v, w). */
 
+  @SuppressWarnings("UnnecessaryReturnStatement")
   private static void addWaveletGradient(Vec3 gradient, int i, int j, int k, double u, double v, double w)
   {
     double dropu, dropv, dropw, product, dot;


### PR DESCRIPTION
These changes, originally proposed in PR #3, need a little discussion and clarification.

In particular:

 - Why `StringBuffer` over `StringBuilder`? The buffer version is syncronized, but none of the affected code needs to be thread safe.
 - Due to the somewhat deep inheritance structure of AOI code, it might be desirable for a subclass to declare that it implements an interface for clarity purposes, even if the Parent class already does.
 - removing unnecessary `return`s makes sense, but in the case of `ArtOfIllusion/src/artofillusion/math/PerlinNoise.java` I need to think about what the class is doing. If the returns are simply to prevent the switch statement from continuing through and testing further cases, perhaps they should be changed to `break`?