### PR TITLE
Drawig overlays independent of 3D-repaint made possible

### DIFF
--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -989,6 +989,16 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
       }
   }
 
+  /** Update the overlays displayed in all of the viewport. 
+      @param view The view whose overlays don't need updating. If null, update all. */
+
+  public void updateOverlays(ViewerCanvas view)
+  {
+    for (int i = 0; i < numViewsShown; i++)
+      if (theView[i] != view)
+        theView[i].updateOverlays();
+  }
+
   /** Update the state of all menu items. */
 
   @Override
@@ -1162,6 +1172,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
   public void addObject(ObjectInfo info, UndoRecord undo)
   {
     theScene.addObject(info, undo);
+<<<<<<< HEAD
     itemTree.setUpdateEnabled(false);
     itemTree.addElement(new ObjectTreeElement(info, itemTree));
     uiEventProcessor.addEvent(new Runnable()
@@ -1174,6 +1185,12 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
         theScore.rebuildList();
       }
     });
+=======
+    itemTree.addElement(new ObjectTreeElement(info, itemTree));
+    for (int i = 0; i < theView.length ; i++)
+      theView[i].rebuildCameraList();
+    theScore.rebuildList();
+>>>>>>> 09dd8fd... Drawig overlays independent of 3D-repaint made possible
   }
 
   /** Add a new object to the scene.  If undo is not null,
@@ -1375,7 +1392,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
       which[i] = theScene.indexOf((ObjectInfo) sel[i]);
     setUndoRecord(new UndoRecord(this, false, UndoRecord.SET_SCENE_SELECTION, new Object [] {getSelectedIndices()}));
     setSelection(which);
-    updateImage();
+    updateOverlays(null);
   }
 
   private void displayModeCommand(CommandEvent ev)
@@ -1481,7 +1498,6 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     theScene.clearSelection();
     itemTree.deselectAll();
     theScore.rebuildList();
-    updateImage();
     updateMenus();
   }
 
@@ -1893,7 +1909,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
       which[i] = i;
     setUndoRecord(new UndoRecord(this, false, UndoRecord.SET_SCENE_SELECTION, new Object [] {getSelectedIndices()}));
     setSelection(which);
-    updateImage();
+    updateOverlays(null);
   }
 
   public void preferencesCommand()
@@ -2501,7 +2517,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
         info.setLocked(locked);
       }
     setUndoRecord(undo);
-    updateImage();
+    updateImage(); // Does something really change?
     itemTree.repaint();
   }
 

--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -1172,7 +1172,6 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
   public void addObject(ObjectInfo info, UndoRecord undo)
   {
     theScene.addObject(info, undo);
-<<<<<<< HEAD
     itemTree.setUpdateEnabled(false);
     itemTree.addElement(new ObjectTreeElement(info, itemTree));
     uiEventProcessor.addEvent(new Runnable()
@@ -1185,18 +1184,12 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
         theScore.rebuildList();
       }
     });
-=======
-    itemTree.addElement(new ObjectTreeElement(info, itemTree));
-    for (int i = 0; i < theView.length ; i++)
-      theView[i].rebuildCameraList();
-    theScore.rebuildList();
->>>>>>> 09dd8fd... Drawig overlays independent of 3D-repaint made possible
   }
 
   /** Add a new object to the scene.  If undo is not null,
       appropriate commands will be added to it to undo this operation. <P>
-	  
-	  NOTE! This method is only used by 'UndoRecord'. Using it in any other context is not safe. */
+
+      NOTE! This method is only used by 'UndoRecord'. Using it in any other context is not safe. */
 
   public void addObject(ObjectInfo info, int index, UndoRecord undo)
   {

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -65,7 +65,7 @@ public class MoveViewTool extends EditingTool
   {
     Camera cam = view.getCamera();
 
-	selectedNavigation = view.getNavigationMode();
+    selectedNavigation = view.getNavigationMode();
     controlDown = e.isControlDown();
     clickPoint = e.getPoint();
     clickPos = cam.convertScreenToWorld(clickPoint, view.getDistToPlane());
@@ -74,159 +74,161 @@ public class MoveViewTool extends EditingTool
     oldRotCenter = new Vec3(view.getRotationCenter());
     oldScale = view.getScale();
     oldDist = view.getDistToPlane(); // distToPlane needs to be kept up to date
-	view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(oldDist)));
-	
-	if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
-	    !e.isAltDown() && !e.isMetaDown()){
-		if (view.getNavigationMode() > 3)
-			view.setNavigationMode(0);
-		else if (view.getNavigationMode() > 1)
-			view.setNavigationMode(view.getNavigationMode()-2, true);
-	}
-	view.mouseDown = true;
-	view.moving = true;
+    view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(oldDist)));
+    
+    if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
+        !e.isAltDown() && !e.isMetaDown()){
+        if (view.getNavigationMode() > 3)
+            view.setNavigationMode(0);
+        else if (view.getNavigationMode() > 1)
+            view.setNavigationMode(view.getNavigationMode()-2, true);
+    }
+    view.mouseDown = true;
+    view.moving = true;
   }
 
-	@Override
-	public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		// If the tool is selected in the tool palette
-		if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
-			dragMoveModel(e, view);
-		else
-		{
-			switch (view.getNavigationMode()) {
-				case ViewerCanvas.NAVIGATE_MODEL_SPACE:
-				case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
-					dragMoveModel(e, view);
-					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
-				case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
-					dragMoveTravel(e, view);
-					break;
-				default:
-					break;
-			}
-		}
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		view.viewChanged(false);	
-	}
+    @Override
+    public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        // If the tool is selected in the tool palette
+        if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
+            dragMoveModel(e, view);
+        else
+        {
+            switch (view.getNavigationMode()) {
+                case ViewerCanvas.NAVIGATE_MODEL_SPACE:
+                case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
+                    dragMoveModel(e, view);
+                    break;
+                case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
+                case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
+                    dragMoveTravel(e, view);
+                    break;
+                default:
+                    break;
+            }
+        }
+        setAuxGraphs(view);
+        view.repaint();
+        if (theWindow instanceof LayoutWindow) ((LayoutWindow)theWindow).updateOverlays(view);
+        if (theWindow instanceof ObjectEditorWindow) ((ObjectEditorWindow)theWindow).updateOverlays(view);
+        view.viewChanged(false);    
+    }
 
-	/* The view must be set to Perspective for travel modes! */
-	private void dragMoveTravel(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		Camera cam = view.getCamera();
-		
-		// We compare the move to the moment when the mouse button was pressed
-		CoordinateSystem coords = oldCoords.duplicate();
-		Point dragPoint = e.getPoint();
-		int dx, dy;
-		
-		dx = dragPoint.x-clickPoint.x;
-		dy = dragPoint.y-clickPoint.y;
+    /* The view must be set to Perspective for travel modes! */
+    private void dragMoveTravel(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        Camera cam = view.getCamera();
+        
+        // We compare the move to the moment when the mouse button was pressed
+        CoordinateSystem coords = oldCoords.duplicate();
+        Point dragPoint = e.getPoint();
+        int dx, dy;
+        
+        dx = dragPoint.x-clickPoint.x;
+        dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown) // forward move!
-		{ 	
-			Vec3 hDir;
-			if (view.getNavigationMode() == 3)
-			{
-				hDir = new Vec3(coords.getZDirection().x, 0.0, coords.getZDirection().z);
-				hDir.normalize();
-			}
-			else
-				hDir = coords.getZDirection();
-				
-			Vec3 newPos = oldCamPos.plus(hDir.times(-dy*0.04*oldDist/cam.getDistToScreen()));
-			coords.setOrigin(newPos);
-			
-			cam.setCameraCoordinates(coords);
-			view.setRotationCenter(newPos.plus(coords.getZDirection().times(oldDist)));
-		}
-		else // Move up-down-right-left
-		{
-			if (e.isShiftDown()) // Shift down move just up or down.
-			{
-				if (Math.abs(dx) > Math.abs(dy))
-					dy = 0;
-				else
-					dx = 0;
-			}
-			Vec3 vDir;
-			if (view.getNavigationMode() == 3)
-				vDir = new Vec3(0,1,0);
-			else
-				vDir = coords.getUpDirection();
+        if (controlDown) // forward move!
+        {     
+            Vec3 hDir;
+            if (view.getNavigationMode() == 3)
+            {
+                hDir = new Vec3(coords.getZDirection().x, 0.0, coords.getZDirection().z);
+                hDir.normalize();
+            }
+            else
+                hDir = coords.getZDirection();
+                
+            Vec3 newPos = oldCamPos.plus(hDir.times(-dy*0.04*oldDist/cam.getDistToScreen()));
+            coords.setOrigin(newPos);
+            
+            cam.setCameraCoordinates(coords);
+            view.setRotationCenter(newPos.plus(coords.getZDirection().times(oldDist)));
+        }
+        else // Move up-down-right-left
+        {
+            if (e.isShiftDown()) // Shift down move just up or down.
+            {
+                if (Math.abs(dx) > Math.abs(dy))
+                    dy = 0;
+                else
+                    dx = 0;
+            }
+            Vec3 vDir;
+            if (view.getNavigationMode() == 3)
+                vDir = new Vec3(0,1,0);
+            else
+                vDir = coords.getUpDirection();
 
-			// Horizontal move
-			Vec3 hMove = cam.findDragVector(clickPos, dx, 0.0);
-			Mat4 m = Mat4.translation(-hMove.x, 0.0, -hMove.z);
-			coords.transformOrigin(m);
+            // Horizontal move
+            Vec3 hMove = cam.findDragVector(clickPos, dx, 0.0);
+            Mat4 m = Mat4.translation(-hMove.x, 0.0, -hMove.z);
+            coords.transformOrigin(m);
 
-			// Vertical move
-			Vec3 newPos = coords.getOrigin().plus(vDir.times(dy*0.01*view.getDistToPlane()/cam.getDistToScreen()));
-			coords.setOrigin(newPos);
-			
-			cam.setCameraCoordinates(coords);
-			view.setRotationCenter(newPos.plus(coords.getZDirection().times(view.getDistToPlane())));
-		}
-	}
-	
-	private void dragMoveModel(WidgetMouseEvent e, ViewerCanvas view)
-	{	
-		Camera cam = view.getCamera();
-		Point dragPoint = e.getPoint();
-		int dx, dy;
-		
-		dx = dragPoint.x-clickPoint.x;
-		dy = dragPoint.y-clickPoint.y;
+            // Vertical move
+            Vec3 newPos = coords.getOrigin().plus(vDir.times(dy*0.01*view.getDistToPlane()/cam.getDistToScreen()));
+            coords.setOrigin(newPos);
+            
+            cam.setCameraCoordinates(coords);
+            view.setRotationCenter(newPos.plus(coords.getZDirection().times(view.getDistToPlane())));
+        }
+    }
+    
+    private void dragMoveModel(WidgetMouseEvent e, ViewerCanvas view)
+    {    
+        Camera cam = view.getCamera();
+        Point dragPoint = e.getPoint();
+        int dx, dy;
+        
+        dx = dragPoint.x-clickPoint.x;
+        dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown) // zoom!
-		{ 	
-			if (view.isPerspective())
-			{
-				CoordinateSystem coords = view.getCamera().getCameraCoordinates();
-				double newDist = oldDist*Math.pow(1.0/1.01, (double)dy);
-				Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
-				coords.setOrigin(newPos);
-				view.getCamera().setCameraCoordinates(coords);
-				view.setDistToPlane(newDist);
-			}
-			else
-			{
-				double newScale = oldScale*(Math.pow(1.01,(double)dy));
-				view.setScale(newScale);
-			}
-		}
-		else // Move up-down-right-left
-		{
-			if (e.isShiftDown()) // Shift down move just up or down.
-			{
-				if (Math.abs(dx) > Math.abs(dy))
-					dy = 0;
-				else
-					dx = 0;
-			}
-			Vec3 move = cam.findDragVector(clickPos, dx, dy); // Check findDragVector()!
+        if (controlDown) // zoom!
+        {     
+            if (view.isPerspective())
+            {
+                CoordinateSystem coords = view.getCamera().getCameraCoordinates();
+                double newDist = oldDist*Math.pow(1.0/1.01, (double)dy);
+                Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
+                coords.setOrigin(newPos);
+                view.getCamera().setCameraCoordinates(coords);
+                view.setDistToPlane(newDist);
+            }
+            else
+            {
+                double newScale = oldScale*(Math.pow(1.01,(double)dy));
+                view.setScale(newScale);
+            }
+        }
+        else // Move up-down-right-left
+        {
+            if (e.isShiftDown()) // Shift down move just up or down.
+            {
+                if (Math.abs(dx) > Math.abs(dy))
+                    dy = 0;
+                else
+                    dx = 0;
+            }
+            Vec3 move = cam.findDragVector(clickPos, dx, dy); // Check findDragVector()!
 
-			// Scaling the move from Camera to Scene
-			if (view.isPerspective())
-				move = move.times(oldDist/view.getDistToPlane());
-			
-			Mat4 m = Mat4.translation(-move.x, -move.y, -move.z);
-			CoordinateSystem newCoords = oldCoords.duplicate();			
-			newCoords.transformOrigin(m);
-			cam.setCameraCoordinates(newCoords);
-			view.setRotationCenter(newCoords.getOrigin().plus(newCoords.getZDirection().times(oldDist)));
-		}
-	}
+            // Scaling the move from Camera to Scene
+            if (view.isPerspective())
+                move = move.times(oldDist/view.getDistToPlane());
+            
+            Mat4 m = Mat4.translation(-move.x, -move.y, -move.z);
+            CoordinateSystem newCoords = oldCoords.duplicate();            
+            newCoords.transformOrigin(m);
+            cam.setCameraCoordinates(newCoords);
+            view.setRotationCenter(newCoords.getOrigin().plus(newCoords.getZDirection().times(oldDist)));
+        }
+    }
 
   @Override
   public void mouseReleased(WidgetMouseEvent e, ViewerCanvas view)
   {
-	view.mouseDown = false;
-	view.moving = false;
-	view.setNavigationMode(selectedNavigation);
+    view.mouseDown = false;
+    view.moving = false;
+    view.setNavigationMode(selectedNavigation);
     if (theWindow != null)
       {
         ObjectInfo bound = view.getBoundCamera();
@@ -234,15 +236,15 @@ public class MoveViewTool extends EditingTool
         {
           // This view corresponds to an actual camera in the scene.  Create an undo record, and move any children of
           // the camera.
-		  bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
+          bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
           UndoRecord undo = new UndoRecord(theWindow, false, UndoRecord.COPY_COORDS, new Object [] {bound.getCoords(), oldCoords});
           moveChildren(bound, bound.getCoords().fromLocal().times(oldCoords.toLocal()), undo);
           theWindow.setUndoRecord(undo);
         }
         theWindow.updateImage();
       }
-	wipeAuxGraphs();
-	view.viewChanged(false);
+    wipeAuxGraphs();
+    view.viewChanged(false);
   }
 
   /** This is called recursively to move any children of a bound camera. */
@@ -258,36 +260,27 @@ public class MoveViewTool extends EditingTool
     }  
   }
 
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (theWindow == null || theWindow instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : theWindow.getAllViews())
-	  	v.repaint();
-  }
-
   private void setAuxGraphs(ViewerCanvas view)
   {
 
-	if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
+    if (theWindow != null)
+      for (ViewerCanvas v : theWindow.getAllViews())
         if (v != view)
-	      v.auxGraphs.set(view, true);
+          v.auxGraphs.set(view, true);
   }
   
   private void wipeAuxGraphs()
   {
     if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-		v.auxGraphs.wipe();
+      for (ViewerCanvas v : theWindow.getAllViews())
+        v.auxGraphs.wipe();
   }
 
   @Override
   public void drawOverlay(ViewerCanvas view)
   {
-     if (view.moving){
-       //view.drawLine(new Point (0,0), new Point (100, 100), Color.MAGENTA);
-	 }
+     //if (view.moving){
+     //  view.drawLine(new Point (0,0), new Point (100, 100), Color.MAGENTA);
+     //}
   }
 }

--- a/ArtOfIllusion/src/artofillusion/ObjectEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectEditorWindow.java
@@ -119,22 +119,22 @@ public abstract class ObjectEditorWindow extends BFrame implements EditingWindow
       theView[i].setShowAxes(lastShowAxes);
       theView[i].setGrid(lastGridSpacing, lastGridSubdivisions, lastShowGrid, lastSnapToGrid);
       theView[i].addEventLink(MousePressedEvent.class, listen);
-	  theView[i].setViewAnimation (new ViewAnimation(this, theView[i]));
+      theView[i].setViewAnimation (new ViewAnimation(this, theView[i]));
     }
     theView[1].setOrientation(2);
     theView[2].setOrientation(4);
     theView[3].setNavigationMode(1,true);
     //theView[3].setPerspective(true);
-	
-	/* 
-	   I wonder if this would have any side effects?
-	   At least this way it will be in the sub classes, including plugins.
-	*/
-	scrollTool = new ScrollViewTool(this);
-	for (ViewerCanvas v : theView)
-		v.setScrollTool(scrollTool);
+    
+    /* 
+       I wonder if this would have any side effects?
+       At least this way it will be in the sub classes, including plugins.
+    */
+    scrollTool = new ScrollViewTool(this);
+    for (ViewerCanvas v : theView)
+        v.setScrollTool(scrollTool);
 
-	viewsContainer.add(viewPanel[0], 0, 0);
+    viewsContainer.add(viewPanel[0], 0, 0);
     viewsContainer.add(viewPanel[1], 1, 0);
     viewsContainer.add(viewPanel[2], 0, 1);
     viewsContainer.add(viewPanel[3], 1, 1);
@@ -232,13 +232,13 @@ public abstract class ObjectEditorWindow extends BFrame implements EditingWindow
   public void toolChanged(EditingTool tool)
   {
     for (ViewerCanvas v:theView)
-	{
-		if (tool instanceof MoveViewTool || tool instanceof RotateViewTool)
-			v.navigationTravelEnabled = false;
-		else
-			v.navigationTravelEnabled = true;
-		v.viewChanged(false); // This should do nothing now...
-	}
+    {
+        if (tool instanceof MoveViewTool || tool instanceof RotateViewTool)
+            v.navigationTravelEnabled = false;
+        else
+            v.navigationTravelEnabled = true;
+        v.viewChanged(false); // This should do nothing now...
+    }
   }
 
   @Override
@@ -265,7 +265,14 @@ public abstract class ObjectEditorWindow extends BFrame implements EditingWindow
     for (ViewerCanvas view : theView)
       view.repaint();
   }
-  
+ 
+  public void updateOverlays(ViewerCanvas view)
+  {
+    for (ViewerCanvas v : theView)
+      if (v != view)
+        v.updateOverlays();
+  }
+
   @Override
   public void setUndoRecord(UndoRecord command)
   {
@@ -332,7 +339,7 @@ public abstract class ObjectEditorWindow extends BFrame implements EditingWindow
         theView[i].setDrawFocus(true);
         currentView = i;
         updateMenus();
-        updateImage();
+        updateOverlays(null);
       }
   }
 
@@ -362,7 +369,7 @@ public abstract class ObjectEditorWindow extends BFrame implements EditingWindow
     lastShowAxes = !wasShown;
     savePreferences();
     updateMenus();
-    updateImage();
+    updateOverlays(null);
   }
 
   /** Toggle whether the template is shown. */

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -235,11 +235,11 @@ public abstract class ObjectViewer extends ViewerCanvas
     // Finish up.
 
     drawOverlay();
-    currentTool.drawOverlay(this);
     if (activeTool != null)
       activeTool.drawOverlay(this);
     if (showAxes)
       drawCoordinateAxes();
+    currentTool.drawOverlay(this);
     drawBorder();
   }
 
@@ -517,6 +517,11 @@ public abstract class ObjectViewer extends ViewerCanvas
   @Override
   protected void mouseMoved(MouseMovedEvent e)
   {
+    if (dragging)
+    {
+      mouseMoving = false;
+      return;
+    }
     mouseMoving = true;
     mousePoint = e.getPoint();
     mouseMoveTimer.restart();

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -28,7 +28,7 @@ import java.util.*;
 public abstract class ObjectViewer extends ViewerCanvas
 {
   protected MeshEditController controller;
-  protected boolean showScene, useWorldCoords, freehandSelection, draggingBox, squareBox, sentClick;
+  protected boolean showScene, useWorldCoords, freehandSelection, draggingBox, squareBox, sentClick, overlaysOnly;
   protected Point clickPoint, dragPoint;
   protected Vector<Point> selectBoundsPoints;
   protected Shape selectBounds;
@@ -40,6 +40,7 @@ public abstract class ObjectViewer extends ViewerCanvas
     super(ArtOfIllusion.getPreferences().getUseOpenGL() && isOpenGLAvailable());
     this.controller = controller;
     buildChoices(p);
+    overlaysOnly = false;
   }
 
   /** Get the controller which maintains the state for this viewer. */
@@ -196,38 +197,47 @@ public abstract class ObjectViewer extends ViewerCanvas
       return;
     }
 
-    super.updateImage();
-    if (controller.getObject() == null)
-      return;
-
-    // Draw the rest of the objects in the scene.
-
-    if (showScene && theScene != null)
+    if (overlaysOnly)
     {
-      Vec3 viewdir = getDisplayCoordinates().toLocal().timesDirection(theCamera.getViewToWorld().timesDirection(Vec3.vz()));
-      for (ObjectInfo obj: theScene.getObjects())
-      {
-        if (!obj.isVisible() || obj == thisObjectInScene)
-          continue;
-        Mat4 objectTransform = obj.getCoords().fromLocal();
-        if (!useWorldCoords && thisObjectInScene != null)
-          objectTransform = thisObjectInScene.getCoords().toLocal().times(objectTransform);
-        theCamera.setObjectTransform(objectTransform);
-        obj.getObject().renderObject(obj, this, thisObjectInScene.getCoords().fromLocal().timesDirection(viewdir));
-      }
+      drawer.applyCachedSnapShot();
     }
-
-    // Draw the object being edited.
-
-    theCamera.setObjectTransform(getDisplayCoordinates().fromLocal());
-    drawObject();
+    else
+    {
+      super.updateImage();
+      if (controller.getObject() == null)
+        return;
+      
+      // Draw the rest of the objects in the scene.
+      
+      if (showScene && theScene != null)
+      {
+        Vec3 viewdir = getDisplayCoordinates().toLocal().timesDirection(theCamera.getViewToWorld().timesDirection(Vec3.vz()));
+        for (ObjectInfo obj: theScene.getObjects())
+        {
+          if (!obj.isVisible() || obj == thisObjectInScene)
+            continue;
+          Mat4 objectTransform = obj.getCoords().fromLocal();
+          if (!useWorldCoords && thisObjectInScene != null)
+            objectTransform = thisObjectInScene.getCoords().toLocal().times(objectTransform);
+          theCamera.setObjectTransform(objectTransform);
+          obj.getObject().renderObject(obj, this, thisObjectInScene.getCoords().fromLocal().timesDirection(viewdir));
+        }
+      }
+      
+      // Draw the object being edited.
+      
+      theCamera.setObjectTransform(getDisplayCoordinates().fromLocal());
+      drawObject();
+      drawer.cacheSnapShot();
+    }
+    overlaysOnly = false;
 
     // Finish up.
 
     drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+      activeTool.drawOverlay(this);
     if (showAxes)
       drawCoordinateAxes();
     drawBorder();
@@ -311,12 +321,12 @@ public abstract class ObjectViewer extends ViewerCanvas
   public void setOrientation (int which)
   {
     if (which < 6)
-	  super.setOrientation(which);
-	else
-	{
-	  orientation = VIEW_OTHER;
-	  viewChanged(false);
-	}
+      super.setOrientation(which);
+    else
+    {
+      orientation = VIEW_OTHER;
+      viewChanged(false);
+    }
   }
 
   /** Begin dragging a selection region.  The variable square determines whether
@@ -349,7 +359,7 @@ public abstract class ObjectViewer extends ViewerCanvas
       selectBounds = createPolygonFromSelection();
     else
       selectBounds = new Rectangle(Math.min(clickPoint.x, dragPoint.x), Math.min(clickPoint.y, dragPoint.y),
-		Math.abs(dragPoint.x-clickPoint.x), Math.abs(dragPoint.y-clickPoint.y));
+        Math.abs(dragPoint.x-clickPoint.x), Math.abs(dragPoint.y-clickPoint.y));
   }
 
   /** Create a Polygon from the selection bounds. */
@@ -503,13 +513,15 @@ public abstract class ObjectViewer extends ViewerCanvas
     theCamera.setCameraCoordinates(cameraCoords);
     adjustCamera(isPerspective());
   }
-  
-   	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		((EditingWindow)controller).updateImage();
-	}
+
+  @Override
+  protected void mouseMoved(MouseMovedEvent e)
+  {
+    mouseMoving = true;
+    mousePoint = e.getPoint();
+    mouseMoveTimer.restart();
+    currentTool.mouseMoved(e, this);
+    updateOverlays();
+    ((ObjectEditorWindow)controller).updateOverlays(this);
+  }
 }

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2012 by Peter Eastman
-   Changes copyright (C) 2106-2017 by Petri Ihalainen
+   Changes copyright (C) 2016-2017 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -72,330 +72,332 @@ public class RotateViewTool extends EditingTool
   public void mousePressed(WidgetMouseEvent e, ViewerCanvas view)
   {
     camera = view.getCamera();
-	
-	selectedNavigation = view.getNavigationMode();
+    
+    selectedNavigation = view.getNavigationMode();
     oldCoords = camera.getCameraCoordinates().duplicate();
-	
-	// Make sure that the rotation Center is on Camera Z-axis.
-	// Some plugins like PolyMesh can have them separated
-	view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(view.getDistToPlane())));
-	
+    
+    // Make sure that the rotation Center is on Camera Z-axis.
+    // Some plugins like PolyMesh can have them separated
+    view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(view.getDistToPlane())));
+    
     controlDown = e.isControlDown();
     clickPoint = e.getPoint();
     viewToWorld = camera.getViewToWorld();
     rotationCenter = view.getRotationCenter();
-	distToRot = oldCoords.getOrigin().minus(rotationCenter).length();
-	
-	if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
-	    !e.isAltDown() && !e.isMetaDown()){
-		if (view.getNavigationMode() > 3)
-			view.setNavigationMode(0);
-		else if (view.getNavigationMode() > 1)
-			view.setNavigationMode(view.getNavigationMode()-2, true);
-	}
-	view.mouseDown = true;
-	view.rotating = true;
+    distToRot = oldCoords.getOrigin().minus(rotationCenter).length();
+    
+    if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
+        !e.isAltDown() && !e.isMetaDown()){
+        if (view.getNavigationMode() > 3)
+            view.setNavigationMode(0);
+        else if (view.getNavigationMode() > 1)
+            view.setNavigationMode(view.getNavigationMode()-2, true);
+    }
+    view.mouseDown = true;
+    view.rotating = true;
   }
  
-	@Override
-  	public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		if (e.getPoint() != clickPoint && view.getBoundCamera() == null) // This is needed even if the mouse has not been dragged yet.
-			view.setOrientation(ViewerCanvas.VIEW_OTHER);
-			
-		if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
-		{
-			if (view.getNavigationMode() == 0)
-				dragRotateSpace(e, view);
-			else if (view.getNavigationMode() == 1)
-			{
-				Vec3 zD = oldCoords.getZDirection();
-				fwMax = Math.PI*0.5+Math.asin(zD.y);
-				fwMin = -Math.PI*0.5+Math.asin(zD.y);
-				dragRotateLandscape(e, view);
-			}
-		}
-		else
-		{
-			switch (view.getNavigationMode()) 
-			{
-				case ViewerCanvas.NAVIGATE_MODEL_SPACE:
-					dragRotateSpace(e, view);
-					break;
-				case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
-					Vec3 zD = oldCoords.getZDirection();
-					fwMax = Math.PI*0.5+Math.asin(zD.y);
-					fwMin = -Math.PI*0.5+Math.asin(zD.y);
-					dragRotateLandscape(e, view);
-					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
-					dragRotateTravelSpace(e, view);
-					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
-					dragRotateTravelLandscape(e, view);
-					break;
-				default:
-					break;
-			}
-		}
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		view.viewChanged(false);	
-	}
-	
-	private void dragRotateTravelSpace(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		Point dragPoint = e.getPoint();
-		Vec3 axis, location;
-		CoordinateSystem c = oldCoords.duplicate();
-		location = c.getOrigin();
-		int dx, dy;
+    @Override
+      public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        if (e.getPoint() != clickPoint && view.getBoundCamera() == null) // This is needed even if the mouse has not been dragged yet.
+            view.setOrientation(ViewerCanvas.VIEW_OTHER);
+            
+        if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
+        {
+            if (view.getNavigationMode() == 0)
+                dragRotateSpace(e, view);
+            else if (view.getNavigationMode() == 1)
+            {
+                Vec3 zD = oldCoords.getZDirection();
+                fwMax = Math.PI*0.5+Math.asin(zD.y);
+                fwMin = -Math.PI*0.5+Math.asin(zD.y);
+                dragRotateLandscape(e, view);
+            }
+        }
+        else
+        {
+            switch (view.getNavigationMode()) 
+            {
+                case ViewerCanvas.NAVIGATE_MODEL_SPACE:
+                    dragRotateSpace(e, view);
+                    break;
+                case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
+                    Vec3 zD = oldCoords.getZDirection();
+                    fwMax = Math.PI*0.5+Math.asin(zD.y);
+                    fwMin = -Math.PI*0.5+Math.asin(zD.y);
+                    dragRotateLandscape(e, view);
+                    break;
+                case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
+                    dragRotateTravelSpace(e, view);
+                    break;
+                case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
+                    dragRotateTravelLandscape(e, view);
+                    break;
+                default:
+                    break;
+            }
+        }
+        setAuxGraphs(view);
+        view.repaint();
+        if (theWindow instanceof LayoutWindow) ((LayoutWindow)theWindow).updateOverlays(view);
+        if (theWindow instanceof ObjectEditorWindow) ((ObjectEditorWindow)theWindow).updateOverlays(view);
+        view.viewChanged(false);    
+    }
 
-		dx = dragPoint.x-clickPoint.x;
-		dy = dragPoint.y-clickPoint.y;
+    private void dragRotateTravelSpace(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        Point dragPoint = e.getPoint();
+        Vec3 axis, location;
+        CoordinateSystem c = oldCoords.duplicate();
+        location = c.getOrigin();
+        int dx, dy;
 
-		if (controlDown && !e.isShiftDown())
-		{
-			view.tilting = true;
-			tilt(e, view, clickPoint);
-			return;
-		}
-		else if (controlDown && e.isShiftDown())
-		{
-			rotateSpace(e, view, clickPoint);
-			return;
-		}
-		else if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
-			{
-				axis = viewToWorld.timesDirection(Vec3.vy());
-				angle = dx * DRAG_SCALE / view.getCamera().getDistToScreen();
-			}
-			else
-			{
-				axis = viewToWorld.timesDirection(Vec3.vx());
-				angle = -dy * DRAG_SCALE / view.getCamera().getDistToScreen();
-			}
-		}
-		else
-		{
-			axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-			angle = axis.length() / view.getCamera().getDistToScreen();
-			axis.normalize(); //  = axis.times(1.0/angle);
-			axis = viewToWorld.timesDirection(axis);
-		}
-		if (angle != 0)
-		{
-			c.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
-			c.transformCoordinates(Mat4.axisRotation(axis, angle));
-			c.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
-			view.getCamera().setCameraCoordinates(c);
-			Vec3 cc = c.getOrigin();
-			view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
-		}
-	}
+        dx = dragPoint.x-clickPoint.x;
+        dy = dragPoint.y-clickPoint.y;
 
-	private void dragRotateSpace(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		// This is modified from AoI 2.7
+        if (controlDown && !e.isShiftDown())
+        {
+            view.tilting = true;
+            tilt(e, view, clickPoint);
+            return;
+        }
+        else if (controlDown && e.isShiftDown())
+        {
+            rotateSpace(e, view, clickPoint);
+            return;
+        }
+        else if (!controlDown && e.isShiftDown())
+        {
+            if (Math.abs(dx) > Math.abs(dy))
+            {
+                axis = viewToWorld.timesDirection(Vec3.vy());
+                angle = dx * DRAG_SCALE / view.getCamera().getDistToScreen();
+            }
+            else
+            {
+                axis = viewToWorld.timesDirection(Vec3.vx());
+                angle = -dy * DRAG_SCALE / view.getCamera().getDistToScreen();
+            }
+        }
+        else
+        {
+            axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+            angle = axis.length() / view.getCamera().getDistToScreen();
+            axis.normalize(); //  = axis.times(1.0/angle);
+            axis = viewToWorld.timesDirection(axis);
+        }
+        if (angle != 0)
+        {
+            c.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
+            c.transformCoordinates(Mat4.axisRotation(axis, angle));
+            c.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
+            view.getCamera().setCameraCoordinates(c);
+            Vec3 cc = c.getOrigin();
+            view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
+        }
+    }
 
-		Point dragPoint = e.getPoint();
-		CoordinateSystem c = oldCoords.duplicate();
-		int dx, dy;
-		Vec3 axis;
+    private void dragRotateSpace(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        // This is modified from AoI 2.7
 
-		dx = dragPoint.x-clickPoint.x;
-		dy = dragPoint.y-clickPoint.y;
+        Point dragPoint = e.getPoint();
+        CoordinateSystem c = oldCoords.duplicate();
+        int dx, dy;
+        Vec3 axis;
 
-		if (controlDown && !e.isShiftDown())
-		{
-			view.tilting = true;
-			tilt(e, view, clickPoint);
-			return;
-		}
-		else if (controlDown && e.isShiftDown()){
-			panSpace(e, view, clickPoint);
-			return;
-		}
-		else if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
-			{
-				axis = viewToWorld.timesDirection(Vec3.vy());
-				angle = dx * DRAG_SCALE;
-			}
-			else
-			{
-				axis = viewToWorld.timesDirection(Vec3.vx());
-				angle = -dy * DRAG_SCALE;
-			}
-		}
-		else
-		{
-			axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-			angle = axis.length();
-			axis = axis.times(1.0/angle);
-			axis = viewToWorld.timesDirection(axis);
-		}
-		if (angle != 0.0)
-		{
-			c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
-			c.transformCoordinates(Mat4.axisRotation(axis, -angle));
-			c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
-			view.getCamera().setCameraCoordinates(c);			
-		}
-	}
+        dx = dragPoint.x-clickPoint.x;
+        dy = dragPoint.y-clickPoint.y;
 
-	private void dragRotateLandscape(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		//This is modified from AoI 3.0
-		
-		Vec3 vertical = new Vec3(0.0,1.0,0.0); 
-		
-		Point dragPoint = e.getPoint();
-		int dx = dragPoint.x-clickPoint.x;
-		int dy = dragPoint.y-clickPoint.y;
-		Mat4 rotation;
-		
-		// Tilting disabled for the time being
-		//if (controlDown)
-		//	rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vz()), -dx*DRAG_SCALE);
-		//else
-		if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
-				rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE);
-			else{
-				double dragAngleFw = dy*DRAG_SCALE;
-				if (dragAngleFw > fwMax) dragAngleFw = fwMax; // These may hep a bit but not all the way
-				if (dragAngleFw < fwMin) dragAngleFw = fwMin;
-				rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
-			}
-		}
-		else if (controlDown && e.isShiftDown())
-		{
-			panLandscape(e, view, clickPoint, vertical);
-			return;
-		}
-		else
-		{
-			// Prevent tilting forward or back more than 90 degrees
-			double dragAngleFw = dy*DRAG_SCALE;
-			if (dragAngleFw > fwMax) dragAngleFw = fwMax; // These may hep a bit but not all the way
-			if (dragAngleFw < fwMin) dragAngleFw = fwMin;
-			rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
-			rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE).times(rotation);
-		}
-		if (!rotation.equals(Mat4.identity()))
-		{
-			CoordinateSystem c = oldCoords.duplicate();
-			c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
-			c.transformCoordinates(rotation);
-			c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
-			view.getCamera().setCameraCoordinates(c);
-		}
-	}
-	private void dragRotateTravelLandscape(WidgetMouseEvent e, ViewerCanvas view)
-	{
-		//This is modified from AoI 3.0
-		Vec3 vertical = new Vec3(0.0,1.0,0.0); 
-		
-		Point dragPoint = e.getPoint();
-		int dx = dragPoint.x-clickPoint.x;
-		int dy = dragPoint.y-clickPoint.y;
-		Mat4 rotation;
-		double dts = view.getCamera().getDistToScreen();
-		// Tilting disabled for the time being
-		//if (controlDown)
-		//	rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vz()), -dx*DRAG_SCALE);
-		//else
-		if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
-				rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/distToRot);
-			else{
-				double dragAngleFw = -dy*DRAG_SCALE/distToRot;
-				if (dragAngleFw > Math.PI) dragAngleFw = Math.PI; // These may hep a bit but not all the way
-				if (dragAngleFw < -Math.PI) dragAngleFw = -Math.PI;
-				rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
-			}
-		}
-		else if (controlDown && e.isShiftDown())
-		{
-			rotateLandscape(e, view, clickPoint, vertical);
-			return;
-		}
-		else
-		{
-			if (view.getBoundCamera() != null){
-				int yp = view.getBounds().height/2;
-				double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
-				
-				// dts is equivalent to the "distToScreen" parameter on SceneCameras.
-				dts = Math.tan(fa)*yp/100;
-			}
-			rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), -dy*DRAG_SCALE/dts);
-			rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/dts).times(rotation);
-		}
-		if (!rotation.equals(Mat4.identity()))
-		{
-			CoordinateSystem c = oldCoords.duplicate();
-			Vec3 cc = c.getOrigin();
-			c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
-			c.transformCoordinates(rotation);
+        if (controlDown && !e.isShiftDown())
+        {
+            view.tilting = true;
+            tilt(e, view, clickPoint);
+            return;
+        }
+        else if (controlDown && e.isShiftDown()){
+            panSpace(e, view, clickPoint);
+            return;
+        }
+        else if (!controlDown && e.isShiftDown())
+        {
+            if (Math.abs(dx) > Math.abs(dy))
+            {
+                axis = viewToWorld.timesDirection(Vec3.vy());
+                angle = dx * DRAG_SCALE;
+            }
+            else
+            {
+                axis = viewToWorld.timesDirection(Vec3.vx());
+                angle = -dy * DRAG_SCALE;
+            }
+        }
+        else
+        {
+            axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+            angle = axis.length();
+            axis = axis.times(1.0/angle);
+            axis = viewToWorld.timesDirection(axis);
+        }
+        if (angle != 0.0)
+        {
+            c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
+            c.transformCoordinates(Mat4.axisRotation(axis, -angle));
+            c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
+            view.getCamera().setCameraCoordinates(c);            
+        }
+    }
 
-			// Prevent tilting forward or back more than 90 degrees.
-			// almost works
-			if (c.getUpDirection().y < 0.0)
-			{
-				Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
-				upD.normalize();
-				Vec3 zD = new Vec3();
-				if (c.getZDirection().y < 0.0) 
-					zD.y = -1.0;
-				else
-					zD.y = 1.0;
-				c.setOrientation(zD,upD);
-			}
-			else
-				c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
+    private void dragRotateLandscape(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        //This is modified from AoI 3.0
+        
+        Vec3 vertical = new Vec3(0.0,1.0,0.0); 
+        
+        Point dragPoint = e.getPoint();
+        int dx = dragPoint.x-clickPoint.x;
+        int dy = dragPoint.y-clickPoint.y;
+        Mat4 rotation;
+        
+        // Tilting disabled for the time being
+        //if (controlDown)
+        //    rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vz()), -dx*DRAG_SCALE);
+        //else
+        if (!controlDown && e.isShiftDown())
+        {
+            if (Math.abs(dx) > Math.abs(dy))
+                rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE);
+            else{
+                double dragAngleFw = dy*DRAG_SCALE;
+                if (dragAngleFw > fwMax) dragAngleFw = fwMax; // These may hep a bit but not all the way
+                if (dragAngleFw < fwMin) dragAngleFw = fwMin;
+                rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
+            }
+        }
+        else if (controlDown && e.isShiftDown())
+        {
+            panLandscape(e, view, clickPoint, vertical);
+            return;
+        }
+        else
+        {
+            // Prevent tilting forward or back more than 90 degrees
+            double dragAngleFw = dy*DRAG_SCALE;
+            if (dragAngleFw > fwMax) dragAngleFw = fwMax; // These may hep a bit but not all the way
+            if (dragAngleFw < fwMin) dragAngleFw = fwMin;
+            rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
+            rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE).times(rotation);
+        }
+        if (!rotation.equals(Mat4.identity()))
+        {
+            CoordinateSystem c = oldCoords.duplicate();
+            c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
+            c.transformCoordinates(rotation);
+            c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
+            view.getCamera().setCameraCoordinates(c);
+        }
+    }
+    private void dragRotateTravelLandscape(WidgetMouseEvent e, ViewerCanvas view)
+    {
+        //This is modified from AoI 3.0
+        Vec3 vertical = new Vec3(0.0,1.0,0.0); 
+        
+        Point dragPoint = e.getPoint();
+        int dx = dragPoint.x-clickPoint.x;
+        int dy = dragPoint.y-clickPoint.y;
+        Mat4 rotation;
+        double dts = view.getCamera().getDistToScreen();
+        // Tilting disabled for the time being
+        //if (controlDown)
+        //    rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vz()), -dx*DRAG_SCALE);
+        //else
+        if (!controlDown && e.isShiftDown())
+        {
+            if (Math.abs(dx) > Math.abs(dy))
+                rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/distToRot);
+            else{
+                double dragAngleFw = -dy*DRAG_SCALE/distToRot;
+                if (dragAngleFw > Math.PI) dragAngleFw = Math.PI; // These may hep a bit but not all the way
+                if (dragAngleFw < -Math.PI) dragAngleFw = -Math.PI;
+                rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dragAngleFw);
+            }
+        }
+        else if (controlDown && e.isShiftDown())
+        {
+            rotateLandscape(e, view, clickPoint, vertical);
+            return;
+        }
+        else
+        {
+            if (view.getBoundCamera() != null){
+                int yp = view.getBounds().height/2;
+                double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
+                
+                // dts is equivalent to the "distToScreen" parameter on SceneCameras.
+                dts = Math.tan(fa)*yp/100;
+            }
+            rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), -dy*DRAG_SCALE/dts);
+            rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/dts).times(rotation);
+        }
+        if (!rotation.equals(Mat4.identity()))
+        {
+            CoordinateSystem c = oldCoords.duplicate();
+            Vec3 cc = c.getOrigin();
+            c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
+            c.transformCoordinates(rotation);
 
-			view.getCamera().setCameraCoordinates(c);
-			view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
-		}
-	}
+            // Prevent tilting forward or back more than 90 degrees.
+            // almost works
+            if (c.getUpDirection().y < 0.0)
+            {
+                Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
+                upD.normalize();
+                Vec3 zD = new Vec3();
+                if (c.getZDirection().y < 0.0) 
+                    zD.y = -1.0;
+                else
+                    zD.y = 1.0;
+                c.setOrientation(zD,upD);
+            }
+            else
+                c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
+
+            view.getCamera().setCameraCoordinates(c);
+            view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
+        }
+    }
 
   @Override
   public void mouseReleased(WidgetMouseEvent e, ViewerCanvas view)
   {
-	view.mouseDown = false;
-	view.tilting = false;
-	view.rotating = false;
-	view.setNavigationMode(selectedNavigation);
+    view.mouseDown = false;
+    view.tilting = false;
+    view.rotating = false;
+    view.setNavigationMode(selectedNavigation);
 
     Point dragPoint = e.getPoint();
     if (theWindow != null)
     {
-		ObjectInfo bound = view.getBoundCamera();
+        ObjectInfo bound = view.getBoundCamera();
         if (bound != null)
         {
             // This view corresponds to an actual camera in the scene.  Create an undo record, and move any children of
             // the camera.
-			bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates()); // for precise action.
+            bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
             UndoRecord undo = new UndoRecord(theWindow, false, UndoRecord.COPY_COORDS, new Object [] {bound.getCoords(), oldCoords});
             moveChildren(bound, bound.getCoords().fromLocal().times(oldCoords.toLocal()), undo);
             theWindow.setUndoRecord(undo);
         }
         theWindow.updateImage();
     }
-	
-	// If the mouse was not dragged then center to the given point
-	// This shouls be directly in the ViewerCanvas but it had a side-effect.
-	if (dragPoint.x == clickPoint.x && dragPoint.y == clickPoint.y)
-	    view.centerToPoint(dragPoint);
-	wipeAuxGraphs();
-	view.viewChanged(false);
+    
+    // If the mouse was not dragged then center to the given point
+    // This shouls be directly in the ViewerCanvas but it had a side-effect.
+    if (dragPoint.x == clickPoint.x && dragPoint.y == clickPoint.y)
+        view.centerToPoint(dragPoint);
+    wipeAuxGraphs();
+    view.viewChanged(false);
   }
 
   /** This is called recursively to move any children of a bound camera. */
@@ -414,199 +416,191 @@ public class RotateViewTool extends EditingTool
   
   private void tilt(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint)
   {
-	int d = Math.min(view.getBounds().width, view.getBounds().height);
-	r = d*0.45;
-	int cx = view.getBounds().width/2;
-	int cy = view.getBounds().height/2;
-	viewCenter = new Point(cx, cy);
-	
-	double aClick = Math.atan2(clickPoint.y-cy, clickPoint.x-cx);
-	p0 = new Point((int)(r*Math.cos(aClick)+cx), (int)(r*Math.sin(aClick))+cy);
-	
-	Point dragPoint = e.getPoint();
-	double aDrag = Math.atan2(dragPoint.y-cy, dragPoint.x-cx);
-	p1 = new Point((int)(r*Math.cos(aDrag))+cx, (int)(r*Math.sin(aDrag))+cy);
-	
-	Vec3 axis = viewToWorld.timesDirection(Vec3.vz());
-	
-	angle = aDrag-aClick;
-	CoordinateSystem c = oldCoords.duplicate();
-	c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
-	c.transformCoordinates(Mat4.axisRotation(axis, -angle));
-	c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
-	view.getCamera().setCameraCoordinates(c);
+    int d = Math.min(view.getBounds().width, view.getBounds().height);
+    r = d*0.45;
+    int cx = view.getBounds().width/2;
+    int cy = view.getBounds().height/2;
+    viewCenter = new Point(cx, cy);
+    
+    double aClick = Math.atan2(clickPoint.y-cy, clickPoint.x-cx);
+    p0 = new Point((int)(r*Math.cos(aClick)+cx), (int)(r*Math.sin(aClick))+cy);
+    
+    Point dragPoint = e.getPoint();
+    double aDrag = Math.atan2(dragPoint.y-cy, dragPoint.x-cx);
+    p1 = new Point((int)(r*Math.cos(aDrag))+cx, (int)(r*Math.sin(aDrag))+cy);
+    
+    Vec3 axis = viewToWorld.timesDirection(Vec3.vz());
+    
+    angle = aDrag-aClick;
+    CoordinateSystem c = oldCoords.duplicate();
+    c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
+    c.transformCoordinates(Mat4.axisRotation(axis, -angle));
+    c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
+    view.getCamera().setCameraCoordinates(c);
   }
 
   private void panSpace(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint)
   {
-	Point dragPoint = e.getPoint();
-	int dx = dragPoint.x-clickPoint.x;
-	int dy = dragPoint.y-clickPoint.y;
-	Vec3 axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-	double angle = axis.length()/view.getCamera().getDistToScreen();
-	axis.normalize();
-	axis = viewToWorld.timesDirection(axis);
+    Point dragPoint = e.getPoint();
+    int dx = dragPoint.x-clickPoint.x;
+    int dy = dragPoint.y-clickPoint.y;
+    Vec3 axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+    double angle = axis.length()/view.getCamera().getDistToScreen();
+    axis.normalize();
+    axis = viewToWorld.timesDirection(axis);
 
-	CoordinateSystem c = oldCoords.duplicate();
-	Vec3 cc = c.getOrigin();
-	c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
-	c.transformCoordinates(Mat4.axisRotation(axis, angle));
-	c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
-	
-	view.getCamera().setCameraCoordinates(c);
-	view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
+    CoordinateSystem c = oldCoords.duplicate();
+    Vec3 cc = c.getOrigin();
+    c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
+    c.transformCoordinates(Mat4.axisRotation(axis, angle));
+    c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
+    
+    view.getCamera().setCameraCoordinates(c);
+    view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
   }
   
   private void panLandscape(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint, Vec3 vertical)
   {
-	Point dragPoint = e.getPoint();
-	int dx = dragPoint.x-clickPoint.x;
-	int dy = dragPoint.y-clickPoint.y;
-	double dts = camera.getDistToScreen();
-	
-	if (view.getBoundCamera() != null){
-		int yp = view.getBounds().height/2;
-		double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
-		dts = Math.tan(fa)*yp/100;
-	}
-	
-	Mat4 rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), -dy*DRAG_SCALE/dts);
-	rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/dts).times(rotation);
-	
-	if (!rotation.equals(Mat4.identity()))
-	{
-		CoordinateSystem c = oldCoords.duplicate();
-		Vec3 cc = c.getOrigin();
-		c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
-		c.transformCoordinates(rotation);
-	
-		// Prevent tilting forward or back more than 90 degrees.
-		// almost works
-		if (c.getUpDirection().y < 0.0)
-		{
-			Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
-			upD.normalize();
-			Vec3 zD = new Vec3();
-			if (c.getZDirection().y < 0.0) 
-				zD.y = -1.0;
-			else
-				zD.y = 1.0;
-			Vec3 cp = cc.plus(zD.times(-distToRot));
-			c.setOrientation(zD,upD);
-			c.setOrigin(cp);
-		}
-		else
-			c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
+    Point dragPoint = e.getPoint();
+    int dx = dragPoint.x-clickPoint.x;
+    int dy = dragPoint.y-clickPoint.y;
+    double dts = camera.getDistToScreen();
+    
+    if (view.getBoundCamera() != null){
+        int yp = view.getBounds().height/2;
+        double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
+        dts = Math.tan(fa)*yp/100;
+    }
+    
+    Mat4 rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), -dy*DRAG_SCALE/dts);
+    rotation = Mat4.axisRotation(vertical, dx*DRAG_SCALE/dts).times(rotation);
+    
+    if (!rotation.equals(Mat4.identity()))
+    {
+        CoordinateSystem c = oldCoords.duplicate();
+        Vec3 cc = c.getOrigin();
+        c.transformCoordinates(Mat4.translation(-cc.x, -cc.y, -cc.z));
+        c.transformCoordinates(rotation);
+    
+        // Prevent tilting forward or back more than 90 degrees.
+        // almost works
+        if (c.getUpDirection().y < 0.0)
+        {
+            Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
+            upD.normalize();
+            Vec3 zD = new Vec3();
+            if (c.getZDirection().y < 0.0) 
+                zD.y = -1.0;
+            else
+                zD.y = 1.0;
+            Vec3 cp = cc.plus(zD.times(-distToRot));
+            c.setOrientation(zD,upD);
+            c.setOrigin(cp);
+        }
+        else
+            c.transformCoordinates(Mat4.translation(cc.x, cc.y, cc.z));
 
-		camera.setCameraCoordinates(c);
-		view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
-	}
+        camera.setCameraCoordinates(c);
+        view.setRotationCenter(cc.plus(c.getZDirection().times(view.getDistToPlane())));
+    }
   }
  
   private void rotateSpace(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint)
   {
-	Point dragPoint = e.getPoint();
-	int dx = dragPoint.x-clickPoint.x;
-	int dy = dragPoint.y-clickPoint.y;
-	
-	Vec3 axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-	double angle = -axis.length();
-	axis.normalize();
-	axis = viewToWorld.timesDirection(axis);
+    Point dragPoint = e.getPoint();
+    int dx = dragPoint.x-clickPoint.x;
+    int dy = dragPoint.y-clickPoint.y;
+    
+    Vec3 axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+    double angle = -axis.length();
+    axis.normalize();
+    axis = viewToWorld.timesDirection(axis);
 
-	CoordinateSystem c = oldCoords.duplicate();
-	c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
-	c.transformCoordinates(Mat4.axisRotation(axis, angle));
-	c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
-	
-	view.getCamera().setCameraCoordinates(c);
+    CoordinateSystem c = oldCoords.duplicate();
+    c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
+    c.transformCoordinates(Mat4.axisRotation(axis, angle));
+    c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
+    
+    view.getCamera().setCameraCoordinates(c);
   }
   
   private void rotateLandscape(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint, Vec3 vertical)
   {
-	Point dragPoint = e.getPoint();
-	int dx = dragPoint.x-clickPoint.x;
-	int dy = dragPoint.y-clickPoint.y;
+    Point dragPoint = e.getPoint();
+    int dx = dragPoint.x-clickPoint.x;
+    int dy = dragPoint.y-clickPoint.y;
 
-	//double dragAngleFw = dy*DRAG_SCALE;
-	//if (dragAngleFw > Math.PI) dragAngleFw = Math.PI;
-	//if (dragAngleFw < -Math.PI) dragAngleFw = -Math.PI;
-	Mat4 rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dy*DRAG_SCALE);
-	rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE).times(rotation);
+    //double dragAngleFw = dy*DRAG_SCALE;
+    //if (dragAngleFw > Math.PI) dragAngleFw = Math.PI;
+    //if (dragAngleFw < -Math.PI) dragAngleFw = -Math.PI;
+    Mat4 rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dy*DRAG_SCALE);
+    rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE).times(rotation);
     
-	if (!rotation.equals(Mat4.identity()))
-	{
-		CoordinateSystem c = oldCoords.duplicate();
-		c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
-		c.transformCoordinates(rotation);
+    if (!rotation.equals(Mat4.identity()))
+    {
+        CoordinateSystem c = oldCoords.duplicate();
+        c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));
+        c.transformCoordinates(rotation);
     
-		// Prevent tilting forward or back more than 90 degrees.
-		// almost works
-		if (c.getUpDirection().y < 0.0)
-		{
-			Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
-			upD.normalize();
-			Vec3 zD = new Vec3();
-			if (c.getZDirection().y < 0.0) 
-				zD.y = -1.0;
-			else
-				zD.y = 1.0;
-			Vec3 cp = rotationCenter.plus(zD.times(-distToRot));
-			c.setOrientation(zD,upD);
-			c.setOrigin(cp);
-		}
-		else
-			c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
+        // Prevent tilting forward or back more than 90 degrees.
+        // almost works
+        if (c.getUpDirection().y < 0.0)
+        {
+            Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 
+            upD.normalize();
+            Vec3 zD = new Vec3();
+            if (c.getZDirection().y < 0.0) 
+                zD.y = -1.0;
+            else
+                zD.y = 1.0;
+            Vec3 cp = rotationCenter.plus(zD.times(-distToRot));
+            c.setOrientation(zD,upD);
+            c.setOrigin(cp);
+        }
+        else
+            c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
     
-		view.getCamera().setCameraCoordinates(c);
-	}
-  }
-
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (theWindow == null || theWindow instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : theWindow.getAllViews())
-	  	v.repaint();
+        view.getCamera().setCameraCoordinates(c);
+    }
   }
 
   private void setAuxGraphs(ViewerCanvas view)
   {
 
-	if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
+    if (theWindow != null)
+      for (ViewerCanvas v : theWindow.getAllViews())
         if (v != view)
-	      v.auxGraphs.set(view, true);
+          v.auxGraphs.set(view, true);
   }
   
   private void wipeAuxGraphs()
   {
     if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-		v.auxGraphs.wipe();
+      for (ViewerCanvas v : theWindow.getAllViews())
+        v.auxGraphs.wipe();
   }
 
   @Override
   public void drawOverlay(ViewerCanvas view)
   {
     if (theWindow != null && view.tilting)
-	{
-	  view.repaint();
-	  for (int i=0; i<4; i++)
-		view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.teal);
-	  
-	  view.drawLine(viewCenter, -Math.PI/2.0, r*0.1, r, view.red);
-	  view.drawLine(viewCenter, Math.PI/2.0, r*0.1, r, view.red);
-	  view.drawLine(viewCenter, Math.PI, r*0.1, r, view.blue);
-	  view.drawLine(viewCenter, 0.0, r*0.1, r, view.blue);
-	  
-	  // draw dial lines
-	  for (int i=0; i<24; i++)
-		view.drawLine(viewCenter, Math.PI/12.0*i+angle, r/.45*.4, r, view.ghost);
-		
-	  view.drawCircle(viewCenter, r, 48, view.ghost);
-      view.drawCircle(viewCenter, r/.45*.4, 48, view.teal);
-	}
+    {
+      view.repaint();
+      for (int i=0; i<4; i++)
+        view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.teal);
+      
+      view.drawLine(viewCenter, -Math.PI/2.0, r*0.1, r, view.red);
+      view.drawLine(viewCenter, Math.PI/2.0, r*0.1, r, view.red);
+      view.drawLine(viewCenter, Math.PI, r*0.1, r, view.blue);
+      view.drawLine(viewCenter, 0.0, r*0.1, r, view.blue);
+      
+      // draw dial lines
+      for (int i=0; i<24; i++)
+        view.drawLine(viewCenter, Math.PI/12.0*i+angle, r/.45*.4, r, view.ghost);
+        
+      //view.drawCircle(viewCenter, r, 48, view.ghost);
+      //view.drawCircle(viewCenter, r/.45*.4, 48, view.teal);
+      view.drawCircle(viewCenter, r/.45*.4, 48, view.ghost);
+    }
   }
 }

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -319,11 +319,11 @@ public class SceneViewer extends ViewerCanvas
     // Finish up.
 
     drawOverlay();
-    currentTool.drawOverlay(this);
     if (activeTool != null)
         activeTool.drawOverlay(this);
     if (showAxes)
       drawCoordinateAxes();
+	currentTool.drawOverlay(this);
     drawBorder();
 }
 
@@ -718,6 +718,11 @@ public class SceneViewer extends ViewerCanvas
   @Override
   protected void mouseMoved(MouseMovedEvent e)
   {
+    if (dragging) 
+    {
+      mouseMoving = false;
+      return;
+    }
     mouseMoving = true;
     mousePoint = e.getPoint();
     mouseMoveTimer.restart();

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -20,274 +20,279 @@ import java.awt.*;
 import java.awt.event.*;
 import javax.swing.Timer;
 
+
+/** ScrollViewTool is a tool to handle mouse scroll wheel events in scene and object views. 
+    It moves the viewpoint in view z-directi and/or in some cases changes view orientation. */
+
 public class ScrollViewTool
 {
-	private EditingWindow window;
-	private MouseScrolledEvent event;
-	private ViewerCanvas view;
-	private Camera camera;
-	private double distToPlane;
-	private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY; // for graphics
-	private int navigationMode;
-	private Rectangle bounds;
-	private Point mousePoint;
-	private CoordinateSystem startCoords;
-	private ObjectInfo boundCamera;
+    private EditingWindow window;
+    private ViewerCanvas view;
+    private Camera camera;
+    private double distToPlane;
+    private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY; // for graphics
+    private int navigationMode, scrollSteps;
+    private Rectangle bounds;
+    private Point mousePoint;
+    private CoordinateSystem startCoords;
+    private ObjectInfo boundCamera;
 
-	public ScrollViewTool(EditingWindow ew)
-	{
-		window = ew;
-		scrollTimer.setCoalesce(false);
-	}
+    public ScrollViewTool(EditingWindow ew)
+    {
+        window = ew;
+        scrollTimer.setCoalesce(false);
+    }
 
-	protected void mouseScrolled(MouseScrolledEvent e, ViewerCanvas v)
-	{
-		event = e;
-		view = v;
-		view.scrolling = true;
-		distToPlane = view.getDistToPlane();
-		navigationMode = view.getNavigationMode();
-		bounds = view.getBounds();
-		camera = view.getCamera();
-		boundCamera = view.getBoundCamera();
-		if (boundCamera != null)
-			startCoords = boundCamera.getCoords().duplicate();
-		
-		// Make sure that the rotation Center is on Camera Z-axis.
-		// After a SceneCamera is read from a file, that may not be the case.
-		// A SceneCamera should have a 'distToPlane' that should be saved with the camera.
-		// Makin it saveable will cause version incompatibility.
-		CoordinateSystem coords = camera.getCameraCoordinates();
-		view.setRotationCenter(coords.getOrigin().plus(coords.getZDirection().times(view.getDistToPlane())));
-	
-		mousePoint = view.mousePoint = e.getPoint();
-		scrollTimer.restart(); // The timer takes case of teh graphics and updating the children of a camera object
+    protected void mouseScrolled(MouseScrolledEvent e, ViewerCanvas v)
+    {
+        scrollSteps = v.scrollBuffer;
+        v.scrollBuffer = 0;
+        v.mouseMoving = false;
+        view = v;
+        view.scrolling = true;
+        distToPlane = view.getDistToPlane();
+        navigationMode = view.getNavigationMode();
+        bounds = view.getBounds();
+        camera = view.getCamera();
+        boundCamera = view.getBoundCamera();
+        if (!scrollTimer.isRunning())// && boundCamera != null)
+            startCoords = camera.getCameraCoordinates().duplicate();
+        
+        // Make sure that the rotation Center is on Camera Z-axis.
+        // After a bound camera is read from a file, that may not be the case.
+        // Any bound should have a 'distToPlane' that should be saved with the object.
 
-		switch (navigationMode) 
-		{
-			case ViewerCanvas.NAVIGATE_MODEL_SPACE:
-			case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
-				scrollMoveModel(e);
-				break;
-			case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
-			case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
-				scrollMoveTravel(e);
-				break;
-			default:
-				break;
-		}
-		
-		if (boundCamera != null && window != null) // wonder why the window is here...
-		{
-			boundCamera.setCoords(camera.getCameraCoordinates().duplicate());
-			((SceneCamera)boundCamera.getObject()).setDistToPlane(distToPlane);
-			moveCameraChildren(boundCamera, boundCamera.getCoords().fromLocal().times(startCoords.toLocal()));
+        CoordinateSystem coords = camera.getCameraCoordinates();
+        view.setRotationCenter(coords.getOrigin().plus(coords.getZDirection().times(view.getDistToPlane())));
+    
+        mousePoint = view.mousePoint = e.getPoint();
+        scrollTimer.restart();
 
-		}
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		view.viewChanged(false);
-	}
+        switch (navigationMode) 
+        {
+            case ViewerCanvas.NAVIGATE_MODEL_SPACE:
+            case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
+                scrollMoveModel();
+                break;
+            case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
+            case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
+                scrollMoveTravel(e);
+                break;
+            default:
+                break;
+        }
+        
+        setAuxGraphs(view);
+        view.repaint();
+        if (window instanceof LayoutWindow) ((LayoutWindow)window).updateOverlays(view);
+        if (window instanceof ObjectEditorWindow) ((ObjectEditorWindow)window).updateOverlays(view);
+        view.viewChanged(false);
+    }
 
-	private void scrollMoveModel(MouseScrolledEvent e)
-	{
-		int amount = e.getWheelRotation();
-		if (!e.isAltDown())
-			amount *= 10;
-		if (ArtOfIllusion.getPreferences().getReverseZooming())
-			amount *= -1;
-		if (view.isPerspective())
-		{
-			CoordinateSystem coords = camera.getCameraCoordinates();
-			double oldDist = distToPlane;
-			//double newDist = oldDist*Math.pow(1.0/1.01, amount); // This woud reverse the action
-			double newDist = oldDist*Math.pow(1.01, amount);
-			Vec3 oldPos = new Vec3(coords.getOrigin());
-			Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
-			coords.setOrigin(newPos);
-			camera.setCameraCoordinates(coords);
-			view.setDistToPlane(newDist);
-			distToPlane = newDist; // local field
-		}
-		else
-		{
-			view.setScale(view.getScale()*Math.pow(1.0/1.01, amount));
-		}
-	}
+    private void scrollMoveModel()
+    {
+        if (ArtOfIllusion.getPreferences().getReverseZooming())
+            scrollSteps *= -1;
+        if (view.isPerspective())
+        {
+            CoordinateSystem coords = camera.getCameraCoordinates();
+            double oldDist = distToPlane;
+            double newDist = oldDist*Math.pow(1.01, scrollSteps);
+            Vec3 oldPos = new Vec3(coords.getOrigin());
+            Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
+            coords.setOrigin(newPos);
+            camera.setCameraCoordinates(coords);
+            view.setDistToPlane(newDist);
+            distToPlane = newDist; // local field
+        }
+        else
+        {
+            view.setScale(view.getScale()*Math.pow(1.0/1.01, scrollSteps));
+        }
+    }
 
-	private void scrollMoveTravel(MouseScrolledEvent e)
-	{	
-		int amount = e.getWheelRotation();
-		if (!e.isAltDown())
-			amount *= 10;
-		if (ArtOfIllusion.getPreferences().getReverseZooming())
-			amount *= -1;
-		
-		Point scrollPoint = e.getPoint();
-		int cx = bounds.width/2;
-		int cy = bounds.height/2;
-		int d = Math.min(bounds.width, bounds.height);
-		
-		Vec3 axis, oldPos, newPos;
-		double angle, deltaZ, deltaY;
-		CoordinateSystem coords = camera.getCameraCoordinates().duplicate();
-		
-		if (navigationMode == ViewerCanvas.NAVIGATE_TRAVEL_SPACE)
-		{
-			int rx = scrollPoint.x - cx;
-			int ry = scrollPoint.y - cy;
-			scrollRadius = Math.sqrt(rx*rx + ry*ry);
-			if (scrollRadius < 0.1*d) scrollRadius = 0.1*d;
-			if (scrollRadius > 0.4*d) scrollRadius = 0.4*d;
-			scrollBlend = (scrollRadius-0.1*d)/(0.3*d);
-			
-			axis = new Vec3(-ry, rx, 0.0);
-			axis.normalize();
-			axis = camera.getViewToWorld().timesDirection(axis);
-			angle = scrollRadius*scrollBlend*amount*0.00002;
-			
-			deltaZ = -distToPlane*0.01*amount*(1.0-scrollBlend);
-			deltaY = 0.0;
-		
-			// Calculate the turn
-			Vec3 location = coords.getOrigin();
-			coords.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
-			coords.transformCoordinates(Mat4.axisRotation(axis, angle));
-			coords.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
-		
-			// Calculate the move
-			oldPos = new Vec3(coords.getOrigin());
-			newPos = oldPos.plus(coords.getZDirection().times(deltaZ));
-			coords.setOrigin(newPos);
-			
-			if (scrollBlend < 0.5)
-				view.blendColorR = blendColor(view.green, view.yellow, scrollBlend*2.0);
-			else
-				view.blendColorR = blendColor(view.yellow, view.red, scrollBlend*2.0-1.0);
-		}
-		
-		else if (navigationMode == ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE)
-		{
-			double scrollX = scrollPoint.x - cx;
-			if (Math.abs(scrollX) < 0.1*d) scrollX = 0.1*d*Math.signum(scrollX);
-			if (Math.abs(scrollX) > 0.4*d) scrollX = 0.4*d*Math.signum(scrollX);
-			double scrollBlendX = (Math.abs(scrollX)-0.1*d)/(0.3*d);
-			
-			double scrollY = scrollPoint.y - cy;
-			if (Math.abs(scrollY) < 0.1*d) scrollY = 0.1*(double)d*Math.signum(scrollY);
-			if (Math.abs(scrollY) > 0.4*d) scrollY = 0.4*(double)d*Math.signum(scrollY);
-			double scrollBlendY = (Math.abs(scrollY)-0.1*d)/(0.3*d);
-		
-			axis = new Vec3(0,1,0);
-			angle = scrollX*scrollBlendX*amount*0.00002;
-			
-			deltaZ = -distToPlane*0.01*amount*(1.0-Math.max(scrollBlendX, scrollBlendY));
-			deltaY = distToPlane*0.002*amount*(scrollBlendY)*Math.signum(scrollY);
-		
-			// Calculate the turn
-			Vec3 location = coords.getOrigin();
-			coords.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
-			coords.transformCoordinates(Mat4.axisRotation(axis, angle));
-			coords.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
-		
-			// Calculate the move
-			Vec3 hDir, vDir;
-			vDir = new Vec3 (0,1,0);
-			if (coords.getZDirection().z < 0.0)
-				hDir = new Vec3 (coords.getZDirection().plus(coords.getUpDirection()));
-			else
-				hDir = new Vec3 (coords.getZDirection().minus(coords.getUpDirection()));
-			hDir.y = 0.0;
-			hDir.normalize();
-		
-			oldPos = new Vec3(coords.getOrigin());
-			newPos = oldPos.plus(hDir.times(deltaZ));
-			newPos = newPos.plus(vDir.times(deltaY));
-			coords.setOrigin(newPos);
-			
-			if (scrollBlendX < 0.5)
-				view.blendColorX = blendColor(view.green, view.yellow, scrollBlendX*2.0);
-			else
-				view.blendColorX = blendColor(view.yellow, view.red, scrollBlendX*2.0-1.0);
-			
-			if (scrollBlendY < 0.5)
-				view.blendColorY = blendColor(view.green, view.yellow, scrollBlendY*2.0);
-			else
-				view.blendColorY = blendColor(view.yellow, view.red, scrollBlendY*2.0-1.0);
-		}
-		else 
-			return;
-		
-		camera.setCameraCoordinates(coords);
-		view.setRotationCenter(newPos.plus(coords.getZDirection().times(distToPlane)));
-	}
+    private void scrollMoveTravel(MouseScrolledEvent e)
+    {
+        if (ArtOfIllusion.getPreferences().getReverseZooming())
+            scrollSteps *= -1;
+        
+        Point scrollPoint = e.getPoint();
+        int cx = bounds.width/2;
+        int cy = bounds.height/2;
+        int d = Math.min(bounds.width, bounds.height);
+        
+        Vec3 axis, oldPos, newPos;
+        double angle, deltaZ, deltaY;
+        CoordinateSystem coords = camera.getCameraCoordinates().duplicate();
+        
+        if (navigationMode == ViewerCanvas.NAVIGATE_TRAVEL_SPACE)
+        {
+            int rx = scrollPoint.x - cx;
+            int ry = scrollPoint.y - cy;
+            scrollRadius = Math.sqrt(rx*rx + ry*ry);
+            if (scrollRadius < 0.1*d) scrollRadius = 0.1*d;
+            if (scrollRadius > 0.4*d) scrollRadius = 0.4*d;
+            scrollBlend = (scrollRadius-0.1*d)/(0.3*d);
+            
+            axis = new Vec3(-ry, rx, 0.0);
+            axis.normalize();
+            axis = camera.getViewToWorld().timesDirection(axis);
+            angle = scrollRadius*scrollBlend*scrollSteps*0.00002;
+            
+            deltaZ = -distToPlane*0.01*scrollSteps*(1.0-scrollBlend);
+            deltaY = 0.0;
+        
+            // Calculate the turn
+            Vec3 location = coords.getOrigin();
+            coords.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
+            coords.transformCoordinates(Mat4.axisRotation(axis, angle));
+            coords.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
+        
+            // Calculate the move
+            oldPos = new Vec3(coords.getOrigin());
+            newPos = oldPos.plus(coords.getZDirection().times(deltaZ));
+            coords.setOrigin(newPos);
+            
+            if (scrollBlend < 0.5)
+                view.blendColorR = blendColor(view.green, view.yellow, scrollBlend*2.0);
+            else
+                view.blendColorR = blendColor(view.yellow, view.red, scrollBlend*2.0-1.0);
+        }
+        
+        else if (navigationMode == ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE)
+        {
+            double scrollX = scrollPoint.x - cx;
+            if (Math.abs(scrollX) < 0.1*d) scrollX = 0.1*d*Math.signum(scrollX);
+            if (Math.abs(scrollX) > 0.4*d) scrollX = 0.4*d*Math.signum(scrollX);
+            double scrollBlendX = (Math.abs(scrollX)-0.1*d)/(0.3*d);
+            
+            double scrollY = scrollPoint.y - cy;
+            if (Math.abs(scrollY) < 0.1*d) scrollY = 0.1*(double)d*Math.signum(scrollY);
+            if (Math.abs(scrollY) > 0.4*d) scrollY = 0.4*(double)d*Math.signum(scrollY);
+            double scrollBlendY = (Math.abs(scrollY)-0.1*d)/(0.3*d);
+        
+            axis = new Vec3(0,1,0);
+            angle = scrollX*scrollBlendX*scrollSteps*0.00002;
+            
+            deltaZ = -distToPlane*0.01*scrollSteps*(1.0-Math.max(scrollBlendX, scrollBlendY));
+            deltaY = distToPlane*0.002*scrollSteps*(scrollBlendY)*Math.signum(scrollY);
+        
+            // Calculate the turn
+            Vec3 location = coords.getOrigin();
+            coords.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
+            coords.transformCoordinates(Mat4.axisRotation(axis, angle));
+            coords.transformCoordinates(Mat4.translation(location.x, location.y, location.z));
+        
+            // Calculate the move
+            Vec3 hDir, vDir;
+            vDir = new Vec3 (0,1,0);
+            if (coords.getZDirection().z < 0.0)
+                hDir = new Vec3 (coords.getZDirection().plus(coords.getUpDirection()));
+            else
+                hDir = new Vec3 (coords.getZDirection().minus(coords.getUpDirection()));
+            hDir.y = 0.0;
+            hDir.normalize();
+        
+            oldPos = new Vec3(coords.getOrigin());
+            newPos = oldPos.plus(hDir.times(deltaZ));
+            newPos = newPos.plus(vDir.times(deltaY));
+            coords.setOrigin(newPos);
+            
+            if (scrollBlendX < 0.5)
+                view.blendColorX = blendColor(view.green, view.yellow, scrollBlendX*2.0);
+            else
+                view.blendColorX = blendColor(view.yellow, view.red, scrollBlendX*2.0-1.0);
+            
+            if (scrollBlendY < 0.5)
+                view.blendColorY = blendColor(view.green, view.yellow, scrollBlendY*2.0);
+            else
+                view.blendColorY = blendColor(view.yellow, view.red, scrollBlendY*2.0-1.0);
+        }
+        else 
+            return;
+        
+        camera.setCameraCoordinates(coords);
+        view.setRotationCenter(newPos.plus(coords.getZDirection().times(distToPlane)));
+    }
 
-	public void mouseStoppedScrolling()
-	{
-		// This should set an undorecord if a camera moved
-		wipeAuxGraphs();
-	}
+    public void mouseStoppedScrolling()
+    {
+        if (window != null && boundCamera != null)
+        {
+            boundCamera.getCoords().copyCoords(camera.getCameraCoordinates());
+            if (boundCamera.getObject() instanceof SceneCamera) ((SceneCamera)boundCamera.getObject()).setDistToPlane(distToPlane);
 
-	private Timer scrollTimer = new Timer(500, new ActionListener() 
-	{
-		public void actionPerformed(ActionEvent e) 
-		{
-			scrollTimer.stop();
-			view.scrolling = false;
-			view.mousePoint = null;
-			mouseStoppedScrolling();
-		}
-	});
+            UndoRecord undo = new UndoRecord(window, false, UndoRecord.COPY_COORDS, new Object [] {boundCamera.getCoords(), startCoords});
+            moveCameraChildren(boundCamera, boundCamera.getCoords().fromLocal().times(startCoords.toLocal()), undo);
+            window.setUndoRecord(undo);
+        }
+        wipeAuxGraphs();
+        window.updateImage();
+    }
 
-	private Color  blendColor(Color color0, Color color1, double blend)
-	{
-		int R = (int)(color0.getRed()*(1.0-blend) + color1.getRed()*blend);
-		int G = (int)(color0.getGreen()*(1.0-blend) + color1.getGreen()*blend);
-		int B = (int)(color0.getBlue()*(1.0-blend) + color1.getBlue()*blend);
-		
-		return new Color(R, G, B);
-	}
+    private Timer scrollTimer = new Timer(350, new ActionListener() 
+    {
+        public void actionPerformed(ActionEvent e) 
+        {
+            scrollTimer.stop();
+            view.scrolling = false;
+            view.mousePoint = null;
+            mouseStoppedScrolling();
+        }
+    });
 
-	/** 
-	    This is called recursively to move any children of a bound camera. 
-		This does not set an undo record.
-	*/
-	private void moveCameraChildren(ObjectInfo parent, Mat4 transform)
-	{	
-		for (int i = 0; i < parent.getChildren().length; i++)
-		{
-			CoordinateSystem coords = parent.getChildren()[i].getCoords();
-			coords.transformCoordinates(transform);
-			moveCameraChildren(parent.getChildren()[i], transform);
-		}  
-	}
+    private Color  blendColor(Color color0, Color color1, double blend)
+    {
+        int R = (int)(color0.getRed()*(1.0-blend) + color1.getRed()*blend);
+        int G = (int)(color0.getGreen()*(1.0-blend) + color1.getGreen()*blend);
+        int B = (int)(color0.getBlue()*(1.0-blend) + color1.getBlue()*blend);
+        
+        return new Color(R, G, B);
+    }
 
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (window == null || window instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : window.getAllViews())
-	  	v.repaint();
-  }
+    /** 
+        This is called recursively to move any children of a bound camera. 
+        This does not set an undo record.
+    */
+    private void moveCameraChildren(ObjectInfo parent, Mat4 transform, UndoRecord undo)
+    {    
+        for (int i = 0; i < parent.getChildren().length; i++)
+        {
+            CoordinateSystem coords = parent.getChildren()[i].getCoords();
+            CoordinateSystem previousCoords = coords.duplicate();
+            coords.transformCoordinates(transform);
+            undo.addCommand(UndoRecord.COPY_COORDS, new Object [] {coords, previousCoords});
+            moveCameraChildren(parent.getChildren()[i], transform, undo);
+        }  
+    }
 
-  private void setAuxGraphs(ViewerCanvas view)
-  {
+    private void repaintAllViews(ViewerCanvas view)
+    {
+        if (window == null || window instanceof UVMappingWindow)
+            view.repaint();
+        else
+            window.updateImage();
+    }
 
-	if (window != null)
-	  for (ViewerCanvas v : window.getAllViews())
-        if (v != view)
-	      v.auxGraphs.set(view, true);
-  }
-  
-  private void wipeAuxGraphs()
-  {
-    if (window != null)
-	  for (ViewerCanvas v : window.getAllViews())
-		v.auxGraphs.wipe();
-  }
+    private void setAuxGraphs(ViewerCanvas view)
+    {
+        if (window != null)
+            for (ViewerCanvas v : window.getAllViews())
+                if (v != view)
+                    v.auxGraphs.set(view, true);
+    }
 
-	/** Maybe some day? */
-	public void drawOverlay()
-	{}
+    private void wipeAuxGraphs()
+    {
+        if (window != null)
+            for (ViewerCanvas v : window.getAllViews())
+                v.auxGraphs.wipe();
+    }
+
+    /** Maybe some day? */
+    public void drawOverlay()
+    {
+        // This could draw a "ghost" of the bound camera and it's children during scroll
+        // In that case the coordinates of the children would need to be updated at every step
+    }
 }

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -266,14 +266,6 @@ public class ScrollViewTool
         }  
     }
 
-    private void repaintAllViews(ViewerCanvas view)
-    {
-        if (window == null || window instanceof UVMappingWindow)
-            view.repaint();
-        else
-            window.updateImage();
-    }
-
     private void setAuxGraphs(ViewerCanvas view)
     {
         if (window != null)
@@ -281,7 +273,7 @@ public class ScrollViewTool
                 if (v != view)
                     v.auxGraphs.set(view, true);
     }
-
+    
     private void wipeAuxGraphs()
     {
         if (window != null)

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -38,9 +38,9 @@ public abstract class ViewerCanvas extends CustomWidget
   protected EditingTool currentTool, activeTool, metaTool, altTool;
   protected ScrollViewTool scrollTool;
   protected PopupMenuManager popupManager;
-  protected int renderMode, gridSubdivisions, orientation, navigation;
+  protected int renderMode, gridSubdivisions, orientation, navigation, scrollBuffer;
   protected double gridSpacing, scale, distToPlane, scrollRadius, scrollX, scrollY, scrollBlend, scrollBlendX, scrollBlendY;
-  protected boolean perspective, perspectiveSwitch, hideBackfaces, showGrid, snapToGrid, drawFocus, showTemplate, showAxes;
+  protected boolean perspective, perspectiveSwitch, hideBackfaces, showGrid, snapToGrid, drawFocus, showTemplate, showAxes, overlaysOnly;
   protected boolean lastModelPerspective;
   protected ActionProcessor mouseProcessor;
   protected Image templateImage, renderedImage;
@@ -49,7 +49,7 @@ public abstract class ViewerCanvas extends CustomWidget
   protected Map<ViewerControl,Widget> controlMap;
   protected Vec3 rotationCenter;
   protected ViewAnimation animation;
-  protected	ClickedPointFinder finder;
+  protected ClickedPointFinder finder;
 
   protected final ViewChangedEvent viewChangedEvent;
 
@@ -125,10 +125,10 @@ public abstract class ViewerCanvas extends CustomWidget
     controlMap = new HashMap<ViewerControl,Widget>();
     theCamera = new Camera();
     theCamera.setCameraCoordinates(coords);
-	finder = new ClickedPointFinder();
+    finder = new ClickedPointFinder();
     setBackground(backgroundColor);
-	setRotationCenter(new Vec3());
-	setDistToPlane(Camera.DEFAULT_DISTANCE_TO_SCREEN);
+    setRotationCenter(new Vec3());
+    setDistToPlane(Camera.DEFAULT_DISTANCE_TO_SCREEN);
     if (useOpenGL)
     {
       try
@@ -150,7 +150,7 @@ public abstract class ViewerCanvas extends CustomWidget
     addEventLink(MouseReleasedEvent.class, this, "processMouseReleased");
     addEventLink(MouseDraggedEvent.class, this, "processMouseDragged");
     addEventLink(MouseMovedEvent.class, this, "processMouseDragged"); // Workaround for Mac OS X bug
-	addEventLink(MouseMovedEvent.class, this, "processMouseMoved");
+    addEventLink(MouseMovedEvent.class, this, "processMouseMoved");
     addEventLink(MouseScrolledEvent.class, this, "processMouseScrolled");
     addEventLink(MouseClickedEvent.class, this, "showPopupIfNeeded");
     //addEventLink(MouseClickedEvent.class, this, "mouseClicked"); // Did not work as expected. See below....
@@ -177,8 +177,18 @@ public abstract class ViewerCanvas extends CustomWidget
     orientation = 0;
     perspective = false;
     scale = 100.0;
-	setNavigationColors();
-	mouseMoveTimer.setCoalesce(false);
+    overlaysOnly = false;
+    setNavigationColors();
+    mouseMoveTimer.setCoalesce(false);
+  }
+
+  /** Repaint the view without regenerating the image of the 3D scene<br>
+      NOTE! 'overLaysOnly' must be set false after checking!' */
+
+  public void updateOverlays()
+  {
+    overlaysOnly = true;
+    repaint();
   }
 
   /** Get the CanvasDrawer which is rendering the image for this canvas. */
@@ -207,6 +217,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   private void processMousePressed(WidgetMouseEvent ev)
   {
+    mouseMoving = false;
     if (mouseProcessor != null)
       mouseProcessor.stopProcessing();
     mousePressed(ev);
@@ -227,7 +238,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   private void processMouseMoved(final MouseMovedEvent ev)
   {
-	if (mouseProcessor != null)
+    if (mouseProcessor != null)
       mouseProcessor.stopProcessing();
     mouseProcessor = new ActionProcessor();
     mouseProcessor.addEvent(new Runnable() {
@@ -241,7 +252,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   private void processMouseReleased(WidgetMouseEvent ev)
   {
-	if (mouseProcessor != null)
+    if (mouseProcessor != null)
     {
       mouseProcessor.stopProcessing();
       mouseProcessor = null;
@@ -250,13 +261,30 @@ public abstract class ViewerCanvas extends CustomWidget
   }
 
   /**
-	Processing scrollwheel events here. Subclasses may override.
+    Processing scrollwheel events here. Subclasses may override.
   */
   protected void processMouseScrolled(MouseScrolledEvent e)
   {
-    // Should there be an ActionProcessor just in case?
-	if (scrollTool != null)
-	  scrollTool.mouseScrolled(e, this);
+    if (scrollTool == null)
+      return;
+
+    if (mouseProcessor != null)
+      mouseProcessor.stopProcessing();
+
+    mouseProcessor = new ActionProcessor();
+    if (e.isAltDown())
+        scrollBuffer += e.getWheelRotation();
+    else
+        scrollBuffer += e.getWheelRotation()*10;
+    final ViewerCanvas viewToProcess = this;
+    final MouseScrolledEvent scrollEvent = e;
+    mouseProcessor.addEvent(new Runnable() {
+      @Override
+      public void run()
+      {
+        scrollTool.mouseScrolled(scrollEvent, viewToProcess);
+      }
+    });
   }
 
   /** Subclasses should override this to handle events. */
@@ -328,7 +356,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   public void setTool(EditingTool tool)
   {
-    currentTool = tool;	
+    currentTool = tool;    
     repaint();
   }
 
@@ -353,10 +381,10 @@ public abstract class ViewerCanvas extends CustomWidget
     altTool = tool;
   }
 
-  /** 	
-	For object editors this tool is set in the abstract ObjectEditorWindow, 
-	whereas the alt- and meta tools are set in each sub(-sub-sub) class of it.
-	This way it gets inherited to plugin tools too (like PME). 
+  /**     
+    For object editors this tool is set in the abstract ObjectEditorWindow, 
+    whereas the alt- and meta tools are set in each sub(-sub-sub) class of it.
+    This way it gets inherited to plugin tools too (like PME). 
   */
 
   public void setScrollTool(ScrollViewTool tool)
@@ -376,71 +404,71 @@ public abstract class ViewerCanvas extends CustomWidget
     return animation;
   }
 
-	/** 
-	  Set whether to display perspective or parallel mode. <p>
-	  
-	  When the mode changes the view scale and camera distance from 
-	  drawing plane are recalculated so that the perceived scale on 
-	  the drawing plane does not change.<p>
-	 
-	  For animated perspective changes the view has to be in perspective during the animation and
-	  the perspective-parameter is turned false at finishAnimation() if needed. The perspectiveSwitch-
-	  parameter tells the users last perspehtive selection during animation. 
-	 */
-	public void setPerspective(boolean nextPerspective)
-	{		
-		// Can't not go parallel in travel modes
-		if (navigation == NAVIGATE_TRAVEL_SPACE || navigation == NAVIGATE_TRAVEL_LANDSCAPE)
-			return;
+    /** 
+      Set whether to display perspective or parallel mode. <p>
+      
+      When the mode changes the view scale and camera distance from 
+      drawing plane are recalculated so that the perceived scale on 
+      the drawing plane does not change.<p>
+     
+      For animated perspective changes the view has to be in perspective during the animation and
+      the perspective-parameter is turned false at finishAnimation() if needed. The perspectiveSwitch-
+      parameter tells the users last perspehtive selection during animation. 
+     */
+    public void setPerspective(boolean nextPerspective)
+    {        
+        // Can't not go parallel in travel modes
+        if (navigation == NAVIGATE_TRAVEL_SPACE || navigation == NAVIGATE_TRAVEL_LANDSCAPE)
+            return;
 
-		// don't recalculate if not necessary
-		if (perspectiveSwitch == nextPerspective){
-			return;
-		}
+        // don't recalculate if not necessary
+        if (perspectiveSwitch == nextPerspective){
+            return;
+        }
 
-		// if the view is not up yet
-		if (getBounds().height == 0 || getBounds().width == 0 || theCamera == null){
-			perspective = perspectiveSwitch = nextPerspective;
-			return;
-		}
+        // if the view is not up yet
+        if (getBounds().height == 0 || getBounds().width == 0 || theCamera == null){
+            perspective = perspectiveSwitch = nextPerspective;
+            return;
+        }
 
-		// I wonder if this is right....
-		if (boundCamera != null){
-			perspective = perspectiveSwitch = nextPerspective;
-			return;
-		}
+        // I wonder if this is right....
+        if (boundCamera != null){
+            perspective = perspectiveSwitch = nextPerspective;
+            return;
+        }
 
-		if (animation.animatingMove() || animation.changingPerspective()) 
-			return;
+        if (animation.animatingMove() || animation.changingPerspective()) 
+            return;
 
-		perspectiveSwitch = nextPerspective;			
-		animation.start(nextPerspective, navigation, theCamera.getCameraCoordinates()); // , refDistToPlane, navigation);
-	}
+        perspectiveSwitch = nextPerspective;            
+        animation.start(nextPerspective, navigation, theCamera.getCameraCoordinates()); // , refDistToPlane, navigation);
+    }
 
-	/** 
-	  This is needed when animated perspective change parallel to perspective begins. 
-	  The scale and perspective parameters can not be accessed directly form the 
-	  animation engine and they take immediade effect on the camera.
-	 */
-	public void preparePerspectiveAnimation()
-	{
-		scale = 100.0;
-		perspective = true;
-	}
+    /** 
+      This is needed when animated perspective change parallel to perspective begins. 
+      The scale and perspective parameters can not be accessed directly form the 
+      animation engine and they take immediade effect on the camera.
+     */
+    public void preparePerspectiveAnimation()
+    {
+        scale = 100.0;
+        perspective = true;
+    }
 
-	/** 
-	  ViewAnimation calls this when the animation is finished, so the orientation menu 
-	  will be up to date and the perspective is set to it's value without launched 
-	  launcing a new animation sequence.
-	*/
-	public void finishAnimation(int which, boolean persp, int navi)
-	{
-		orientation = which;
-		perspective = persp;
-		navigation = navi;
-		viewChanged(false);
-		repaint();
-	}
+    /** 
+      ViewAnimation calls this when the animation is finished, so the orientation menu 
+      will be up to date and the perspective is set to it's value without launched 
+      launcing a new animation sequence.
+    */
+    public void finishAnimation(int which, boolean persp, int navi)
+    {
+        orientation = which;
+        perspective = persp;
+        navigation = navi;
+        viewChanged(false);
+        repaint();
+    }
 
   /** Determine whether the view is currently is perspective mode. */
   public boolean isPerspective()
@@ -468,7 +496,7 @@ public abstract class ViewerCanvas extends CustomWidget
   public void setScale(double scale)
   {
     if (scale > 0.0)
-		this.scale = scale;
+        this.scale = scale;
   }
 
   /** Get whether a focus ring should be drawn around this component. */
@@ -575,34 +603,34 @@ public abstract class ViewerCanvas extends CustomWidget
   {
     CoordinateSystem coords = theCamera.getCameraCoordinates();
     double distToCenter = -coords.getZDirection().dot(coords.getOrigin());
-	setRotationCenter(coords.getOrigin().plus(coords.getZDirection().times(distToCenter)));
+    setRotationCenter(coords.getOrigin().plus(coords.getZDirection().times(distToCenter)));
     return getRotationCenter();
   }
 
   /** 
     Set the distance from drawing plane to view camera. <p>
-	
-	Depending on the view action this may be used to recalculate 
-	the positon of the camera or the rotationCenter or it may be 
-	recalculated from the rotationCenter and camera position.
+    
+    Depending on the view action this may be used to recalculate 
+    the positon of the camera or the rotationCenter or it may be 
+    recalculated from the rotationCenter and camera position.
    */
   public void setDistToPlane(double dist)
   {
-	distToPlane = dist;
+    distToPlane = dist;
 
-	if (boundCamera != null)
-		if (boundCamera.getObject() instanceof SceneCamera)
-			((SceneCamera)boundCamera.getObject()).setDistToPlane(dist);
-		else if (boundCamera.getObject() instanceof SpotLight)
-			((SpotLight)boundCamera.getObject()).setDistToPlane(dist);
-		else if (boundCamera.getObject() instanceof DirectionalLight)
-			((DirectionalLight)boundCamera.getObject()).setDistToPlane(dist);
+    if (boundCamera != null)
+        if (boundCamera.getObject() instanceof SceneCamera)
+            ((SceneCamera)boundCamera.getObject()).setDistToPlane(dist);
+        else if (boundCamera.getObject() instanceof SpotLight)
+            ((SpotLight)boundCamera.getObject()).setDistToPlane(dist);
+        else if (boundCamera.getObject() instanceof DirectionalLight)
+            ((DirectionalLight)boundCamera.getObject()).setDistToPlane(dist);
   }
 
   /** Get the distance from camera to drawing plane */
   public double getDistToPlane()
   {
-	return distToPlane;
+    return distToPlane;
   }
 
   /** Get the currently used navigation mode */
@@ -630,12 +658,12 @@ public abstract class ViewerCanvas extends CustomWidget
   public void setNavigationMode(int nextNavigation)
   {
     if (nextNavigation == navigation)
-	  return;
+      return;
 
-	if (nextNavigation < 2)
- 	  setNavigationMode(nextNavigation, perspectiveSwitch);
-	else
-	  setNavigationMode(nextNavigation, true);
+    if (nextNavigation < 2)
+       setNavigationMode(nextNavigation, perspectiveSwitch);
+    else
+      setNavigationMode(nextNavigation, true);
   }
 
   /** Set navigation mode and perspective */
@@ -644,100 +672,100 @@ public abstract class ViewerCanvas extends CustomWidget
   {
     // If not changing, do nothing
     if (nextNavigation == navigation)
-	return;
+    return;
 
     // If the view is not up yet, just set the parameters
     if (getBounds().height == 0 || getBounds().width == 0 || theCamera == null)
-	{
- 	  navigation = nextNavigation;
+    {
+       navigation = nextNavigation;
       if (navigation > 1)
-	    perspective = true;
+        perspective = true;
       return;
     }
 
     
-	// Change perspective without animation, if needed.
+    // Change perspective without animation, if needed.
     if (nextNavigation < 2) // ...?
-	  perspective = nextPerspective;
+      perspective = nextPerspective;
     else
-	  perspective = true;
-	
-	repaint(); 
+      perspective = true;
+    
+    repaint(); 
 
-	//if (nextNavigation > 1)
-	  nextPerspective = true; // Just to be sure
-	//
+    //if (nextNavigation > 1)
+      nextPerspective = true; // Just to be sure
+    //
     // Turn y up for landscape modes. Animated
     if ((navigation == 0 || navigation == 2) && (nextNavigation == 1 || nextNavigation == 3))
     {
-		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-		Vec3 z  = coords.getZDirection();
-		Vec3 up = coords.getUpDirection();
+        CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
+        Vec3 z  = coords.getZDirection();
+        Vec3 up = coords.getUpDirection();
 
-		// if camera z-axis is aligned with world y-axis the orientation is good for 
-		// landscape modes. The z.y may be 1.0 but z.x and z.x may have error in the 
-		// magnitude of 1E-15.
-		if((z.x < 1E-6 && z.x > -1E-6) && (z.z < 1E-6 && z.z > -1E-6))
-		{
-			z.x = z.z = 0.0; 
-			z.y = 1.0*Math.signum(z.y); 
-			
-			coords.setOrientation(z, up);
-			coords.setOrigin(rotationCenter.minus(z.times(distToPlane)));
-			theCamera.setCameraCoordinates(coords);
-			navigation = nextNavigation;
-			viewChanged(false);
-			repaint();
-		}
-		else
-		{
-			// The system uses only the projection of the y-direction, that is needed.
-			coords.setOrientation(z, new Vec3(0,1,0)); // new coords
-			animation.start(coords, rotationCenter, scale, orientation, nextNavigation);
-			//animation.start(nextPerspective, nextNavigation, coords);
-		}
+        // if camera z-axis is aligned with world y-axis the orientation is good for 
+        // landscape modes. The z.y may be 1.0 but z.x and z.x may have error in the 
+        // magnitude of 1E-15.
+        if((z.x < 1E-6 && z.x > -1E-6) && (z.z < 1E-6 && z.z > -1E-6))
+        {
+            z.x = z.z = 0.0; 
+            z.y = 1.0*Math.signum(z.y); 
+            
+            coords.setOrientation(z, up);
+            coords.setOrigin(rotationCenter.minus(z.times(distToPlane)));
+            theCamera.setCameraCoordinates(coords);
+            navigation = nextNavigation;
+            viewChanged(false);
+            repaint();
+        }
+        else
+        {
+            // The system uses only the projection of the y-direction, that is needed.
+            coords.setOrientation(z, new Vec3(0,1,0)); // new coords
+            animation.start(coords, rotationCenter, scale, orientation, nextNavigation);
+            //animation.start(nextPerspective, nextNavigation, coords);
+        }
     }
-	else
+    else
     {
-		navigation = nextNavigation;
-		viewChanged(false);
-		repaint();
-	}
+        navigation = nextNavigation;
+        viewChanged(false);
+        repaint();
+    }
   }
   
   /* changing perspective without animation */
   private void flipPerspectiveSwitch(boolean nextPerspective)
   {
-	if (perspective == nextPerspective || perspectiveSwitch == nextPerspective)
-		return;
-	
-	if(nextPerspective)
-	{
-		// converting scale to distance
-		distToPlane = 100.0*theCamera.getDistToScreen()/scale;
-		scale = 100.0; // scale needs to be 100 in perspective mode or the magnification is incorrect.
-		
-		// repositioning camera
-		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-		Vec3 cz = new Vec3(coords.getZDirection());
-		Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
-		coords.setOrigin(cp);
-		theCamera.setCameraCoordinates(coords);	
-	}
-	else
-	{
-		// converting distance to scale
-		scale = 100.0*theCamera.getDistToScreen()/distToPlane;
-		distToPlane = 20.0; // to follow the convention
-		
-		// repositioning camera
-		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-		Vec3 cz = new Vec3(coords.getZDirection());
-		Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
-		coords.setOrigin(cp);
-		theCamera.setCameraCoordinates(coords);
-	}
-	perspectiveSwitch = perspective = nextPerspective;
+    if (perspective == nextPerspective || perspectiveSwitch == nextPerspective)
+        return;
+    
+    if(nextPerspective)
+    {
+        // converting scale to distance
+        distToPlane = 100.0*theCamera.getDistToScreen()/scale;
+        scale = 100.0; // scale needs to be 100 in perspective mode or the magnification is incorrect.
+        
+        // repositioning camera
+        CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
+        Vec3 cz = new Vec3(coords.getZDirection());
+        Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
+        coords.setOrigin(cp);
+        theCamera.setCameraCoordinates(coords);    
+    }
+    else
+    {
+        // converting distance to scale
+        scale = 100.0*theCamera.getDistToScreen()/distToPlane;
+        distToPlane = 20.0; // to follow the convention
+        
+        // repositioning camera
+        CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
+        Vec3 cz = new Vec3(coords.getZDirection());
+        Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
+        coords.setOrigin(cp);
+        theCamera.setCameraCoordinates(coords);
+    }
+    perspectiveSwitch = perspective = nextPerspective;
   }
 
   /** Set the PopupMenuManager for this canvas. */
@@ -760,10 +788,10 @@ public abstract class ViewerCanvas extends CustomWidget
 
   /* 
       Decide what to do when a mouse is clicked on the viewercanvas
-	  - Show pop-up menu
-	  - Center to a new point
-	  - Sub classes may override but should call super first
-	  I wonder if this needs an action processor?
+      - Show pop-up menu
+      - Center to a new point
+      - Sub classes may override but should call super first
+      I wonder if this needs an action processor?
   */
   //For some reason after this, when an object was opened for editing by double clicking it on the view, 
   //the first time of pressing Cancel or OK launched an undo sequence. If the object was opened by 
@@ -779,7 +807,7 @@ public abstract class ViewerCanvas extends CustomWidget
     }
     if (ev.isAltDown() && ev.getClickCount() == 1)
     //if (ev.getButton() == WidgetMouseEvent.BUTTON2 && ev.getClickCount() == 1)
-  	centerToPoint(ev.getPoint());
+      centerToPoint(ev.getPoint());
   }
   */
 
@@ -792,7 +820,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
     if (boundCamera != null && boundCamera.getObject() instanceof SceneCamera){
       theCamera.setScreenTransform(((SceneCamera) boundCamera.getObject()).getScreenTransform(bounds.width, bounds.height), bounds.width, bounds.height);
-	}
+    }
     else if (perspective)
       theCamera.setScreenParams(0, scale, bounds.width, bounds.height);
     else
@@ -864,8 +892,8 @@ public abstract class ViewerCanvas extends CustomWidget
 
   /** 
       @deprecated <p>
-	  Use {@link "fitToObjects()} instead.<p>
-	  
+      Use {@link "fitToObjects()} instead.<p>
+      
       Adjust the camera position and magnification so that the specified box
       fills the view.  This has no effect if there is a camera bound to this
       view.
@@ -915,37 +943,37 @@ public abstract class ViewerCanvas extends CustomWidget
   }
 
   /**
-	Fit view to the selected MeshVertices OR the entire mesh.<p>
-	
-	@param selection If set to true, fits to selected vertices else 
-	fit to the entire mesh.
+    Fit view to the selected MeshVertices OR the entire mesh.<p>
+    
+    @param selection If set to true, fits to selected vertices else 
+    fit to the entire mesh.
    */
  
   public void fitToVertices(MeshEditorWindow w, boolean selection)
   {
-	BoundingBox b = boundsOfSelection(w, selection);		
-	if (b == null) 
-		return;
+    BoundingBox b = boundsOfSelection(w, selection);        
+    if (b == null) 
+        return;
 
-	Vec3 newCenter = new Vec3(b.getCenter());
-	CoordinateSystem newCoords = theCamera.getCameraCoordinates().duplicate();
-	int d = Math.min(getBounds().width, getBounds().height);
-	double diag = Math.sqrt((b.maxx-b.minx)*(b.maxx-b.minx)+(b.maxy-b.miny)*(b.maxy-b.miny)+(b.maxz-b.minz)*(b.maxz-b.minz));
+    Vec3 newCenter = new Vec3(b.getCenter());
+    CoordinateSystem newCoords = theCamera.getCameraCoordinates().duplicate();
+    int d = Math.min(getBounds().width, getBounds().height);
+    double diag = Math.sqrt((b.maxx-b.minx)*(b.maxx-b.minx)+(b.maxy-b.miny)*(b.maxy-b.miny)+(b.maxz-b.minz)*(b.maxz-b.minz));
 
-	if (perspective)
-	{
-		double newDistToPlane = 2000 / (double)d / 0.9 * diag;
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane-(b.maxz-b.minz) * 0.5)));
+    if (perspective)
+    {
+        double newDistToPlane = 2000 / (double)d / 0.9 * diag;
+        newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane-(b.maxz-b.minz) * 0.5)));
 
-		animation.start(newCoords, newCenter, scale, orientation, navigation);
-	}
-	else
-	{
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-distToPlane)));
-		double newScale = (double)d * 0.9 / diag; // with minimum 5% margins
+        animation.start(newCoords, newCenter, scale, orientation, navigation);
+    }
+    else
+    {
+        newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-distToPlane)));
+        double newScale = (double)d * 0.9 / diag; // with minimum 5% margins
 
-		animation.start(newCoords, newCenter, newScale, orientation, navigation);
-	}
+        animation.start(newCoords, newCenter, newScale, orientation, navigation);
+    }
   }
 
   /** Sub classes that can handle bones needs to override this */
@@ -953,47 +981,47 @@ public abstract class ViewerCanvas extends CustomWidget
   {
   }
 
-	/** Create a bounding box for  selected vertices */
-	public BoundingBox boundsOfSelection(MeshEditorWindow w, boolean selection)
-	{	
-		Mesh mesh = (Mesh) w.getObject().getObject();
-		MeshVertex vert[] = mesh.getVertices();
-		int selected[] = w.getSelectionDistance();
-		double minx, miny, minz, maxx, maxy, maxz;
-		boolean anything = false;
-		minx = miny = minz = Double.MAX_VALUE;
-		maxx = maxy = maxz = -Double.MAX_VALUE;
-		Mat4 t = ((ObjectViewer)w.getView()).getDisplayCoordinates().fromLocal();
-		
-		for (int i = 0; i < vert.length; i++)
-		{
-			if (selected[i] == 0 || !selection)
-			{
-				anything = true;
-				Vec3 v = t.times(vert[i].r);
-				if (v.x < minx) minx = v.x;
-				if (v.x > maxx) maxx = v.x;
-				if (v.y < miny) miny = v.y;
-				if (v.y > maxy) maxy = v.y;
-				if (v.z < minz) minz = v.z;
-				if (v.z > maxz) maxz = v.z;
-			}
-		}
-		if (anything)
-		{	
-			// This is in case you have selected only on vertex.
-			// The size of it would be zero --> ViewerCavas would go  blank
-			// The zero size should be handled in the calling method
-			
-			if (maxx-minx < 0.001) {maxx += 0.0005; minx -= 0.0005;}
-			if (maxy-miny < 0.001) {maxy += 0.0005; miny -= 0.0005;}
-			if (maxz-minz < 0.001) {maxz += 0.0005; minz -= 0.0005;}
-			
-			return new BoundingBox(minx, maxx, miny, maxy, minz, maxz);
-		}
-		else
-			return null;
-	}
+    /** Create a bounding box for  selected vertices */
+    public BoundingBox boundsOfSelection(MeshEditorWindow w, boolean selection)
+    {    
+        Mesh mesh = (Mesh) w.getObject().getObject();
+        MeshVertex vert[] = mesh.getVertices();
+        int selected[] = w.getSelectionDistance();
+        double minx, miny, minz, maxx, maxy, maxz;
+        boolean anything = false;
+        minx = miny = minz = Double.MAX_VALUE;
+        maxx = maxy = maxz = -Double.MAX_VALUE;
+        Mat4 t = ((ObjectViewer)w.getView()).getDisplayCoordinates().fromLocal();
+        
+        for (int i = 0; i < vert.length; i++)
+        {
+            if (selected[i] == 0 || !selection)
+            {
+                anything = true;
+                Vec3 v = t.times(vert[i].r);
+                if (v.x < minx) minx = v.x;
+                if (v.x > maxx) maxx = v.x;
+                if (v.y < miny) miny = v.y;
+                if (v.y > maxy) maxy = v.y;
+                if (v.z < minz) minz = v.z;
+                if (v.z > maxz) maxz = v.z;
+            }
+        }
+        if (anything)
+        {    
+            // This is in case you have selected only on vertex.
+            // The size of it would be zero --> ViewerCavas would go  blank
+            // The zero size should be handled in the calling method
+            
+            if (maxx-minx < 0.001) {maxx += 0.0005; minx -= 0.0005;}
+            if (maxy-miny < 0.001) {maxy += 0.0005; miny -= 0.0005;}
+            if (maxz-minz < 0.001) {maxz += 0.0005; minz -= 0.0005;}
+            
+            return new BoundingBox(minx, maxx, miny, maxy, minz, maxz);
+        }
+        else
+            return null;
+    }
   
   /**
      Fit view to the given set of objects.<p>
@@ -1001,71 +1029,71 @@ public abstract class ViewerCanvas extends CustomWidget
    */
   public void fitToObjects(Collection<ObjectInfo> objects)
   {
-	if (objects.size() == 0) 
-		return;
-	 
-	CoordinateSystem newCoords;
-	BoundingBox b;
-	double br, z; // box radius, view z coordinate
-	Vec3 bc;   // box center
-	Vec3 cx, cy, cz, newCenter;
-	cz = theCamera.getCameraCoordinates().getZDirection();
-	cy = theCamera.getCameraCoordinates().getUpDirection();
-	cx = cz.cross(cy);
-	Vec2 p;  // x-y-point in view space
-	Mat4 toScene, worldToView, viewToWorld;
-	worldToView = theCamera.getWorldToView();
-	viewToWorld = theCamera.getViewToWorld();
-	int w = getBounds().width;
-	int h = getBounds().height;
-	int d = Math.min(w, h);
+    if (objects.size() == 0) 
+        return;
+     
+    CoordinateSystem newCoords;
+    BoundingBox b;
+    double br, z; // box radius, view z coordinate
+    Vec3 bc;   // box center
+    Vec3 cx, cy, cz, newCenter;
+    cz = theCamera.getCameraCoordinates().getZDirection();
+    cy = theCamera.getCameraCoordinates().getUpDirection();
+    cx = cz.cross(cy);
+    Vec2 p;  // x-y-point in view space
+    Mat4 toScene, worldToView, viewToWorld;
+    worldToView = theCamera.getWorldToView();
+    viewToWorld = theCamera.getViewToWorld();
+    int w = getBounds().width;
+    int h = getBounds().height;
+    int d = Math.min(w, h);
 
-	double minx, miny, minz, maxx, maxy, maxz;
-	minx = miny = minz = Double.POSITIVE_INFINITY;
-	maxx = maxy = maxz = Double.NEGATIVE_INFINITY;
+    double minx, miny, minz, maxx, maxy, maxz;
+    minx = miny = minz = Double.POSITIVE_INFINITY;
+    maxx = maxy = maxz = Double.NEGATIVE_INFINITY;
 
-	for (ObjectInfo info : objects)
-	{
-		b = info.getBounds();
-		bc = b.getCenter();
-		br = Math.sqrt((b.maxx-b.minx)*(b.maxx-b.minx)+(b.maxy-b.miny)*(b.maxy-b.miny)+(b.maxz-b.minz)*(b.maxz-b.minz)) / 2.0;
-		toScene = info.getCoords().fromLocal();
-		toScene.transform(bc);
+    for (ObjectInfo info : objects)
+    {
+        b = info.getBounds();
+        bc = b.getCenter();
+        br = Math.sqrt((b.maxx-b.minx)*(b.maxx-b.minx)+(b.maxy-b.miny)*(b.maxy-b.miny)+(b.maxz-b.minz)*(b.maxz-b.minz)) / 2.0;
+        toScene = info.getCoords().fromLocal();
+        toScene.transform(bc);
 
-		p = worldToView.timesXY(bc.plus(cx.times(-br))); // In view space x is 'backwards'.
-		maxx = Math.max(maxx, p.x);
-		p = worldToView.timesXY(bc.plus(cx.times(br)));
-		minx = Math.min(minx, p.x);
-		
- 		p = worldToView.timesXY(bc.plus(cy.times(br)));
-		maxy = Math.max(maxy, p.y);
-		p = worldToView.timesXY(bc.plus(cy.times(-br)));
-		miny = Math.min(miny, p.y);
-		
-		z = worldToView.timesZ(bc.plus(cz.times(br)));
-		maxz= Math.max(maxz, z);
-		z = worldToView.timesZ(bc.plus(cz.times(-br)));
-		minz = Math.min(minz, z);
-	}
+        p = worldToView.timesXY(bc.plus(cx.times(-br))); // In view space x is 'backwards'.
+        maxx = Math.max(maxx, p.x);
+        p = worldToView.timesXY(bc.plus(cx.times(br)));
+        minx = Math.min(minx, p.x);
+        
+         p = worldToView.timesXY(bc.plus(cy.times(br)));
+        maxy = Math.max(maxy, p.y);
+        p = worldToView.timesXY(bc.plus(cy.times(-br)));
+        miny = Math.min(miny, p.y);
+        
+        z = worldToView.timesZ(bc.plus(cz.times(br)));
+        maxz= Math.max(maxz, z);
+        z = worldToView.timesZ(bc.plus(cz.times(-br)));
+        minz = Math.min(minz, z);
+    }
 
-	newCenter = new Vec3((minx+maxx)*0.5, (miny+maxy)*0.5, (minz+maxz)*0.5);
-	viewToWorld.transform(newCenter);
-	newCoords = theCamera.getCameraCoordinates().duplicate();
-	
-	if (perspective)
-	{
-		double newDistToPlane = 2000 / (double)d / 0.9 * Math.max(maxx-minx, maxy-miny);
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane-(maxz-minz) * 0.5)));
+    newCenter = new Vec3((minx+maxx)*0.5, (miny+maxy)*0.5, (minz+maxz)*0.5);
+    viewToWorld.transform(newCenter);
+    newCoords = theCamera.getCameraCoordinates().duplicate();
+    
+    if (perspective)
+    {
+        double newDistToPlane = 2000 / (double)d / 0.9 * Math.max(maxx-minx, maxy-miny);
+        newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane-(maxz-minz) * 0.5)));
 
-		animation.start(newCoords, newCenter, scale, orientation, navigation);
-	}
-	else
-	{
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-distToPlane)));
-		double newScale = (double)d * 0.9 / Math.max(maxx-minx, maxy-miny); // with minimum 5% margins
+        animation.start(newCoords, newCenter, scale, orientation, navigation);
+    }
+    else
+    {
+        newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-distToPlane)));
+        double newScale = (double)d * 0.9 / Math.max(maxx-minx, maxy-miny); // with minimum 5% margins
 
-		animation.start(newCoords, newCenter, newScale, orientation, navigation);
-	}
+        animation.start(newCoords, newCenter, newScale, orientation, navigation);
+    }
   }
 
   /** 
@@ -1075,11 +1103,11 @@ public abstract class ViewerCanvas extends CustomWidget
   public void alignWithClosestAxis()
   {
     CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-	int newOrientation = ViewerCanvas.VIEW_OTHER;
+    int newOrientation = ViewerCanvas.VIEW_OTHER;
     Vec3 zDir = coords.getZDirection();
     Vec3 upDir = coords.getUpDirection();
-	Vec3 center;
-	
+    Vec3 center;
+    
     Vec3 zNew  =  new Vec3(0,0,zDir.z);
     if (Math.abs(zDir.x) > Math.abs(zDir.z)) zNew  =  new Vec3(zDir.x,0,0);
     if (Math.abs(zDir.y) > Math.abs(zDir.z) && Math.abs(zDir.y) > Math.abs(zDir.x)) zNew  =  new Vec3(0,zDir.y,0);
@@ -1090,58 +1118,58 @@ public abstract class ViewerCanvas extends CustomWidget
     
     zNew.normalize();
     upNew.normalize();
-	
-	// Sometimes the new Up- and Z-directions end up the same or opposite.
-	// Then keep the one that was closer to what was found and find the next closest to the other one.
-	if (zNew.equals(upNew) || zNew.equals(upNew.times(-1)))
-	{
-		if (Math.max(Math.max(Math.abs(zDir.x),Math.abs(zDir.y)),Math.abs(zDir.z)) < Math.max(Math.max(Math.abs(upDir.x),Math.abs(upDir.y)),Math.abs(upDir.z)))
-			zNew = findNextAxis(zDir, upNew);
-		else
-			upNew = findNextAxis(upDir, zNew);
-	}
-	if (zNew.equals(upNew) || zNew.equals(upNew.times(-1))) // A safety measure. Should not be needed
-		return;
-		
+    
+    // Sometimes the new Up- and Z-directions end up the same or opposite.
+    // Then keep the one that was closer to what was found and find the next closest to the other one.
+    if (zNew.equals(upNew) || zNew.equals(upNew.times(-1)))
+    {
+        if (Math.max(Math.max(Math.abs(zDir.x),Math.abs(zDir.y)),Math.abs(zDir.z)) < Math.max(Math.max(Math.abs(upDir.x),Math.abs(upDir.y)),Math.abs(upDir.z)))
+            zNew = findNextAxis(zDir, upNew);
+        else
+            upNew = findNextAxis(upDir, zNew);
+    }
+    if (zNew.equals(upNew) || zNew.equals(upNew.times(-1))) // A safety measure. Should not be needed
+        return;
+        
     center = rotationCenter.plus(zNew.times(-distToPlane));
     coords.setOrientation(zNew,upNew);
     coords.setOrigin(center);
-	
-	if (theCamera == null)
-	{
-		if (zNew.z == -1 && upNew.y ==  1) newOrientation = 0; // Front
-		if (zNew.z ==  1 && upNew.y ==  1) newOrientation = 1; // Back
-		if (zNew.x ==  1 && upNew.y ==  1) newOrientation = 2; // Left
-		if (zNew.x == -1 && upNew.y ==  1) newOrientation = 3; // Right
-		if (zNew.y == -1 && upNew.z == -1) newOrientation = 4; // Top
-		if (zNew.y ==  1 && upNew.z ==  1) newOrientation = 5; // Bottom
-	}
-	else
-		newOrientation = orientation;
-	
+    
+    if (theCamera == null)
+    {
+        if (zNew.z == -1 && upNew.y ==  1) newOrientation = 0; // Front
+        if (zNew.z ==  1 && upNew.y ==  1) newOrientation = 1; // Back
+        if (zNew.x ==  1 && upNew.y ==  1) newOrientation = 2; // Left
+        if (zNew.x == -1 && upNew.y ==  1) newOrientation = 3; // Right
+        if (zNew.y == -1 && upNew.z == -1) newOrientation = 4; // Top
+        if (zNew.y ==  1 && upNew.z ==  1) newOrientation = 5; // Bottom
+    }
+    else
+        newOrientation = orientation;
+    
     animation.start(coords, rotationCenter, scale, newOrientation, navigation);
   }
   
   private Vec3 findNextAxis(Vec3 dir, Vec3 fixed)
   {
-	double maxD = Math.max(Math.max(Math.abs(dir.x),Math.abs(dir.y)),Math.abs(dir.z));
-	double minD = Math.min(Math.min(Math.abs(dir.x),Math.abs(dir.y)),Math.abs(dir.z));
-	Vec3 nextDir;
-	
-	if (Math.abs(dir.x) != maxD && Math.abs(dir.x) != minD) nextDir = new Vec3(dir.x,0,0);
-	else if (Math.abs(dir.y) != maxD && Math.abs(dir.y) != minD) nextDir = new Vec3(0,dir.y,0);
-	else nextDir = new Vec3(0,0,dir.z);
-	nextDir.normalize();
-	
-	// There still is the possibility that the directions are same
-	// try in a different order
-	if (nextDir.equals(fixed) || nextDir.equals(fixed.times(-1)))
-		if (Math.abs(dir.z) != maxD && Math.abs(dir.z) != minD) nextDir = new Vec3(0,0,dir.z); // already z ?
-		else if (Math.abs(dir.y) != maxD && Math.abs(dir.y) != minD) nextDir = new Vec3(0,0,dir.y); // already checked
-		else nextDir = new Vec3(0,0,dir.x); // this would be definitely different.
-	nextDir.normalize();
+    double maxD = Math.max(Math.max(Math.abs(dir.x),Math.abs(dir.y)),Math.abs(dir.z));
+    double minD = Math.min(Math.min(Math.abs(dir.x),Math.abs(dir.y)),Math.abs(dir.z));
+    Vec3 nextDir;
+    
+    if (Math.abs(dir.x) != maxD && Math.abs(dir.x) != minD) nextDir = new Vec3(dir.x,0,0);
+    else if (Math.abs(dir.y) != maxD && Math.abs(dir.y) != minD) nextDir = new Vec3(0,dir.y,0);
+    else nextDir = new Vec3(0,0,dir.z);
+    nextDir.normalize();
+    
+    // There still is the possibility that the directions are same
+    // try in a different order
+    if (nextDir.equals(fixed) || nextDir.equals(fixed.times(-1)))
+        if (Math.abs(dir.z) != maxD && Math.abs(dir.z) != minD) nextDir = new Vec3(0,0,dir.z); // already z ?
+        else if (Math.abs(dir.y) != maxD && Math.abs(dir.y) != minD) nextDir = new Vec3(0,0,dir.y); // already checked
+        else nextDir = new Vec3(0,0,dir.x); // this would be definitely different.
+    nextDir.normalize();
 
-	return nextDir;
+    return nextDir;
   }
   
   /** This should be called by the CanvasDrawer just before rendering an image.  It sets up the camera correctly. */
@@ -1176,6 +1204,9 @@ public abstract class ViewerCanvas extends CustomWidget
 
   public synchronized void updateImage()
   {
+    if (overlaysOnly) // continue in sub classes.
+      return;
+
     Rectangle bounds = getBounds();
 
     if (bounds.height <= 0)
@@ -1284,7 +1315,7 @@ public abstract class ViewerCanvas extends CustomWidget
   protected void drawCoordinateAxes()
   {
     // Select a size for the coordinate axes.
-	// drawLine(new Point(200,1), new Point (100,100), Color.ORANGE);
+    // drawLine(new Point(200,1), new Point (100,100), Color.ORANGE);
 
     Rectangle bounds = getBounds();
     int axisLength = 50;
@@ -1405,10 +1436,10 @@ public abstract class ViewerCanvas extends CustomWidget
 
   public void setOrientation(int which)
   {
-	if (orientation == which || which > 5)
-		return;
-	CoordinateSystem coords = new CoordinateSystem();
-	Vec3 center = new Vec3(getRotationCenter());
+    if (orientation == which || which > 5)
+        return;
+    CoordinateSystem coords = new CoordinateSystem();
+    Vec3 center = new Vec3(getRotationCenter());
     if (which == 0)             // Front
     {
       center.z += distToPlane;
@@ -1439,7 +1470,7 @@ public abstract class ViewerCanvas extends CustomWidget
       center.y -= distToPlane;
       coords = new CoordinateSystem(center, Vec3.vy(), Vec3.vz());
     }
-	animation.start(coords, rotationCenter, scale, which, navigation);
+    animation.start(coords, rotationCenter, scale, which, navigation);
   }
 
   /** If there is a camera bound to this view, copy the coordinates from it. */
@@ -1454,19 +1485,19 @@ public abstract class ViewerCanvas extends CustomWidget
 
   /** 
     Center the view to a point in the model space. No need to 
-	override by subclasses. Local coordinates are handled 
-	by the ClickedPointFinder, 'finder'. 
+    override by subclasses. Local coordinates are handled 
+    by the ClickedPointFinder, 'finder'. 
    */
   public void centerToPoint(Point pointOnView)
   {
-	Vec3 pointInSpace = finder.newPoint(this, pointOnView);
-	CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate(); 
-	Vec3 cz = coords.getZDirection();
-	distToPlane = coords.getOrigin().minus(pointInSpace).length();
-	Vec3 cp = pointInSpace.plus(cz.times(-distToPlane));
-	coords.setOrigin(cp);
-	
-	animation.start(coords, pointInSpace, scale, orientation, navigation);
+    Vec3 pointInSpace = finder.newPoint(this, pointOnView);
+    CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate(); 
+    Vec3 cz = coords.getZDirection();
+    distToPlane = coords.getOrigin().minus(pointInSpace).length();
+    Vec3 cp = pointInSpace.plus(cz.times(-distToPlane));
+    coords.setOrigin(cp);
+    
+    animation.start(coords, pointInSpace, scale, orientation, navigation);
   }
 
   /** Show feedback to the user in response to a mouse drag, by drawing a Shape over the
@@ -1687,451 +1718,451 @@ public abstract class ViewerCanvas extends CustomWidget
   {
     return Collections.unmodifiableMap(controlMap);
   }
-	
-	//---------------------------------------------------//
-	//   The cue graphics drawing starts here            //
-	//---------------------------------------------------//
-	
-	/** Get the centermost point of the screen */
-	public Point getViewCenter()
-	{
-		int x = getBounds().width;
-		int y = getBounds().height;
-		int cx = x/2;
-		int cy = y/2;
-		return (new Point(cx, cy));
-	}
-	
-	private void drawMouseMoveGraphics()
-	{
-		// Nothing to draw currently
-	}
+    
+    //---------------------------------------------------//
+    //   The cue graphics drawing starts here            //
+    //---------------------------------------------------//
+    
+    /** Get the centermost point of the screen */
+    public Point getViewCenter()
+    {
+        int x = getBounds().width;
+        int y = getBounds().height;
+        int cx = x/2;
+        int cy = y/2;
+        return (new Point(cx, cy));
+    }
+    
+    private void drawMouseMoveGraphics()
+    {
+        // Nothing to draw currently
+    }
   
-	private void drawNavigationGraphics()
-	{
-		if (tilting || moving || rotating) return;
-		
-		int d = Math.min(getBounds().width, getBounds().height);
-		Point viewCenter = getViewCenter();
-		Color color1, colorR, colorX, colorY;
-		
-		if (scrolling){
-			color1 = teal;
-			colorR = blendColorR;
-			colorX = blendColorX;
-			colorY = blendColorY;
-		}
-		else{
-			color1 = ghost;
-			colorR = ghost;
-			colorX = ghost;
-			colorY = ghost;
-		}
-		if (navigation == 2){
-			drawCircle(viewCenter, d*0.1, 30, color1);
-			drawCircle(viewCenter, d*0.4, 60, color1);
-		}
-		if (navigation == 3){
-			drawSquare(viewCenter, d*0.1, color1);
-			drawSquare(viewCenter, d*0.4, color1);
-		}
-		
-		if (mousePoint == null) return; // This is very important!
-		
-		double mx, my;
-		mx = mousePoint.x-viewCenter.x;
-		my = mousePoint.y-viewCenter.y;
-		double angle = Math.atan2(my, mx);
-		double rMouse = Math.sqrt(mx*mx+my*my);
-		
-		// Draw the radial pointer
-		if (navigation == 2)
-		{
-			if(rMouse >= (double)d*.1)
-			{
-				drawLine(viewCenter, angle, d*.1, d*.4, colorR);
-				
-				Point point = mousePoint;
-				if (rMouse > (double)d*.4)
-				{
-					double r = (double)d*.4;
-					int px = (int)(Math.cos(angle)*(double)d*.4);
-					int py = (int)(Math.sin(angle)*(double)d*.4);
-					point = new Point(viewCenter.x+px, viewCenter.y+py);
-				}
-				drawCircle(point, 10.0, 12, colorR);
-			}
-			else
-				if (scrolling)
-					drawCircle(viewCenter, (double)d*.1, 30, green); // Just draw the center circle green if mouse is inside it.
-		}
-		// Draw vertical and horizontal ponters
-		if (navigation == 3)
-		{
-			int cx = viewCenter.x;
-			int cy = viewCenter.y;
-			
-			if (Math.abs(mx) >= d*.1){
-				drawLine(new Point(viewCenter.x+(int)((d*.1)*Math.signum(mx)), viewCenter.y), 
-				         new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y),
-						 colorX);
-				if (Math.abs(mx) <= d*.4)
-					drawCircle(new Point(viewCenter.x+(int)mx, viewCenter.y), 10.0, 8, colorX);
-				else
-					drawCircle(new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y), 10.0, 8, colorX);
-			}
-			else if(scrolling)
-			{
-				drawLine(new Point(cx+(int)(d*.1), (int)(cy+d*0.1)), 
-				         new Point(cx+(int)(d*.1), (int)(cy-d*0.1)), 
-				         green);
-				drawLine(new Point(cx-(int)(d*.1), (int)(cy+d*0.1)), 
-				         new Point(cx-(int)(d*.1), (int)(cy-d*0.1)), 
-				         green);
-			}
-			if (Math.abs(my) >= d*.1){
-				drawLine(new Point(viewCenter.x, viewCenter.y+(int)((d*.1)*Math.signum(my))), 
-				         new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))),
-						 colorY);
-				if (Math.abs(my) <= d*.4)
-					drawCircle(new Point(viewCenter.x, viewCenter.y+(int)my), 10.0, 8, colorY);
-				else
-					drawCircle(new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))), 10.0, 8, colorY);
-			}
-			else if(scrolling)
-			{
-				drawLine(new Point((int)(cx+(int)(d*.1)), cy+(int)(d*.1)), 
-				         new Point((int)(cx-(int)(d*.1)), cy+(int)(d*.1)),
-				         blendColorY);
-				drawLine(new Point((int)(cx+(int)(d*.1)), cy-(int)(d*.1)), 
-				         new Point((int)(cx-(int)(d*.1)), cy-(int)(d*.1)),
-				         blendColorY);
-			}
-		}
-	}
+    private void drawNavigationGraphics()
+    {
+        if (tilting || moving || rotating) return;
+        
+        int d = Math.min(getBounds().width, getBounds().height);
+        Point viewCenter = getViewCenter();
+        Color color1, colorR, colorX, colorY;
+        
+        if (scrolling){
+            color1 = teal;
+            colorR = blendColorR;
+            colorX = blendColorX;
+            colorY = blendColorY;
+        }
+        else{
+            color1 = ghost;
+            colorR = ghost;
+            colorX = ghost;
+            colorY = ghost;
+        }
+        if (navigation == 2){
+            drawCircle(viewCenter, d*0.1, 30, color1);
+            drawCircle(viewCenter, d*0.4, 60, color1);
+        }
+        if (navigation == 3){
+            drawSquare(viewCenter, d*0.1, color1);
+            drawSquare(viewCenter, d*0.4, color1);
+        }
+        
+        if (mousePoint == null) return; // This is very important!
+        
+        double mx, my;
+        mx = mousePoint.x-viewCenter.x;
+        my = mousePoint.y-viewCenter.y;
+        double angle = Math.atan2(my, mx);
+        double rMouse = Math.sqrt(mx*mx+my*my);
+        
+        // Draw the radial pointer
+        if (navigation == 2)
+        {
+            if(rMouse >= (double)d*.1)
+            {
+                drawLine(viewCenter, angle, d*.1, d*.4, colorR);
+                
+                Point point = mousePoint;
+                if (rMouse > (double)d*.4)
+                {
+                    double r = (double)d*.4;
+                    int px = (int)(Math.cos(angle)*(double)d*.4);
+                    int py = (int)(Math.sin(angle)*(double)d*.4);
+                    point = new Point(viewCenter.x+px, viewCenter.y+py);
+                }
+                drawCircle(point, 10.0, 12, colorR);
+            }
+            else
+                if (scrolling)
+                    drawCircle(viewCenter, (double)d*.1, 30, green); // Just draw the center circle green if mouse is inside it.
+        }
+        // Draw vertical and horizontal ponters
+        if (navigation == 3)
+        {
+            int cx = viewCenter.x;
+            int cy = viewCenter.y;
+            
+            if (Math.abs(mx) >= d*.1){
+                drawLine(new Point(viewCenter.x+(int)((d*.1)*Math.signum(mx)), viewCenter.y), 
+                         new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y),
+                         colorX);
+                if (Math.abs(mx) <= d*.4)
+                    drawCircle(new Point(viewCenter.x+(int)mx, viewCenter.y), 10.0, 8, colorX);
+                else
+                    drawCircle(new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y), 10.0, 8, colorX);
+            }
+            else if(scrolling)
+            {
+                drawLine(new Point(cx+(int)(d*.1), (int)(cy+d*0.1)), 
+                         new Point(cx+(int)(d*.1), (int)(cy-d*0.1)), 
+                         green);
+                drawLine(new Point(cx-(int)(d*.1), (int)(cy+d*0.1)), 
+                         new Point(cx-(int)(d*.1), (int)(cy-d*0.1)), 
+                         green);
+            }
+            if (Math.abs(my) >= d*.1){
+                drawLine(new Point(viewCenter.x, viewCenter.y+(int)((d*.1)*Math.signum(my))), 
+                         new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))),
+                         colorY);
+                if (Math.abs(my) <= d*.4)
+                    drawCircle(new Point(viewCenter.x, viewCenter.y+(int)my), 10.0, 8, colorY);
+                else
+                    drawCircle(new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))), 10.0, 8, colorY);
+            }
+            else if(scrolling)
+            {
+                drawLine(new Point((int)(cx+(int)(d*.1)), cy+(int)(d*.1)), 
+                         new Point((int)(cx-(int)(d*.1)), cy+(int)(d*.1)),
+                         blendColorY);
+                drawLine(new Point((int)(cx+(int)(d*.1)), cy-(int)(d*.1)), 
+                         new Point((int)(cx-(int)(d*.1)), cy-(int)(d*.1)),
+                         blendColorY);
+            }
+        }
+    }
 
-	protected Timer mouseMoveTimer = new Timer(500, new ActionListener() 
-	{
-		public void actionPerformed(ActionEvent e) 
-		{
-			mouseMoving = false;
-			mouseMoveTimer.stop();
-			mousePoint = null;
-			repaint();
-		}
-	});
-	
-	/* Draw a point in the modelling space on the screen */
-	private void renderPoint(Vec3 p, Color c, int radius)
-	{
-		Vec2 ps = getCamera().getWorldToScreen().timesXY(p);
-		drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x+radius+1, (int)ps.y), c);		
-		drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x-radius, (int)ps.y), c);		
-		drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x, (int)ps.y+radius+1), c);		
-		drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x, (int)ps.y-radius), c);		
-	}
+    protected Timer mouseMoveTimer = new Timer(500, new ActionListener() 
+    {
+        public void actionPerformed(ActionEvent e) 
+        {
+            mouseMoving = false;
+            mouseMoveTimer.stop();
+            mousePoint = null;
+            repaint();
+        }
+    });
+    
+    /* Draw a point in the modelling space on the screen */
+    private void renderPoint(Vec3 p, Color c, int radius)
+    {
+        Vec2 ps = getCamera().getWorldToScreen().timesXY(p);
+        drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x+radius+1, (int)ps.y), c);        
+        drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x-radius, (int)ps.y), c);        
+        drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x, (int)ps.y+radius+1), c);        
+        drawLine(new Point((int)ps.x, (int)ps.y), new Point((int)ps.x, (int)ps.y-radius), c);        
+    }
 
-	/** 
-	 *  Draw a line on the screen as segment of a radius from a center point. 
-	 *  Angle ar radii and r0 and r1 as screen (pixel) coordinate scale.
-	 */
-	public void drawLine(Point center, double angle, double r0, double r1, Color color)
-	{
-		Point p0, p1;
-		p0 = new Point(center.x + (int)(Math.cos(angle)*r0), center.y + (int)(Math.sin(angle)*r0));
-		p1 = new Point(center.x + (int)(Math.cos(angle)*r1), center.y + (int)(Math.sin(angle)*r1));
-		
-		drawLine(p0, p1, color);
-	}
+    /** 
+     *  Draw a line on the screen as segment of a radius from a center point. 
+     *  Angle ar radii and r0 and r1 as screen (pixel) coordinate scale.
+     */
+    public void drawLine(Point center, double angle, double r0, double r1, Color color)
+    {
+        Point p0, p1;
+        p0 = new Point(center.x + (int)(Math.cos(angle)*r0), center.y + (int)(Math.sin(angle)*r0));
+        p1 = new Point(center.x + (int)(Math.cos(angle)*r1), center.y + (int)(Math.sin(angle)*r1));
+        
+        drawLine(p0, p1, color);
+    }
 
-	/** Draw a circle on the screen out of small pieces of lines*/
-	public void drawCircle(Point center, double radius, int segments, Color color)
-	{
-		// Works only with SWCanvasDrawer
-		/*
-		Ellipse2D.Double circle = new Ellipse2D.Double();
-		circle.setFrameFromCenter(center, new Point(center.x+(int)radius, center.y+(int)radius));
-		drawer.drawShape(circle, color);
-		*/
-		Point p0, p1;
-		
-		for (int i = 0; i < segments; i++)
-		{
-			double a0 = 2*Math.PI/segments*i;
-			double x0 = Math.cos(a0)*radius;
-			double y0 = Math.sin(a0)*radius;
-			double a1 = 2*Math.PI/segments*(i+1);
-			double x1 = Math.cos(a1)*radius;
-			double y1 = Math.sin(a1)*radius;
-			
-			p0 = new Point(center.x + (int)x0, center.y + (int)y0);
-			p1 = new Point(center.x + (int)x1, center.y + (int)y1);
-			
-			drawLine(p0 ,p1, color);
-		}
-	}
-	
-	/** draw a suare on the screen */
-	public void drawSquare(Point center, double distance, Color color)
-	{
-		Point p0, p1;
-		double x0 = center.x-(int)(distance);
-		double y0 = center.y-(int)(distance);
-		double x1 = center.x+(int)(distance);
-		double y1 = center.y+(int)(distance);
-		p0 = new Point((int)x0, (int)y0);
-		p1 = new Point((int)x1, (int)y0);
-		drawLine(p0 ,p1, color);
-		p0 = new Point((int)x0, (int)y1);
-		p1 = new Point((int)x1, (int)y1);
-		drawLine(p0 ,p1, color);
-		p0 = new Point((int)x0, (int)y0);
-		p1 = new Point((int)x0, (int)y1);
-		drawLine(p0 ,p1, color);
-		p0 = new Point((int)x1, (int)y0);
-		p1 = new Point((int)x1, (int)y1);
-		drawLine(p0 ,p1, color);
-	}
-	
-	/* These colors are used on the navigation cue graphics */
-	private void setNavigationColors()
-	{
-		TEAL = new Color(0, 127, 127);
-		
-		gray   = new Color(Color.GRAY.getRed()/2+backgroundColor.getRed()/2,
+    /** Draw a circle on the screen out of small pieces of lines*/
+    public void drawCircle(Point center, double radius, int segments, Color color)
+    {
+        // Works only with SWCanvasDrawer
+        /*
+        Ellipse2D.Double circle = new Ellipse2D.Double();
+        circle.setFrameFromCenter(center, new Point(center.x+(int)radius, center.y+(int)radius));
+        drawer.drawShape(circle, color);
+        */
+        Point p0, p1;
+        
+        for (int i = 0; i < segments; i++)
+        {
+            double a0 = 2*Math.PI/segments*i;
+            double x0 = Math.cos(a0)*radius;
+            double y0 = Math.sin(a0)*radius;
+            double a1 = 2*Math.PI/segments*(i+1);
+            double x1 = Math.cos(a1)*radius;
+            double y1 = Math.sin(a1)*radius;
+            
+            p0 = new Point(center.x + (int)x0, center.y + (int)y0);
+            p1 = new Point(center.x + (int)x1, center.y + (int)y1);
+            
+            drawLine(p0 ,p1, color);
+        }
+    }
+    
+    /** draw a suare on the screen */
+    public void drawSquare(Point center, double distance, Color color)
+    {
+        Point p0, p1;
+        double x0 = center.x-(int)(distance);
+        double y0 = center.y-(int)(distance);
+        double x1 = center.x+(int)(distance);
+        double y1 = center.y+(int)(distance);
+        p0 = new Point((int)x0, (int)y0);
+        p1 = new Point((int)x1, (int)y0);
+        drawLine(p0 ,p1, color);
+        p0 = new Point((int)x0, (int)y1);
+        p1 = new Point((int)x1, (int)y1);
+        drawLine(p0 ,p1, color);
+        p0 = new Point((int)x0, (int)y0);
+        p1 = new Point((int)x0, (int)y1);
+        drawLine(p0 ,p1, color);
+        p0 = new Point((int)x1, (int)y0);
+        p1 = new Point((int)x1, (int)y1);
+        drawLine(p0 ,p1, color);
+    }
+    
+    /* These colors are used on the navigation cue graphics */
+    private void setNavigationColors()
+    {
+        TEAL = new Color(0, 127, 127);
+        
+        gray   = new Color(Color.GRAY.getRed()/2+backgroundColor.getRed()/2,
                            Color.GRAY.getGreen()/2+backgroundColor.getGreen()/2,
                            Color.GRAY.getBlue()/2+backgroundColor.getBlue()/2);
-						 
-		ghost  = new Color(Color.GRAY.getRed()/3+backgroundColor.getRed()*2/3,
+                         
+        ghost  = new Color(Color.GRAY.getRed()/3+backgroundColor.getRed()*2/3,
                            Color.GRAY.getGreen()/3+backgroundColor.getGreen()*2/3,
                            Color.GRAY.getBlue()/3+backgroundColor.getBlue()*2/3);
-						 
-		red    = new Color(Color.RED.getRed()*3/4+backgroundColor.getRed()/4,
+                         
+        red    = new Color(Color.RED.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.RED.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.RED.getBlue()*3/4+backgroundColor.getBlue()/4);
-						 
-		yellow = new Color(Color.YELLOW.getRed()*3/4+backgroundColor.getRed()/4,
+                         
+        yellow = new Color(Color.YELLOW.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.YELLOW.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.YELLOW.getBlue()*3/4+backgroundColor.getBlue()/4);
-						   
-		green  = new Color(Color.GREEN.getRed()*3/4+backgroundColor.getRed()/4,
+                           
+        green  = new Color(Color.GREEN.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.GREEN.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.GREEN.getBlue()*3/4+backgroundColor.getBlue()/4);
-				 		 
-		blue   = new Color(Color.BLUE.getRed()*3/4+backgroundColor.getRed()/4,
+                          
+        blue   = new Color(Color.BLUE.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.BLUE.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.BLUE.getBlue()*3/4+backgroundColor.getBlue()/4);
-				 		 
-		teal   = new Color(TEAL.getRed()*3/4+backgroundColor.getRed()/4,
+                          
+        teal   = new Color(TEAL.getRed()*3/4+backgroundColor.getRed()/4,
                            TEAL.getGreen()*3/4+backgroundColor.getGreen()/4,
                            TEAL.getBlue()*3/4+backgroundColor.getBlue()/4);
 
-		cone   = new Color(Color.GREEN.getRed()/2+backgroundColor.getRed()/2,
+        cone   = new Color(Color.GREEN.getRed()/2+backgroundColor.getRed()/2,
                            Color.GREEN.getGreen()/2+backgroundColor.getGreen()/2,
                            Color.GREEN.getBlue()/2+backgroundColor.getBlue()/2);
-	}
-	
-	/* 
-	 * Blend between two colors. 
-	 * The 'blend' is the balance of the color in range 0.0 - 1.0 from color0 to color1
-	 */
-	private Color blendColor(Color color0, Color color1, double blend)
-	{
-		int R = (int)(color0.getRed()*(1.0-blend) + color1.getRed()*blend);
-		int G = (int)(color0.getGreen()*(1.0-blend) + color1.getGreen()*blend);
-		int B = (int)(color0.getBlue()*(1.0-blend) + color1.getBlue()*blend);
-		
-		return new Color(R, G, B);
-	}
-	
-	/** Call all the methods that draw informative graphics on the screen */
-	public void drawOverlay()
-	{
-		if (mouseMoving || scrolling)
-			drawNavigationGraphics();
-		auxGraphs.render();
-	}
-	
-	/** 
-		This class creates and stores information for drawing view cones or other 
-		temporary 3D graphics and privides a method to draw them on the screen.
-	*/
-	public class AuxiliaryGraphics
-	{
-		private ArrayList<Vec3>   points;
-		private ArrayList<Vec3[]> lines;
-		private ArrayList<Color>  pointColors, lineColors;
-		
-		/** Create an empty AuxiliaryGraphics object */
-		public AuxiliaryGraphics()
-		{}
+    }
+    
+    /* 
+     * Blend between two colors. 
+     * The 'blend' is the balance of the color in range 0.0 - 1.0 from color0 to color1
+     */
+    private Color blendColor(Color color0, Color color1, double blend)
+    {
+        int R = (int)(color0.getRed()*(1.0-blend) + color1.getRed()*blend);
+        int G = (int)(color0.getGreen()*(1.0-blend) + color1.getGreen()*blend);
+        int B = (int)(color0.getBlue()*(1.0-blend) + color1.getBlue()*blend);
+        
+        return new Color(R, G, B);
+    }
+    
+    /** Call all the methods that draw informative graphics on the screen */
+    public void drawOverlay()
+    {
+        if (mouseMoving || scrolling)
+            drawNavigationGraphics();
+        auxGraphs.render();
+    }
+    
+    /** 
+        This class creates and stores information for drawing view cones or other 
+        temporary 3D graphics and privides a method to draw them on the screen.
+    */
+    public class AuxiliaryGraphics
+    {
+        private ArrayList<Vec3>   points;
+        private ArrayList<Vec3[]> lines;
+        private ArrayList<Color>  pointColors, lineColors;
+        
+        /** Create an empty AuxiliaryGraphics object */
+        public AuxiliaryGraphics()
+        {}
 
-		/* Create emply point list */
-		private void newPoints(){
-			points = new ArrayList<Vec3>();
-			pointColors = new ArrayList<Color>();
-		}
-			
-		/* Create emply point list */
-		private void newLines(){
-			lines = new ArrayList<Vec3[]>();
-			lineColors = new ArrayList<Color>();
-		}
-		/** 
-			Create contents using the given view<p>
-			
-			@ param newGraphics tells to clear any previously stored graphics
-		*/
-		public void set(ViewerCanvas v, boolean newGraphics)
-		{
-			if(! showViewCone)
-				return;
-			if (newGraphics){
-				newPoints();
-				newLines();
-			}
-			
-			Camera ca = v.getCamera();
-			CoordinateSystem cs = ca.getCameraCoordinates();
-			Vec3 rc = v.getRotationCenter();
-			Vec3 cz = cs.getZDirection();
-			Vec3 cp = new Vec3(cs.getOrigin().plus(cz.times(0.0001))); // Need to move so that the camera can see it
-			double dp = v.getDistToPlane();
+        /* Create emply point list */
+        private void newPoints(){
+            points = new ArrayList<Vec3>();
+            pointColors = new ArrayList<Color>();
+        }
+            
+        /* Create emply point list */
+        private void newLines(){
+            lines = new ArrayList<Vec3[]>();
+            lineColors = new ArrayList<Color>();
+        }
+        /** 
+            Create contents using the given view<p>
+            
+            @ param newGraphics tells to clear any previously stored graphics
+        */
+        public void set(ViewerCanvas v, boolean newGraphics)
+        {
+            if(! showViewCone)
+                return;
+            if (newGraphics){
+                newPoints();
+                newLines();
+            }
+            
+            Camera ca = v.getCamera();
+            CoordinateSystem cs = ca.getCameraCoordinates();
+            Vec3 rc = v.getRotationCenter();
+            Vec3 cz = cs.getZDirection();
+            Vec3 cp = new Vec3(cs.getOrigin().plus(cz.times(0.0001))); // Need to move so that the camera can see it
+            double dp = v.getDistToPlane();
 
-			// rotation center 
-			add(new Vec3(rc), Color.GREEN);
-			
-			// view edges
-			Rectangle b = v.getBounds();
-			Vec3 c0, c1, c2, c3;
-			c0 = ca.convertScreenToWorld(new Point(0, 0), dp);
-			c1 = ca.convertScreenToWorld(new Point(b.width, 0), dp);
-			c2 = ca.convertScreenToWorld(new Point(b.width, b.height), dp);
-			c3 = ca.convertScreenToWorld(new Point(0, b.height), dp);
-			
-			// screen border
-			add(new Vec3[]{c0, c1}, cone);
-			add(new Vec3[]{c1, c2}, cone);
-			add(new Vec3[]{c2, c3}, cone);
-			add(new Vec3[]{c3, c0}, cone);
-			
-			if (v.isPerspective()){
-				// camera position
-				add(new Vec3(cp), Color.MAGENTA);
-				// corner lines
-				add(new Vec3[]{c0, cp}, cone);
-				add(new Vec3[]{c1, cp}, cone);
-				add(new Vec3[]{c2, cp}, cone);
-				add(new Vec3[]{c3, cp}, cone);
-			}
-			else{
-				Vec3 m0, m1, m2, m3, mh, cpp;
-				
-				// pseudo location for view point position
-				double cppDist = 100.0*ca.getDistToScreen()/v.getScale();
-				cpp = rc.minus(cz.times(cppDist*1.0));
-				add(cpp, Color.MAGENTA);
-				
-				m0 = c0.minus(cz.times(cppDist*(1-0.618033))); // "Golden mean.. :) "
-				m1 = c1.minus(cz.times(cppDist*(1-0.618033)));
-				m2 = c2.minus(cz.times(cppDist*(1-0.618033)));
-				m3 = c3.minus(cz.times(cppDist*(1-0.618033)));
+            // rotation center 
+            add(new Vec3(rc), Color.GREEN);
+            
+            // view edges
+            Rectangle b = v.getBounds();
+            Vec3 c0, c1, c2, c3;
+            c0 = ca.convertScreenToWorld(new Point(0, 0), dp);
+            c1 = ca.convertScreenToWorld(new Point(b.width, 0), dp);
+            c2 = ca.convertScreenToWorld(new Point(b.width, b.height), dp);
+            c3 = ca.convertScreenToWorld(new Point(0, b.height), dp);
+            
+            // screen border
+            add(new Vec3[]{c0, c1}, cone);
+            add(new Vec3[]{c1, c2}, cone);
+            add(new Vec3[]{c2, c3}, cone);
+            add(new Vec3[]{c3, c0}, cone);
+            
+            if (v.isPerspective()){
+                // camera position
+                add(new Vec3(cp), Color.MAGENTA);
+                // corner lines
+                add(new Vec3[]{c0, cp}, cone);
+                add(new Vec3[]{c1, cp}, cone);
+                add(new Vec3[]{c2, cp}, cone);
+                add(new Vec3[]{c3, cp}, cone);
+            }
+            else{
+                Vec3 m0, m1, m2, m3, mh, cpp;
+                
+                // pseudo location for view point position
+                double cppDist = 100.0*ca.getDistToScreen()/v.getScale();
+                cpp = rc.minus(cz.times(cppDist*1.0));
+                add(cpp, Color.MAGENTA);
+                
+                m0 = c0.minus(cz.times(cppDist*(1-0.618033))); // "Golden mean.. :) "
+                m1 = c1.minus(cz.times(cppDist*(1-0.618033)));
+                m2 = c2.minus(cz.times(cppDist*(1-0.618033)));
+                m3 = c3.minus(cz.times(cppDist*(1-0.618033)));
 
-				add(new Vec3[]{m0, m1}, cone);
-				add(new Vec3[]{m1, m2}, cone);
-				add(new Vec3[]{m2, m3}, cone);
-				add(new Vec3[]{m3, m0}, cone);
+                add(new Vec3[]{m0, m1}, cone);
+                add(new Vec3[]{m1, m2}, cone);
+                add(new Vec3[]{m2, m3}, cone);
+                add(new Vec3[]{m3, m0}, cone);
 
-				add(new Vec3[]{c0, m0}, cone);
-				add(new Vec3[]{c1, m1}, cone);
-				add(new Vec3[]{c2, m2}, cone);
-				add(new Vec3[]{c3, m3}, cone);
+                add(new Vec3[]{c0, m0}, cone);
+                add(new Vec3[]{c1, m1}, cone);
+                add(new Vec3[]{c2, m2}, cone);
+                add(new Vec3[]{c3, m3}, cone);
 
-				add(new Vec3[]{m0, cpp}, gray);
-				add(new Vec3[]{m1, cpp}, gray);
-				add(new Vec3[]{m2, cpp}, gray);
-				add(new Vec3[]{m3, cpp}, gray);
-			}
-		}
+                add(new Vec3[]{m0, cpp}, gray);
+                add(new Vec3[]{m1, cpp}, gray);
+                add(new Vec3[]{m2, cpp}, gray);
+                add(new Vec3[]{m3, cpp}, gray);
+            }
+        }
 
-		/** Add a point */
-		public void add(Vec3 point, Color pointColor)
-		{
-			if (points == null)
-				newPoints();
-			points.add(point);
-			pointColors.add(pointColor);
-		}
+        /** Add a point */
+        public void add(Vec3 point, Color pointColor)
+        {
+            if (points == null)
+                newPoints();
+            points.add(point);
+            pointColors.add(pointColor);
+        }
 
-		/** Add a line */
-		public void add(Vec3[] lineEnds, Color lineColor)
-		{
-			if (lines == null)
-				newLines();
-			lines.add(lineEnds);
-			lineColors.add(lineColor);
-		}
+        /** Add a line */
+        public void add(Vec3[] lineEnds, Color lineColor)
+        {
+            if (lines == null)
+                newLines();
+            lines.add(lineEnds);
+            lineColors.add(lineColor);
+        }
 
-		/** Copy all information from an existing graphics object */
-		public void copy(AuxiliaryGraphics ext)
-		{
-			points = ext.getPoints();
-			pointColors = ext.getPointColors(); 
-			lines = ext.getLines();
-			lineColors = ext.getLineColors(); 
-		}
+        /** Copy all information from an existing graphics object */
+        public void copy(AuxiliaryGraphics ext)
+        {
+            points = ext.getPoints();
+            pointColors = ext.getPointColors(); 
+            lines = ext.getLines();
+            lineColors = ext.getLineColors(); 
+        }
 
-		public ArrayList<Vec3> getPoints()
-		{
-			return points;
-		}
+        public ArrayList<Vec3> getPoints()
+        {
+            return points;
+        }
 
-		public ArrayList<Color> getPointColors()
-		{
-			return pointColors;
-		}
+        public ArrayList<Color> getPointColors()
+        {
+            return pointColors;
+        }
 
-		public ArrayList<Vec3[]> getLines()
-		{
-			return lines;
-		}
+        public ArrayList<Vec3[]> getLines()
+        {
+            return lines;
+        }
 
-		public ArrayList<Color> getLineColors()
-		{
-			return lineColors;
-		}
+        public ArrayList<Color> getLineColors()
+        {
+            return lineColors;
+        }
 
-		/** Render the object on screen */
-		public void render()
-		{
-		
-			Vec2 v0, v1;
-			Point p0, p1;
-			int pointRadius = 4;
-			if (points != null)
-				for(int i = 0; i < points.size(); i++){
-					renderPoint(points.get(i), pointColors.get(i), pointRadius);
-				}
-			if (lines != null)
-				for(int i = 0; i < lines.size(); i++){
-				
-					// renderLine of CanvasDrawer does not work right here. Object dependencies...
+        /** Render the object on screen */
+        public void render()
+        {
+        
+            Vec2 v0, v1;
+            Point p0, p1;
+            int pointRadius = 4;
+            if (points != null)
+                for(int i = 0; i < points.size(); i++){
+                    renderPoint(points.get(i), pointColors.get(i), pointRadius);
+                }
+            if (lines != null)
+                for(int i = 0; i < lines.size(); i++){
+                
+                    // renderLine of CanvasDrawer does not work right here. Object dependencies...
 
-					v0 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[0]));
-					v1 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[1]));
-					p0 = new Point((int)v0.x, (int)v0.y);
-					p1 = new Point((int)v1.x, (int)v1.y);
-					drawLine (p0, p1, lineColors.get(i));
-				}
-		}
+                    v0 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[0]));
+                    v1 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[1]));
+                    p0 = new Point((int)v0.x, (int)v0.y);
+                    p1 = new Point((int)v1.x, (int)v1.y);
+                    drawLine (p0, p1, lineColors.get(i));
+                }
+        }
 
-		/** Empty the object */
-		public void wipe()
-		{
-			points = null;
-			pointColors = null;
-			lines = null;
-			lineColors = null;
-		}
-	} // AuxiliaryGraphics
+        /** Empty the object */
+        public void wipe()
+        {
+            points = null;
+            pointColors = null;
+            lines = null;
+            lineColors = null;
+        }
+    } // AuxiliaryGraphics
 }

--- a/ArtOfIllusion/src/artofillusion/view/CanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/CanvasDrawer.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2005-2009 by Peter Eastman
+   Modifications Copyright (C) 2016-2017 Petri Ihalainen
 
 This program is free software; you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -127,6 +128,14 @@ public interface CanvasDrawer
   /** Draw a filled Shape onto the canvas. */
 
   public void fillShape(Shape shape, Color color);
+
+  /** Take a snapshot of the current state of the drawn view and cache it */
+
+  public void cacheSnapShot();
+
+  /** Draw the chached snapShot */
+
+  public void applyCachedSnapShot();
 
   /**
    * This should be called to indicate that a previously drawn image has changed, and cached information

--- a/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
@@ -1007,7 +1007,6 @@ public class GLCanvasDrawer implements CanvasDrawer
         drawImage(template, 0, 0);
       gl.glClear(GL.GL_DEPTH_BUFFER_BIT);
       view.updateImage();
-      view.getCurrentTool().drawOverlay(view);
       if (draggedShape != null)
         drawShape(draggedShape, ViewerCanvas.lineColor);
       draggedShape = null;

--- a/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
@@ -98,7 +98,6 @@ public class SoftwareCanvasDrawer implements CanvasDrawer
     bounds = view.getBounds();
     prepareToRender();
     view.updateImage();
-    view.getCurrentTool().drawOverlay(view);
     ev.getGraphics().drawImage(theImage, 0, 0, null);
   }
 

--- a/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/SoftwareCanvasDrawer.java
@@ -26,7 +26,7 @@ import java.lang.ref.*;
 public class SoftwareCanvasDrawer implements CanvasDrawer
 {
   protected ViewerCanvas view;
-  protected BufferedImage theImage;
+  protected BufferedImage theImage, cachedSnapShot;
   protected Graphics2D imageGraphics;
   protected int pixel[], zbuffer[];
   protected boolean hideBackfaces;
@@ -1755,6 +1755,25 @@ public class SoftwareCanvasDrawer implements CanvasDrawer
       {
       }
     }, camera, false, null);
+  }
+
+  /** Take a snapshot of the current state of the drawn view and cache it */
+
+  @Override
+  public void cacheSnapShot()
+  {
+    cachedSnapShot = new BufferedImage(theImage.getWidth(null), theImage.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g = cachedSnapShot.createGraphics();
+    g.drawImage(theImage, 0, 0, null);
+    g.dispose();
+  }
+
+  /** Draw the chached snapShot */
+
+  @Override
+  public void applyCachedSnapShot()
+  {
+    drawImage(cachedSnapShot, 0, 0);
   }
 
   @Override


### PR DESCRIPTION
Quite a few files edited, but that's, what it took to get the basics work.

Now there is a possibility to update views without repainting the scene on the view. For example tool handles and the 3DManipulator can be drawn without a full repaint.

At every repaint the CanvasDrawer saves a snaphot of the view after painting the scene. If only overlays need updating, calling `updateOverlays()` has `updateImege()` use the cached snapshot instead of recalculating the scene image.

In future this should enable things like selection pre-hilights and drag-ghost shapes on the sceen.

Currently the cached images are kept "hard" in the memory.  They probably should be handled as SoftReferences, unless there is somethign more to it than just that? _(There are some even more advanced ways of handling data in the Canvas Drawers)_

This PR also contains the changes in #65.
