### PR TITLE
Fix to uninitialized SoftReferences

### DIFF
--- a/ArtOfIllusion/src/artofillusion/image/MIPMappedImage.java
+++ b/ArtOfIllusion/src/artofillusion/image/MIPMappedImage.java
@@ -48,8 +48,6 @@ public class MIPMappedImage extends ImageMap
     Image im = new ImageIcon(file.getAbsolutePath()).getImage();
     init(im);
     setDataCreated(file);
-    preview = new SoftReference(null);
-    mapImage = new SoftReference(null);
   }
 
   /** Initialize a newly created MIPMappedImage. */
@@ -58,6 +56,8 @@ public class MIPMappedImage extends ImageMap
   {
     buildMipMaps(im);
     findAverage();
+    preview = new SoftReference(null);
+    mapImage = new SoftReference(null);
   }
 
   /** Given an Image object, this method builds the full set of mipmaps for it. */


### PR DESCRIPTION
Was not initializing the SoftReferences, when a MIPMappedImage was created form an image in the memory (the LotteryBall script does that).

The effect was, that preview images could not be created and therefore the images dialog was unusable before save/open, when a MIPMap was created "online". Nothing was damaged though.
