### PR TITLE
View handling development

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -1,5 +1,5 @@
-/* Copyright (C) 2002-2009 by Peter Eastman
-   Changes Copyright (C) 2016 by Petri Ihalainen
+/* Copyright (C) 2002 - 2009 by Peter Eastman
+   Changes Copyright (C) 2016 - 2018 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -26,7 +26,8 @@ public class ApplicationPreferences
   private Properties properties;
   private int defaultDisplayMode, undoLevels;
   private double interactiveTol, maxAnimationDuration, animationFrameRate;
-  private boolean keepBackupFiles, useOpenGL, useCompoundMeshTool, reverseZooming, useViewAnimations;
+  private boolean keepBackupFiles, useOpenGL, useCompoundMeshTool, reverseZooming;
+  private boolean useViewAnimations, updateImmediately, showActiveView, showNavigationCues;
   private Renderer objectPreviewRenderer, texturePreviewRenderer, defaultRenderer;
 
   /**
@@ -142,9 +143,12 @@ public class ApplicationPreferences
     keepBackupFiles = false;
     useCompoundMeshTool = false;
     reverseZooming = false;
-	useViewAnimations = true;
-	maxAnimationDuration = 1.0;
-	animationFrameRate = 60.0;
+    useViewAnimations = true;
+    maxAnimationDuration = 1.0;
+    animationFrameRate = 60.0;
+    updateImmediately = true;
+    showActiveView = true;
+    showNavigationCues = true;
   }
 
   /** Parse the properties loaded from the preferences file. */
@@ -166,7 +170,11 @@ public class ApplicationPreferences
     useViewAnimations = parseBooleanProperty("useViewAnimations", useViewAnimations);
     maxAnimationDuration = parseDoubleProperty("maxAnimationDuration", maxAnimationDuration);
     animationFrameRate = parseDoubleProperty("animationFrameRate", animationFrameRate);
-	
+
+    updateImmediately = parseBooleanProperty("updateImmediately", updateImmediately);
+    showActiveView = parseBooleanProperty("showActiveView", showActiveView);
+    showNavigationCues = parseBooleanProperty("showNavigationCues", showNavigationCues);
+
     Translate.setLocale(parseLocaleProperty("language"));
     if (properties.getProperty("theme") == null)
     {
@@ -491,5 +499,52 @@ public class ApplicationPreferences
   {
     animationFrameRate = rate;
 	properties.put("animationFrameRate", Double.toString(rate));
+  }
+  
+  /** Get whether inactive views should be update immediately, 
+      when a bound camera moves. */
+
+  public final boolean getUpdateImmediately()
+  {
+    return updateImmediately;
+  }
+
+  /** Set whether inactive views should be update immediately, 
+      when a bound camera moves. */
+
+  public final void setUpdateImmediately(boolean now)
+  {
+    updateImmediately = now;
+    properties.put("updateImmediately", Boolean.toString(now));
+  }
+  
+  /** Get whether to animate view moves. */
+
+  public final boolean getShowActiveView()
+  {
+    return showActiveView;
+  }
+
+  /** Set whether to animate views moves. */
+
+  public final void setShowActiveView(boolean show)
+  {
+    showActiveView = show;
+    properties.put("showActiveView", Boolean.toString(show));
+  }
+  
+  /** Get whether to animate view moves. */
+
+  public final boolean getShowNavigationCues()
+  {
+    return showNavigationCues;
+  }
+
+  /** Set whether to animate views moves. */
+
+  public final void setShowNavigationCues(boolean show)
+  {
+    showNavigationCues = show;
+    properties.put("showNavigationCues", Boolean.toString(show));
   }
 }

--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -96,6 +96,12 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
         setCurrentView((ViewerCanvas) ev.getWidget());
       }
     };
+    Object listenScroll = new Object() {
+      void processEvent(MouseScrolledEvent ev)
+      {
+        setCurrentView((ViewerCanvas) ev.getWidget());
+      }
+    };
     Object keyListener = new Object() {
       public void processEvent(KeyPressedEvent ev)
       {
@@ -120,6 +126,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
       viewPanel[i].add(theView[i] = new SceneViewer(theScene, row, this), BorderContainer.CENTER);
       theView[i].setGrid(theScene.getGridSpacing(), theScene.getGridSubdivisions(), theScene.getShowGrid(), theScene.getSnapToGrid());
       theView[i].addEventLink(MousePressedEvent.class, listen);
+      theView[i].addEventLink(MouseScrolledEvent.class, listenScroll);
       theView[i].addEventLink(KeyPressedEvent.class, keyListener);
       theView[i].setPopupMenuManager(this);
       theView[i].setViewAnimation(new ViewAnimation(this, theView[i]));
@@ -1289,6 +1296,9 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
 
   public void setCurrentView(ViewerCanvas view)
   {
+    if (theView[currentView] == view) // This is necessary for the scroll wheel activation
+        return;
+        
     for (int i = 0; i < theView.length; i++)
       if (currentView != i && view == theView[i])
       {

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -256,18 +256,21 @@ public class MoveViewTool extends EditingTool
   {
     ObjectInfo bound = view.getBoundCamera();
     if (bound == null)
-        return;
-    if (bound.getObject() instanceof SceneCamera)
+        return; 
+    if (view.isPerspective())
+    {
         bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
-	{
-		double objDist = 100.0*view.getCamera().getDistToScreen()/view.getScale();
-		view.setDistToPlane(objDist);
-		Vec3 objCenter = view.getRotationCenter().minus(view.getCamera().getCameraCoordinates().getZDirection().times(objDist));
-		bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
-		bound.getCoords().setOrigin(objCenter);
-	}
+    }
+    else
+    {
+        double objDist = 100.0*view.getCamera().getDistToScreen()/view.getScale();
+        view.setDistToPlane(objDist);
+        Vec3 objCenter = view.getRotationCenter().minus(view.getCamera().getCameraCoordinates().getZDirection().times(objDist));
+        bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
+        bound.getCoords().setOrigin(objCenter);
+    }
   }
-  
+
   /** This is called recursively to move any children of a bound camera. */
   private void moveChildren(ObjectInfo parent, Mat4 transform, UndoRecord undo)
   {

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -189,7 +189,6 @@ public abstract class ObjectViewer extends ViewerCanvas
         drawImage(renderedImage, 0, 0);
       else
         viewChanged(false);
-      drawOverlay();
       drawBorder();
       if (showAxes)
         drawCoordinateAxes();
@@ -224,10 +223,12 @@ public abstract class ObjectViewer extends ViewerCanvas
 
     // Finish up.
 
-    drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
+    if (controller instanceof ObjectEditorWindow)
+        ((ObjectEditorWindow)controller).getView().drawOverlay(this);
+    drawCues();
     if (showAxes)
       drawCoordinateAxes();
     drawBorder();
@@ -503,13 +504,4 @@ public abstract class ObjectViewer extends ViewerCanvas
     theCamera.setCameraCoordinates(cameraCoords);
     adjustCamera(isPerspective());
   }
-  
-   	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		((EditingWindow)controller).updateImage();
-	}
 }

--- a/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
+++ b/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
@@ -27,7 +27,8 @@ public class PreferencesWindow
 {
   private BComboBox defaultRendChoice, objectRendChoice, texRendChoice, localeChoice, themeChoice, colorChoice, toolChoice;
   private ValueField interactiveTolField, undoField, animationDurationField, animationFrameRateField;
-  private BCheckBox glBox, backupBox, reverseZoomBox, useViewAnimationsBox;
+  private BCheckBox glBox, backupBox, reverseZoomBox; 
+  private BCheckBox useViewAnimationsBox, updateImmediatelyBox, showActiveViewBox, showNavigationCuesBox;
   private List<ThemeManager.ThemeInfo> themes;
   private static int lastTab;
   
@@ -79,6 +80,11 @@ public class PreferencesWindow
     prefs.setUseViewAnimations(useViewAnimationsBox.getState());
 	prefs.setMaxAnimationDuration(animationDurationField.getValue());
 	prefs.setAnimationFrameRate(animationFrameRateField.getValue());
+
+    prefs.setUpdateImmediately(updateImmediatelyBox.getState());
+    prefs.setShowActiveView(showActiveViewBox.getState());
+    prefs.setShowNavigationCues(showNavigationCuesBox.getState());
+
     prefs.setUseCompoundMeshTool(toolChoice.getSelectedIndex() == 1);
 	
     ThemeManager.setSelectedTheme(themes.get(themeChoice.getSelectedIndex()));
@@ -121,9 +127,9 @@ public class PreferencesWindow
     useViewAnimationsBox =  new BCheckBox(Translate.text("useViewAnimations"), prefs.getUseViewAnimations());
     animationDurationField = new ValueField(prefs.getMaxAnimationDuration(), ValueField.POSITIVE);
     animationFrameRateField = new ValueField(prefs.getAnimationFrameRate(), ValueField.POSITIVE);
-
-	//useViewAnimationsBox.addEventLink(ValueChangedEvent.class, this, "useViewAnimationsChanged");
-	//animationDurationField.addEventLink(ValueChangedEvent.class, this, "animationDurationChanged");
+    updateImmediatelyBox = new BCheckBox(Translate.text("updateImmediately"), prefs.getUpdateImmediately());
+    showActiveViewBox = new BCheckBox(Translate.text("showActiveView"), prefs.getShowActiveView());
+    showNavigationCuesBox = new BCheckBox(Translate.text("showNavigationCues"), prefs.getShowNavigationCues());
 
     themes = new ArrayList<ThemeManager.ThemeInfo>();
     for (ThemeManager.ThemeInfo theme: ThemeManager.getThemes())
@@ -179,7 +185,7 @@ public class PreferencesWindow
 
     // Layout the panel.
 
-    FormContainer panel = new FormContainer(2, 16);
+    FormContainer panel = new FormContainer(2, 19);
     panel.setColumnWeight(1, 1.0);
     LayoutInfo labelLayout = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(2, 0, 2, 5), null);
     LayoutInfo widgetLayout = new LayoutInfo(LayoutInfo.WEST, LayoutInfo.BOTH, new Insets(2, 0, 2, 0), null);
@@ -211,8 +217,17 @@ public class PreferencesWindow
 	panel.add(Translate.label("animationFrameRate"), 0, 15, labelLayout);
 	panel.add(animationDurationField, 1, 14, widgetLayout);
 	panel.add(animationFrameRateField, 1, 15, widgetLayout);
-	//animationDurationField.setEnabled(false);
-	//animationFrameRateField.setEnabled(false);
+    panel.add(updateImmediatelyBox, 1, 16, widgetLayout);
+    panel.add(showActiveViewBox, 1, 17, widgetLayout);
+    panel.add(showNavigationCuesBox, 1, 18, widgetLayout);
+
+    updateImmediatelyBox.addEventLink(ValueChangedEvent.class, new Object() {
+      void processEvent()
+      {
+        showActiveViewBox.setEnabled(updateImmediatelyBox.getState());
+      }
+    });
+
     return panel;
   }
 

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -409,19 +409,21 @@ public class RotateViewTool extends EditingTool
   {
     ObjectInfo bound = view.getBoundCamera();
     if (bound == null)
-        return;
-    if (bound.getObject() instanceof SceneCamera)
+        return; 
+    if (view.isPerspective())
+    {
         bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
+    }
     else
     {
         double objDist = 100.0*view.getCamera().getDistToScreen()/view.getScale();
         view.setDistToPlane(objDist);
-        Vec3 objCenter = rotationCenter.minus(view.getCamera().getCameraCoordinates().getZDirection().times(objDist));
+        Vec3 objCenter = view.getRotationCenter().minus(view.getCamera().getCameraCoordinates().getZDirection().times(objDist));
         bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
         bound.getCoords().setOrigin(objCenter);
     }
   }
-  
+
   /** This is called recursively to move any children of a bound camera. */
 
   private void moveChildren(ObjectInfo parent, Mat4 transform, UndoRecord undo)

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -168,6 +168,11 @@ public class SceneViewer extends ViewerCanvas
     return new double [] {min, max};
   }
 
+  /*
+      The rotation center should always be known. This method should 
+      be removed, when we can be sure, that nothing uses it any more.
+  */
+
   @Override
   public Vec3 getDefaultRotationCenter()
   {
@@ -308,10 +313,11 @@ public class SceneViewer extends ViewerCanvas
 
     // Finish up.
 
-	drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
+    parentFrame.getView().drawOverlay(this);
+    drawCues();
     if (showAxes)
       drawCoordinateAxes();
     drawBorder();
@@ -551,7 +557,6 @@ public class SceneViewer extends ViewerCanvas
   protected void mouseDragged(WidgetMouseEvent e)
   {
 	mousePoint = e.getPoint();
-	drawOverlay();
     moveToGrid(e);
     if (!dragging)
     {
@@ -704,8 +709,6 @@ public class SceneViewer extends ViewerCanvas
 
   public void mouseClicked(MouseClickedEvent e)
   {
-	//super.mouseClicked(e);
-	
     if (e.getClickCount() == 2 && (activeTool.whichClicks() & EditingTool.OBJECT_CLICKS) != 0 && clickedObject != null && clickedObject.getObject().isEditable())
     {
       final Object3D obj = clickedObject.getObject();
@@ -722,15 +725,6 @@ public class SceneViewer extends ViewerCanvas
     }
   }
 
- 	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		parentFrame.updateImage(); // I wonder why, but that's how it works
-	}
-	
   /** This is called recursively to move any children of a bound camera. */
 
   private void moveChildren(ObjectInfo obj, Mat4 transform, UndoRecord undo)

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -245,8 +245,10 @@ public class ScrollViewTool
 		ObjectInfo bound = view.getBoundCamera();
 		if (bound == null)
 			return;
-		if (bound.getObject() instanceof SceneCamera)
+		if (view.isPerspective())
+		{
 			bound.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
+		}
 		else
 		{
 			double objDist = 100.0*view.getCamera().getDistToScreen()/view.getScale();

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -676,7 +676,7 @@ public abstract class ViewerCanvas extends CustomWidget
 			Vec3 yonz = z.times(y.dot(z));
 			Vec3 newUp = y.minus(yonz);
 			newUp.normalize();
-			coords.setOrientation(z, up); // new coords
+			coords.setOrientation(z, newUp);
 			animation.start(coords, rotationCenter, scale, orientation, nextNavigation);
 		}
     }


### PR DESCRIPTION
Hi.

This PR is still WIP, but I thought I'd send this for commenting. So far 10 files affected. Most of these changes are really too closely related to be separated. -- _And this time I tried to avoid white space editing,... ;)_

What I have been working on is mostly to redesign the graphic information on view manipulation. It's still there, but I tried to tame it down a bit.

Changes:

- I removed the `mouseMoved()` methods from views for the time being. There also was some interaction with `mouseMoved` and `mouseScrolled`, that emerged after the `mouseMoved` was gone, so I simplified the scroll handling back to, what it was before. 
- Using the scroll wheel sets now that view active, which was not the case before.
- The cue graphics in travel modes are static and they can be switched off in the preferences. 
- The active view visualization in the other views is hopefully less annoying and can be switched off too.
- The colors of the two above are blended closer to the color of the background.
- I tried to [edit] use a combination of [/edit] `renderLine` and `drawLine` to add a 3D-effect on displayed view frustum but I was not happy with the result. Some Issues with both of the drawers so that  the results were a bit messy and really, alpha channel transparency would be the tool to make things happen there.
- The largest changes (mostly in `ViewerCanvas` are, that I turned the view frustum drawing inside out -- now the active view draws it's picture on the other views basically the same way that tools do. 

And of course some new clitches turned up: 

- The switching from tiltable modes back to y=up stopped working. What exactly happens seems to have some connection to drawing the active view. 
- Camera zoom jumps back at the next move or rotate command.
- Light cameras still have issues.

Those aren't anything I haven't seen before, but the causes may be new ones. I'll keep digging.
