### PR TITLE
Workaround for bug on Mac

### DIFF
--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -246,6 +246,9 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     if (ArtOfIllusion.APP_ICON != null)
       setIcon(ArtOfIllusion.APP_ICON);
     Rectangle screenBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+    String os = System.getProperties().getProperty("os.name").toLowerCase();
+    if (os.startsWith("mac os"))
+      screenBounds.height -= 11; // Workaround for bug in Java on Mac.
     setBounds(screenBounds);
     tools.requestFocus();
     setTime(theScene.getTime());


### PR DESCRIPTION
With Java 1.8.0_144 on Mac OS 10.12.6, the window briefly appears full size, but then immediately shrinks down to almost nothing.  I don't know why this fixes it, but it will do as a workaround.  See https://sourceforge.net/p/aoi/discussion/47784/thread/df034b7c/?limit=25#66b6 for more details.