### PR TITLE
A fix to Shatter track freezing textured views

### DIFF
--- a/ArtOfIllusion/src/artofillusion/animation/distortion/ShatterDistortion.java
+++ b/ArtOfIllusion/src/artofillusion/animation/distortion/ShatterDistortion.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2002-2012 by Peter Eastman
+   A modification copyright (C) 2017 Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -99,8 +100,14 @@ public class ShatterDistortion extends Distortion
               visible[i] = true;
               num++;
             }
-        if (num == 0)
-          return new TriangleMesh(new Vec3 [] {new Vec3()}, new int [0][0]);
+
+        // This was supposed to make updating the views faster, but because the new TriangeMesh
+        // has no texture, textured views can not be updated after the shattered object has 
+        // disappeared. The error occurs in the constructor of TexturedVertexShader.
+       
+        //if (num == 0)
+        //  return new TriangleMesh(new TriangleMesh.Vertex []{vert[0]}, new int [0][0]);
+
         TriangleMesh.Face shownface[] = new TriangleMesh.Face [num];
         seed = new int [num];
         num = 0;

--- a/ArtOfIllusion/src/artofillusion/animation/distortion/ShatterDistortion.java
+++ b/ArtOfIllusion/src/artofillusion/animation/distortion/ShatterDistortion.java
@@ -101,13 +101,6 @@ public class ShatterDistortion extends Distortion
               num++;
             }
 
-        // This was supposed to make updating the views faster, but because the new TriangeMesh
-        // has no texture, textured views can not be updated after the shattered object has 
-        // disappeared. The error occurs in the constructor of TexturedVertexShader.
-       
-        //if (num == 0)
-        //  return new TriangleMesh(new TriangleMesh.Vertex []{vert[0]}, new int [0][0]);
-
         TriangleMesh.Face shownface[] = new TriangleMesh.Face [num];
         seed = new int [num];
         num = 0;

--- a/ArtOfIllusion/src/artofillusion/object/TriangleMesh.java
+++ b/ArtOfIllusion/src/artofillusion/object/TriangleMesh.java
@@ -785,13 +785,6 @@ public class TriangleMesh extends Object3D implements FacetedMesh
   @Override
   public RenderingMesh getRenderingMesh(double tol, boolean interactive, ObjectInfo info)
   {
-	// It is possible, that there are no faces on a TriangleMesh.
-	// In that case there is nothing to render. A null for RenderingMesh 
-	// is handled better than a RenderingMesh with no faces.
-	
-	if (face.length == 0)
-	  return null;
-
     TriangleMesh mesh = this;
     Vec3 vert[], normalArray[];
     List<Vec3> norm;

--- a/ArtOfIllusion/src/artofillusion/object/TriangleMesh.java
+++ b/ArtOfIllusion/src/artofillusion/object/TriangleMesh.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 1999-2015 by Peter Eastman
    Changes copyright (C) 2017 by Maksim Khramov
-
+   A modification copyright (C) 2017 Petri Ihalainen
+   
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
@@ -784,6 +785,13 @@ public class TriangleMesh extends Object3D implements FacetedMesh
   @Override
   public RenderingMesh getRenderingMesh(double tol, boolean interactive, ObjectInfo info)
   {
+	// It is possible, that there are no faces on a TriangleMesh.
+	// In that case there is nothing to render. A null for RenderingMesh 
+	// is handled better than a RenderingMesh with no faces.
+	
+	if (face.length == 0)
+	  return null;
+
     TriangleMesh mesh = this;
     Vec3 vert[], normalArray[];
     List<Vec3> norm;


### PR DESCRIPTION
This is my proposal for a fix to the problem, that a Shatter track freezes textured views at the point where a shattered object is set to disappear.

Two files were edited and either one of these changes would fix the problem alone. However, I chose to include both of modifications. They are actually addressed to different sides of the issue. Short comments added into the files.

