### PR TITLE
Set window modified on import file

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -269,17 +269,17 @@ public class ArtOfIllusion
     newWindow(theScene);
   }
 
-  /** Create a new window for editing the specified scene. */
-  public static void newWindow(final Scene theScene)
+  /** Create a new window for editing the specified scene and set window modified. */
+  public static void newWindow(final Scene scene, final boolean modified)
   {
     // New windows should always be created on the event thread.
-
+    
     numNewWindows++;
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run()
       {
-        LayoutWindow fr = new LayoutWindow(theScene);
+        LayoutWindow fr = new LayoutWindow(scene);        
         windows.add(fr);
         
         for (Plugin plugin: PluginRegistry.getPlugins(Plugin.class))
@@ -296,6 +296,7 @@ public class ArtOfIllusion
         }
         fr.setVisible(true);
         fr.arrangeDockableWidgets();
+        if(modified) fr.setModified();
 
         // If the user opens a file immediately after running the program, close the empty
         // scene window.
@@ -308,7 +309,14 @@ public class ArtOfIllusion
               closeWindow(win);
           }
       }
-    });
+    });    
+  }
+  
+  /** Create a new window for editing the specified scene. */
+  public static void newWindow(final Scene scene)
+  {
+    boolean modified = false;
+    newWindow(scene, modified);
   }
 
   /** Add a window to the list of open windows. */

--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -269,8 +269,8 @@ public class ArtOfIllusion
     newWindow(theScene);
   }
 
-  /** Create a new window for editing the specified scene and set window modified. */
-  public static void newWindow(final Scene scene, final boolean modified)
+  /** Create a new window for editing the specified scene. */
+  public static void newWindow(final Scene scene)
   {
     // New windows should always be created on the event thread.
     
@@ -296,7 +296,6 @@ public class ArtOfIllusion
         }
         fr.setVisible(true);
         fr.arrangeDockableWidgets();
-        if(modified) fr.setModified();
 
         // If the user opens a file immediately after running the program, close the empty
         // scene window.
@@ -310,13 +309,6 @@ public class ArtOfIllusion
           }
       }
     });    
-  }
-  
-  /** Create a new window for editing the specified scene. */
-  public static void newWindow(final Scene scene)
-  {
-    boolean modified = false;
-    newWindow(scene, modified);
   }
 
   /** Add a window to the list of open windows. */

--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -1694,11 +1694,10 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
 
   void importCommand(String format)
   {
-    List<Translator> trans = PluginRegistry.getPlugins(Translator.class);
-    for (int i = 0; i < trans.size(); i++)
-      if (trans.get(i).canImport() && format.equals(trans.get(i).getName()))
+    for (Translator importer: PluginRegistry.getPlugins(Translator.class))
+      if (importer.canImport() && format.equals(importer.getName()))
         {
-          trans.get(i).importFile(this);
+          importer.importFile(this);
           return;
         }
   }

--- a/ArtOfIllusion/src/artofillusion/util/FileUtils.java
+++ b/ArtOfIllusion/src/artofillusion/util/FileUtils.java
@@ -1,0 +1,34 @@
+/* Copyright (C) 2017 by Maksim Khramov
+
+   This program is free software; you can redistribute it and/or modify it under the
+   terms of the GNU General Public License as published by the Free Software
+   Foundation; either version 2 of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
+
+package artofillusion.util;
+
+import java.io.File;
+
+/**
+ *
+ * @author MaksK
+ */
+public final class FileUtils
+{
+  private static final String FIX_SEPARATOR=".";
+  
+  private FileUtils()
+  {    
+  }
+  
+  public static String getNameNoExtension(File file)
+  {
+    String fileName = file.getName();
+    int pointPos = fileName.lastIndexOf(FIX_SEPARATOR);
+    return (pointPos == -1) ? fileName : fileName.substring(0, pointPos);    
+  }
+  
+}

--- a/Translators/src/artofillusion/translators/OBJImporter.java
+++ b/Translators/src/artofillusion/translators/OBJImporter.java
@@ -468,7 +468,8 @@ public class OBJImporter
     try
     {
       Scene scene = importFile(bfc.getSelectedFile());
-      ArtOfIllusion.newWindow(scene, true);
+      scene.setName("Untitled");
+      ArtOfIllusion.newWindow(scene);
     }
     catch (Exception ex)
     {

--- a/Translators/src/artofillusion/translators/OBJImporter.java
+++ b/Translators/src/artofillusion/translators/OBJImporter.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2002-2015 by Peter Eastman
+   Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -17,6 +18,7 @@ import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.texture.*;
 import artofillusion.ui.*;
+import artofillusion.util.FileUtils;
 import buoy.widget.*;
 
 import javax.swing.filechooser.*;
@@ -32,9 +34,7 @@ public class OBJImporter
    */
   public static Scene importFile(File f) throws Exception
   {
-    String objName = f.getName();
-    if (objName.lastIndexOf('.') > 0)
-      objName = objName.substring(0, objName.lastIndexOf('.'));
+    String objName = FileUtils.getNameNoExtension(f);
     File directory = f.getCanonicalFile().getParentFile();
 
     // Create a scene to add objects to.
@@ -42,13 +42,11 @@ public class OBJImporter
     Scene theScene = new Scene();
     CoordinateSystem coords = new CoordinateSystem(new Vec3(0.0, 0.0, Camera.DEFAULT_DISTANCE_TO_SCREEN), new Vec3(0.0, 0.0, -1.0), Vec3.vy());
     ObjectInfo info = new ObjectInfo(new SceneCamera(), coords, "Camera 1");
-    info.addTrack(new PositionTrack(info), 0);
-    info.addTrack(new RotationTrack(info), 1);
-    theScene.addObject(info, null);
+
+    theScene.addObject(info, (UndoRecord)null);
     info = new ObjectInfo(new DirectionalLight(new RGBColor(1.0f, 1.0f, 1.0f), 0.8f), coords.duplicate(), "Light 1");
-    info.addTrack(new PositionTrack(info), 0);
-    info.addTrack(new RotationTrack(info), 1);
-    theScene.addObject(info, null);
+
+    theScene.addObject(info, (UndoRecord)null);
 
     // Open the file and read the contents.
 
@@ -468,7 +466,7 @@ public class OBJImporter
     try
     {
       Scene scene = importFile(bfc.getSelectedFile());
-      scene.setName(bfc.getSelectedFile().getName());
+      scene.setName(FileUtils.getNameNoExtension(bfc.getSelectedFile()));
       ArtOfIllusion.newWindow(scene);
     }
     catch (Exception ex)

--- a/Translators/src/artofillusion/translators/OBJImporter.java
+++ b/Translators/src/artofillusion/translators/OBJImporter.java
@@ -467,7 +467,8 @@ public class OBJImporter
     ArtOfIllusion.setCurrentDirectory(bfc.getDirectory().getAbsolutePath());
     try
     {
-      ArtOfIllusion.newWindow(importFile(bfc.getSelectedFile()));
+      Scene scene = importFile(bfc.getSelectedFile());
+      ArtOfIllusion.newWindow(scene, true);
     }
     catch (Exception ex)
     {

--- a/Translators/src/artofillusion/translators/OBJImporter.java
+++ b/Translators/src/artofillusion/translators/OBJImporter.java
@@ -468,7 +468,7 @@ public class OBJImporter
     try
     {
       Scene scene = importFile(bfc.getSelectedFile());
-      scene.setName("Untitled");
+      scene.setName(bfc.getSelectedFile().getName());
       ArtOfIllusion.newWindow(scene);
     }
     catch (Exception ex)

--- a/Translators/src/artofillusion/translators/POVExporter.java
+++ b/Translators/src/artofillusion/translators/POVExporter.java
@@ -16,6 +16,7 @@ import artofillusion.math.*;
 import artofillusion.ui.*;
 import artofillusion.object.*;
 import artofillusion.texture.*;
+import artofillusion.util.FileUtils;
 import buoy.widget.*;
 import java.io.*;
 import java.util.*;
@@ -31,7 +32,7 @@ public class POVExporter
     static char CHAR_REPLACE='_';
     static final String TEXTURE_NAME_PREFIX="AOI";  //  prefix of the texture declaration for povray files
     static final char REPLACEMENT_CHARACTER='_';   // replacement for non allowed characters in names
-    static final String FIX_SEPARATOR=".";   // The separator in file names of suffices and prefices
+
 
     static String exportFileName="Untitled";
 
@@ -69,9 +70,8 @@ public class POVExporter
 	if (!fc.showDialog(parent))
 	    return;
         File path = fc.getDirectory();
-	int endpos=fc.getSelectedFile().getName().indexOf(FIX_SEPARATOR);
-	if (endpos==-1) endpos=fc.getSelectedFile().getName().length();
-	exportFileName=fc.getSelectedFile().getName().substring(0,endpos);
+
+	exportFileName = FileUtils.getNameNoExtension(fc.getSelectedFile());
 	ArtOfIllusion.setCurrentDirectory(fc.getDirectory().getAbsolutePath());
 
 	// Check whether file/s exist/s


### PR DESCRIPTION
Once import performed and new window opened it marked as unmodified. If after that user opens other window or create other new window, the imported scene is silently closed.
I add code to force set window mofified on import