### PR TITLE
Catch for NoClasDefFoundError

### DIFF
--- a/ArtOfIllusion/src/artofillusion/PluginRegistry.java
+++ b/ArtOfIllusion/src/artofillusion/PluginRegistry.java
@@ -204,7 +204,7 @@ public class PluginRegistry
         registerResource(info.type, info.id, jar.loader, info.name, info.locale);
       }
     }
-    catch(LinkageError | Exception ex)
+    catch(Error | Exception ex)
     {
       new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginLoadError", jar.file.getName())), BStandardDialog.ERROR).showMessageDialog(null);
       System.err.println("*** Exception while initializing plugin " + jar.file.getName() + ":");

--- a/ArtOfIllusion/src/artofillusion/PluginRegistry.java
+++ b/ArtOfIllusion/src/artofillusion/PluginRegistry.java
@@ -1,6 +1,6 @@
-/* Copyright (C) 2007-2009 by Peter Eastman
+ /* Copyright (C) 2007-2009 by Peter Eastman
    Some parts copyright (C) 2006 by Nik Trevallyn-Jones
-   Changes copyright (C) 2018 by Maksim Khramov
+   Changes copyright (C) 2018-2021 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -204,16 +204,10 @@ public class PluginRegistry
         registerResource(info.type, info.id, jar.loader, info.name, info.locale);
       }
     }
-    catch(NoClassDefFoundError ncdfe)
+    catch(LinkageError | Exception ex)
     {
       new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginLoadError", jar.file.getName())), BStandardDialog.ERROR).showMessageDialog(null);
-      System.err.println("*** Exception while initializing plugin "+jar.file.getName()+":");
-      ncdfe.printStackTrace();      
-    }
-    catch (Exception ex)
-    {
-      new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginLoadError", jar.file.getName())), BStandardDialog.ERROR).showMessageDialog(null);
-      System.err.println("*** Exception while initializing plugin "+jar.file.getName()+":");
+      System.err.println("*** Exception while initializing plugin " + jar.file.getName() + ":");
       ex.printStackTrace();
     }
   }

--- a/ArtOfIllusion/src/artofillusion/PluginRegistry.java
+++ b/ArtOfIllusion/src/artofillusion/PluginRegistry.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2007-2009 by Peter Eastman
    Some parts copyright (C) 2006 by Nik Trevallyn-Jones
+   Changes copyright (C) 2018 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -202,6 +203,12 @@ public class PluginRegistry
       {
         registerResource(info.type, info.id, jar.loader, info.name, info.locale);
       }
+    }
+    catch(NoClassDefFoundError ncdfe)
+    {
+      new BStandardDialog("", UIUtilities.breakString(Translate.text("pluginLoadError", jar.file.getName())), BStandardDialog.ERROR).showMessageDialog(null);
+      System.err.println("*** Exception while initializing plugin "+jar.file.getName()+":");
+      ncdfe.printStackTrace();      
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
I try to install GLRenderer plugin with SPManager. 
Once application is restarted it stuck on showing TitleWindow.
I see NoClassDefFoundError as this plugin expected classes from old JOGL