### PR TITLE
Catch exceptions for missing properties

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -201,7 +201,7 @@ public class ApplicationPreferences
       {
         return Integer.parseInt(properties.getProperty(name));
       }
-    catch (NumberFormatException ex)
+    catch (Exception ex)
       {
         return defaultVal;
       }
@@ -215,7 +215,7 @@ public class ApplicationPreferences
       {
         return Double.valueOf(properties.getProperty(name));
       }
-    catch (NumberFormatException ex)
+    catch (Exception ex)
       {
         return defaultVal;
       }


### PR DESCRIPTION
#30 changed this from `Exception` to `NumberFormatException`, which meant that if any other type of exception was thrown, it wouldn't be caught.  Most importantly, if a preference simply isn't present (because you've just upgraded from an older version), it throws a `NullPointerException`.  This is a case where it's safest to just catch all exceptions, since returning the default value is always the best we can do in that case.