### PR TITLE
Fix to blank view on mouse drag in SceneViewer

### DIFF
--- a/ArtOfIllusion/src/artofillusion/Camera.java
+++ b/ArtOfIllusion/src/artofillusion/Camera.java
@@ -338,7 +338,7 @@ public class Camera implements Cloneable
   
   public Vec3 findDragVector(Vec3 p, double dx, double dy)
   {
-    Vec3 v1, v2;
+    Vec3 v1, v2, v;
     Vec2 v3, v4, p1;
     double a, b;
     
@@ -363,7 +363,10 @@ public class Camera implements Cloneable
         a = Math.floor(a/gridSpacing + 0.5) * gridSpacing;
         b = Math.floor(b/gridSpacing + 0.5) * gridSpacing;
       }
-    return (v1.times(a)).plus(v2.times(b));
+    v = (v1.times(a)).plus(v2.times(b));
+    if (Double.isNaN(v.x) || Double.isNaN(v.y) || Double.isNaN(v.z))
+      v = new Vec3();
+    return v;
   }
   
   /** Given a bounding box (specified in object coordinates), return a rectangle which

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -463,10 +463,12 @@ public class SceneViewer extends ViewerCanvas
 
     j = -1;
     minarea = Integer.MAX_VALUE;
+    Vec3 cameraPosition = theCamera.getCameraCoordinates().getOrigin();
+    Vec3 cameraAxis = theCamera.getCameraCoordinates().getZDirection();
     for (i = 0; i < theScene.getNumObjects(); i++)
     {
       info = theScene.getObject(i);
-      if (info.isVisible() && !info.isLocked())
+      if (info.isVisible() && !info.isLocked() && inFront(info, cameraPosition, cameraAxis))
       {
         theCamera.setObjectTransform(info.getCoords().fromLocal());
         bounds = theCamera.findScreenBounds(info.getBounds());
@@ -526,6 +528,24 @@ public class SceneViewer extends ViewerCanvas
   private boolean pointInRectangle(Point p, Rectangle r)
   {
     return (r.x-1 <= p.x && r.y-1 <= p.y && r.x+r.width+1 >= p.x && r.y+r.height+1 >= p.y);
+  }
+
+  /** 
+   * Check if an object can be selected in perspective mode. An object, whose origin is on the "camera plane"
+   * or behid it, should not be selected, when the view is set to perspective.
+   */
+
+  private boolean inFront(ObjectInfo info, Vec3 cameraPosition, Vec3 cameraAxis)
+  {
+    if (isPerspective())
+    {
+      Vec3 difference = info.getCoords().getOrigin().minus(cameraPosition);
+      double projectionDist = difference.dot(cameraAxis);
+      System.out.println("Z-projection "  + projectionDist);
+      return (projectionDist > 0.0);
+    }
+    else
+      return true;
   }
 
   @Override
@@ -616,10 +636,12 @@ public class SceneViewer extends ViewerCanvas
           theScene.clearSelection();
         parentFrame.updateMenus();
       }
+	  Vec3 cameraPosition = theCamera.getCameraCoordinates().getOrigin();
+      Vec3 cameraAxis = theCamera.getCameraCoordinates().getZDirection();
       for (int i = 0; i < theScene.getNumObjects(); i++)
       {
         info = theScene.getObject(i);
-        if (info.isVisible() && !info.isLocked())
+        if (info.isVisible() && !info.isLocked() && inFront(info, cameraPosition, cameraAxis))
         {
           theCamera.setObjectTransform(info.getCoords().fromLocal());
           b = theCamera.findScreenBounds(info.getBounds());


### PR DESCRIPTION
This fixes the problem that Konrad reported on SourceForge. 

The bug was, that the views could go blank, when you pressd and dragged on a view, that was set to perspective viewing. The cause was, that an object that was in the same location as then view camera could be selected at mouse press and then moved by drag, which caused an uncaught error in `findDragVector()` of `Camera`.

It is still possible to select a "wrong object" using the object list, but this fix deselects those when the illegal move is attempted.

I have not tested object editors for a similar case, but I believe the same phenomenon to be present there as well, though less likely to happen.

