### PR TITLE
Performance fix in 'mouseMoved()'

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -225,9 +225,9 @@ public abstract class ObjectViewer extends ViewerCanvas
     // Finish up.
 
     drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
     if (showAxes)
       drawCoordinateAxes();
     drawBorder();
@@ -311,12 +311,12 @@ public abstract class ObjectViewer extends ViewerCanvas
   public void setOrientation (int which)
   {
     if (which < 6)
-	  super.setOrientation(which);
-	else
-	{
-	  orientation = VIEW_OTHER;
-	  viewChanged(false);
-	}
+      super.setOrientation(which);
+    else
+    {
+      orientation = VIEW_OTHER;
+      viewChanged(false);
+    }
   }
 
   /** Begin dragging a selection region.  The variable square determines whether
@@ -349,7 +349,7 @@ public abstract class ObjectViewer extends ViewerCanvas
       selectBounds = createPolygonFromSelection();
     else
       selectBounds = new Rectangle(Math.min(clickPoint.x, dragPoint.x), Math.min(clickPoint.y, dragPoint.y),
-		Math.abs(dragPoint.x-clickPoint.x), Math.abs(dragPoint.y-clickPoint.y));
+        Math.abs(dragPoint.x-clickPoint.x), Math.abs(dragPoint.y-clickPoint.y));
   }
 
   /** Create a Polygon from the selection bounds. */
@@ -503,13 +503,13 @@ public abstract class ObjectViewer extends ViewerCanvas
     theCamera.setCameraCoordinates(cameraCoords);
     adjustCamera(isPerspective());
   }
-  
-   	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		((EditingWindow)controller).updateImage();
-	}
+
+       @Override
+    protected void mouseMoved(MouseMovedEvent e)
+    {
+        mouseMoving = true;
+        mousePoint = e.getPoint();
+        mouseMoveTimer.restart();
+        repaint();
+    }
 }

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -106,28 +106,28 @@ public class SceneViewer extends ViewerCanvas
     super.setOrientation(which);
     if (which > 5 && which < 6+cameras.size())
     {
-		ObjectInfo nextCamera = cameras.elementAt(which-6);
-		CoordinateSystem coords = nextCamera.coords.duplicate();
+        ObjectInfo nextCamera = cameras.elementAt(which-6);
+        CoordinateSystem coords = nextCamera.coords.duplicate();
 
-		if (nextCamera.getObject() instanceof SceneCamera){
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SceneCamera)nextCamera.getObject()).getDistToPlane())));
-		}
-		else if (nextCamera.getObject() instanceof SpotLight)
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SpotLight)nextCamera.getObject()).getDistToPlane())));
-		else if (nextCamera.getObject() instanceof DirectionalLight)
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((DirectionalLight)nextCamera.getObject()).getDistToPlane())));
-		else
-			return;
+        if (nextCamera.getObject() instanceof SceneCamera){
+            nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SceneCamera)nextCamera.getObject()).getDistToPlane())));
+        }
+        else if (nextCamera.getObject() instanceof SpotLight)
+            nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SpotLight)nextCamera.getObject()).getDistToPlane())));
+        else if (nextCamera.getObject() instanceof DirectionalLight)
+            nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((DirectionalLight)nextCamera.getObject()).getDistToPlane())));
+        else
+            return;
 
-		animation.start(coords, rotationCenter, 100.0, which, navigation);
+        animation.start(coords, rotationCenter, 100.0, which, navigation);
     }
     else
     {
       boundCamera = null;
-	  if (which > 5) // Would have thought that the super takes care of this but not always.
-		orientation = VIEW_OTHER;
+      if (which > 5) // Would have thought that the super takes care of this but not always.
+        orientation = VIEW_OTHER;
       viewChanged(false);
-	  //repaint();
+      //repaint();
     }
   }
 
@@ -139,12 +139,12 @@ public class SceneViewer extends ViewerCanvas
   public void finishAnimation(int which, boolean persp, int navi)
   {
     if (which > 5  && which < 6+cameras.size())
-		boundCamera = cameras.elementAt(which-6);
+        boundCamera = cameras.elementAt(which-6);
     orientation = which;
-	perspective = persp;
-	navigation = navi;
-	viewChanged(false);
-	repaint();
+    perspective = persp;
+    navigation = navi;
+    viewChanged(false);
+    repaint();
   }
 
   /** Estimate the range of depth values that the camera will need to render.  This need not be exact,
@@ -308,10 +308,10 @@ public class SceneViewer extends ViewerCanvas
 
     // Finish up.
 
-	drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    drawOverlay();
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
     if (showAxes)
       drawCoordinateAxes();
     drawBorder();
@@ -531,8 +531,8 @@ public class SceneViewer extends ViewerCanvas
   @Override
   protected void mouseDragged(WidgetMouseEvent e)
   {
-	mousePoint = e.getPoint();
-	drawOverlay();
+    mousePoint = e.getPoint();
+    drawOverlay();
     moveToGrid(e);
     if (!dragging)
     {
@@ -540,8 +540,8 @@ public class SceneViewer extends ViewerCanvas
       if (Math.abs(p.x-clickPoint.x) < 2 && Math.abs(p.y-clickPoint.y) < 2)
         return;
     }
-	
-	
+    
+    
     dragging = true;
     deselect = -1;
     if (draggingBox)
@@ -674,7 +674,7 @@ public class SceneViewer extends ViewerCanvas
       changed = (oldSelection[i] != newSelection[i]);
     if (changed)
       parentFrame.setUndoRecord(new UndoRecord(parentFrame, false, UndoRecord.SET_SCENE_SELECTION, new Object [] {oldSelection}));
-	dragging = false;
+    dragging = false;
   }
 
   /** 
@@ -683,33 +683,33 @@ public class SceneViewer extends ViewerCanvas
 
   public void mouseClicked(MouseClickedEvent e)
   {
-	//super.mouseClicked(e);
-	
+    //super.mouseClicked(e);
+    
     if (e.getClickCount() == 2 && (activeTool.whichClicks() & EditingTool.OBJECT_CLICKS) != 0 && clickedObject != null && clickedObject.getObject().isEditable())
     {
       final Object3D obj = clickedObject.getObject();
       parentFrame.setUndoRecord(new UndoRecord(parentFrame, false, UndoRecord.COPY_OBJECT, new Object [] {obj, obj.duplicate()}));
       obj.edit(parentFrame, clickedObject,  new Runnable() {
         @Override
-	    public void run()
-	    {
-	      theScene.objectModified(obj);
-	      parentFrame.updateImage();
-	      parentFrame.updateMenus();
-	    }
-	});
+        public void run()
+        {
+          theScene.objectModified(obj);
+          parentFrame.updateImage();
+          parentFrame.updateMenus();
+        }
+    });
     }
   }
 
- 	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		parentFrame.updateImage(); // I wonder why, but that's how it works
-	}
-	
+     @Override
+    protected void mouseMoved(MouseMovedEvent e)
+    {
+        mouseMoving = true;
+        mousePoint = e.getPoint();
+        mouseMoveTimer.restart();
+        repaint();
+    }
+
   /** This is called recursively to move any children of a bound camera. */
 
   private void moveChildren(ObjectInfo obj, Mat4 transform, UndoRecord undo)


### PR DESCRIPTION
- A performance fix in `mouseMoved()` method: Update only the view where the mouse is (Object viewer. line  513 and SceneViewer, line 710). -- The update is stilll rather heavy thingking of the need. 
- Refactoring: Cleand tabs while I was at it.
