### PR TITLE
Fix #49, Image buttons @ purge

### DIFF
--- a/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
@@ -207,7 +207,12 @@ public class ImagesDialog extends BDialog
         new BStandardDialog("", Translate.text("errorLoadingImage", file.getName()), BStandardDialog.ERROR).showMessageDialog(this);
         ex.printStackTrace();
         setCursor(Cursor.getDefaultCursor());
-        return;
+        
+        // Return if any of the files can not be loaded. 
+        // This should not be the case but currently there is no way of interrupting the load 
+        // deliberately otherwise. 
+
+        return; 
       }
     }
     setCursor(Cursor.getDefaultCursor());
@@ -243,8 +248,9 @@ public class ImagesDialog extends BDialog
   {
     new PurgeDialog(true);
     ic.imagesChanged();
+    hilightButtons();
   }
-  
+
   private void doSelectNone()
   {
     selection = -1;
@@ -312,7 +318,7 @@ public class ImagesDialog extends BDialog
     else
     {
       // If the dialog is accessed through a ProcedureEditor, the scene is already marked modified.
-	}
+    }
   } 
 
   /** Pressing Return and Escape are equivalent to clicking OK and Cancel. Arrow keys can be used to select. */
@@ -754,11 +760,10 @@ public class ImagesDialog extends BDialog
       int count = 0;
       for (int r = 0; r < removeBox.length; r++)
         if (removeBox[r].getState())
-           count++;
+          count++;
            
       if (count > 0 && confirmRemoval(count))
       {
-        selection = -1;
         deleteSelectedImages();
         ic.imagesChanged();
         dispose();
@@ -774,7 +779,6 @@ public class ImagesDialog extends BDialog
            count++;
       if (count > 0 && confirmRemoval(count))
       {
-        selection = -1;
         deleteSelectedImages();
         close();
       }
@@ -799,7 +803,13 @@ public class ImagesDialog extends BDialog
         if (removeBox[d].getState())
           for (int i = 0; i < theScene.getNumImages(); i++)
             if (theScene.getImage(i) == unusedImages.get(d))
+            {
               theScene.removeImage(i);
+              if (selection > i)
+                selection--;
+              else if (selection == i)
+                selection = -1;
+            }
       setModified();
     }
 


### PR DESCRIPTION
Fixed the button issue and added follow up to the selected image at purge. Left the multiple load interrupt at error as it is with a comment in the file.

The reason I left the the interrupting there is, that if the user _(myself, as it happened_) accidentally tries to load a folder full of files that are not image files there is no way of interrupting the process otherwise. Probably the best way to handle that would be just to load the files, that can be loaded and notify afterwards about the failed ones. That change could be made as a separate PR though.

-P-

