### PR TITLE
ImageFileChooser to match read-supported file types

### DIFF
--- a/ArtOfIllusion/src/artofillusion.properties
+++ b/ArtOfIllusion/src/artofillusion.properties
@@ -1051,12 +1051,14 @@ objectType=Object Type
 # Various File filters
 #
 
-fileFilter.png=PNG Images (.png)
-fileFilter.jpeg=JPEG Images (.jpg)
-fileFilter.hdr=High Dynamic Range Images (.hdr)
-fileFilter.svg=SVG Images (.svg)
-fileFilter.tif=TIFF Images  (.tif)
 fileFilter.images=All Supported Image Formats
+fileFilter.gif=Graphic Interchange Format (.gif)
+fileFilter.hdr=High Dynamic Range Images (.hdr)
+fileFilter.jpeg=Joint Photographic Experts Group (.jpg, .jpeg, .jpe, .jif, .jfif)
+fileFilter.pic=Pictor PC Paint (.pic)
+fileFilter.png=Portable Network Graphics (.png)
+fileFilter.svg=Scalable Vector Graphics (.svg)
+fileFilter.tif=Tagged Image File Format (.tif, .tiff)
 
 fileFilter.obj=OBJ Files (.obj)
 

--- a/ArtOfIllusion/src/artofillusion/ui/ImageFileChooser.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ImageFileChooser.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2005 by Peter Eastman
+   Modification copyright (C) 2017 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -51,12 +52,18 @@ public class ImageFileChooser extends BFileChooser
     // Set up filename filters.
 
     jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.images"),
-                     "jpg", "jpeg", "png", "tif", "tiff", "svg", "svgz", "hdr"));
-    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.jpeg"), "jpg", "jpeg"));
-    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.hdr"), "hdr"));
+                              "gif", 
+                              "hdr", "hdri", 
+                              "jpg", "jpeg", "jpe", "jif", "jfif", 
+                              "pic", 
+                              "png", 
+                              "svg"));
+    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.gif"), "gif"));
+    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.hdr"), "hdr", "hdri", "pic"));
+    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.jpeg"), "jpg", "jpeg", "jpe", "jif", "jfif"));
+    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.pic"), "pic"));
     jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.png"), "png"));
-    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.svg"), "svg", "svgz"));
-    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.tif"), "tif", "tiff"));
+    jfc.addChoosableFileFilter(new FileNameExtensionFilter(Translate.text("fileFilter.svg"), "svg"));
     jfc.setAcceptAllFileFilterUsed(true);
 
     // Read the saved filter Preference.

--- a/ArtOfIllusion/src/artofillusion_fi.properties
+++ b/ArtOfIllusion/src/artofillusion_fi.properties
@@ -1048,6 +1048,23 @@ Solid=Kiinte\u00E4 kappale
 objectType=Esineen tyyppi
 
 #
+# Various File filters
+#
+
+fileFilter.images=Kaikki tuetut kuvatyypit
+fileFilter.gif=Graphic Interchange Format (.gif)
+fileFilter.hdr=High Dynamic Range Images (.hdr)
+fileFilter.jpeg=Joint Photographic Experts Group (.jpg, .jpeg, .jpe, .jif, .jfif)
+fileFilter.pic=Pictor PC Paint (.pic)
+fileFilter.png=Portable Network Graphics (.png)
+fileFilter.svg=Scalable Vector Graphics (.svg)
+fileFilter.tif=Tagged Image File Format (.tif, .tiff)
+
+fileFilter.obj=OBJ Files (.obj)
+
+fileFilter.aoi=Art of Illusion tiedostot (.aoi)
+
+#
 # Miscellaneous pieces of short text scattered through the program
 #
 


### PR DESCRIPTION
Changes:
- Removed tif
- Removed svgz -- Needs unzipping, which is not provided by `SVGImage` constructors.
- Added  gif
- Added more  jpeg-type extensios
- Could not verify if pic-format is really supported _(did not find any pic-images)_, but I left it there because it was in `ImageMap.loadImage()` in the same block with hdr.
