### PR TITLE
Keep reference to currently intersected object resolves #2

### DIFF
--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -1460,6 +1460,9 @@ public class RaytracerRenderer implements Renderer, Runnable
     }
     if (treeDepth == 0)
       workspace.firstObjectHit = first.getObject();
+    //the intersection object backing 'first' might get recycled,
+    //but we still need the object for transmitted rays.
+    RTObject hitObject = first.getObject();
     dist = intersection.intersectionDist(0);
     totalDist += dist;
     intersection.trueNormal(trueNorm);
@@ -1564,7 +1567,6 @@ public class RaytracerRenderer implements Renderer, Runnable
       col.scale(transmittedScale);
       workspace.ray[treeDepth+1].getOrigin().set(intersectionPoint);
       temp = workspace.ray[treeDepth].tempVec1;
-      RTObject hitObject = first.getObject();
       if (hitObject.getMaterialMapping() == null)
       {
         // Not a solid object, so the bulk material does not change.


### PR DESCRIPTION
The SurfaceIntersection object provided to spawnRay()
may be recycled during call to getDirectLight()

Moved assigenment of hitObject to as soon as there is a
valid object to assign.