### PR TITLE
Use correct parent when creating dialogs

### DIFF
--- a/ArtOfIllusion/src/artofillusion/CameraFilterDialog.java
+++ b/ArtOfIllusion/src/artofillusion/CameraFilterDialog.java
@@ -43,11 +43,11 @@ public class CameraFilterDialog extends BDialog implements RenderListener
   private static final int PREVIEW_WIDTH = 200;
   private static final int PREVIEW_HEIGHT = 150;
 
-  public CameraFilterDialog(EditingWindow parent, SceneCamera camera, CoordinateSystem cameraCoords)
+  public CameraFilterDialog(WindowWidget parent, Scene scene, SceneCamera camera, CoordinateSystem cameraCoords)
   {
-    super(parent.getFrame(), Translate.text("Filters"), true);
+    super(parent, Translate.text("Filters"), true);
     theCamera = camera;
-    theScene = parent.getScene();
+    theScene = scene;
     this.cameraCoords = cameraCoords;
     oldFilters = theCamera.getImageFilters();
     for (int i = 0; i < oldFilters.length; i++)
@@ -101,7 +101,7 @@ public class CameraFilterDialog extends BDialog implements RenderListener
     // Display the window.
 
     pack();
-    UIUtilities.centerDialog(this, parent.getFrame());
+    UIUtilities.centerDialog(this, parent);
     setVisible(true);
   }
 

--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -2947,7 +2947,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     {
       void processEvent()
       {
-        new ColorChooser(LayoutWindow.this, Translate.text("ambientColor"), ambColor);
+        new ColorChooser(ambPatch, Translate.text("ambientColor"), ambColor);
         ambPatch.setBackground(ambColor.getColor());
         ambPatch.repaint();
       }
@@ -2956,7 +2956,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     {
       void processEvent()
       {
-        new ColorChooser(LayoutWindow.this, Translate.text("environmentColor"), envColor);
+        new ColorChooser(envPatch, Translate.text("environmentColor"), envColor);
         envPatch.setBackground(envColor.getColor());
         envPatch.repaint();
       }
@@ -2965,7 +2965,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     {
       void processEvent()
       {
-        new ColorChooser(LayoutWindow.this, Translate.text("fogColor"), fogColor);
+        new ColorChooser(fogPatch, Translate.text("fogColor"), fogColor);
         fogPatch.setBackground(fogColor.getColor());
         fogPatch.repaint();
       }

--- a/ArtOfIllusion/src/artofillusion/TexturesAndMaterialsDialog.java
+++ b/ArtOfIllusion/src/artofillusion/TexturesAndMaterialsDialog.java
@@ -425,7 +425,7 @@ public class TexturesAndMaterialsDialog extends BDialog
           Texture tex = textureTypes.get(newType).getClass().newInstance();
           tex.setName(name);
           theScene.addTexture(tex);
-          tex.edit(parentFrame.getFrame(), theScene);
+          tex.edit(this, theScene);
         }
         catch (Exception ex)
         {
@@ -497,7 +497,7 @@ public class TexturesAndMaterialsDialog extends BDialog
     if (selectedTexture != null)
     {
       Texture tex = selectedTexture;
-      tex.edit(parentFrame.getFrame(), theScene);
+      tex.edit(this, theScene);
       tex.assignNewID();
       theScene.changeTexture(theScene.indexOf(tex));
       parentFrame.setModified();

--- a/ArtOfIllusion/src/artofillusion/image/ImageDetailsDialog.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImageDetailsDialog.java
@@ -27,7 +27,7 @@ import java.awt.event.MouseEvent;
 
 public class ImageDetailsDialog extends BDialog
 {
-    private BFrame parent;
+    private WindowWidget parent;
     private Scene scene;
     private ImageMap im;
     private ArrayList<String> texturesUsing;
@@ -41,7 +41,7 @@ public class ImageDetailsDialog extends BDialog
     private BLabel[] title, data; 
     private Color defaultTextColor, errorTextColor, hilightTextColor, currentTextColor;
 
-    public ImageDetailsDialog(BFrame parent, Scene scene, ImageMap im)
+    public ImageDetailsDialog(WindowWidget parent, Scene scene, ImageMap im)
     {
         super(parent, "Image data", true);
         this.parent = parent;

--- a/ArtOfIllusion/src/artofillusion/image/ImageOrColor.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImageOrColor.java
@@ -123,11 +123,11 @@ public class ImageOrColor
 
   /** Get a Widget with which the user can edit the color.  This Widget will send out
       ValueChangedEvents whenever the color changes.
-      @param parent    a parent BFrame which can be used for displaying dialogs
+      @param parent    a parent window which can be used for displaying dialogs
       @param theScene  the Scene from which to get images
   */
   
-  public Widget getEditingPanel(final BFrame parent, final Scene theScene)
+  public Widget getEditingPanel(final WindowWidget parent, final Scene theScene)
   {
     final RowContainer row = new RowContainer();
     final CustomWidget preview = new CustomWidget();

--- a/ArtOfIllusion/src/artofillusion/image/ImageOrValue.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImageOrValue.java
@@ -144,25 +144,25 @@ public class ImageOrValue
 
   /** Get a Widget with which the user can edit the value.  This Widget will send out
       ValueChangedEvents whenever the value changes.
-      @param parent    a parent BFrame which can be used for displaying dialogs
+      @param parent    a parent window which can be used for displaying dialogs
       @param theScene  the Scene from which to get images
   */
   
-  public Widget getEditingPanel(BFrame parent, Scene theScene)
+  public Widget getEditingPanel(WindowWidget parent, Scene theScene)
   {
     return new EditingPanel(parent, theScene);
   }
   
   private class EditingPanel extends FormContainer
   {
-    BFrame fr;
+    WindowWidget fr;
     Scene sc;
     CustomWidget preview;
     BComboBox componentChoice;
     BLabel componentLabel, valueLabel;
     ValueSlider slider;
 
-    public EditingPanel(BFrame parent, Scene theScene)
+    public EditingPanel(WindowWidget parent, Scene theScene)
     {
       super(new double [] {0.0, 1.0, 0.0}, new double [] {1.0, 1.0});
       fr = parent;

--- a/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
+++ b/ArtOfIllusion/src/artofillusion/image/ImagesDialog.java
@@ -30,7 +30,7 @@ import static java.lang.Math.*;
 public class ImagesDialog extends BDialog
 {
   private Scene theScene;
-  private BFrame parent;
+  private WindowWidget parent;
   private int selection, dialogHeight, dialogWidth, frameWidth, cOff=0;
   private BScrollPane sp;
   private ImagesCanvas ic;
@@ -41,7 +41,7 @@ public class ImagesDialog extends BDialog
   private ImageMap selectedImage;
   private Timer timer;
   
-  public ImagesDialog(BFrame fr, Scene sc, ImageMap selected)
+  public ImagesDialog(WindowWidget fr, Scene sc, ImageMap selected)
   {
     super(fr, "Images", true);
     selectedImage = selected;
@@ -272,7 +272,7 @@ public class ImagesDialog extends BDialog
   private void openDetailsDialog()
   {
     File oldFile = getSelection().getFile();
-    new ImageDetailsDialog(parent, theScene, getSelection());
+    new ImageDetailsDialog(this, theScene, getSelection());
     ic.imagesChanged();
     ic.scrollToSelection();
     if (getSelection().getFile() != oldFile)
@@ -613,7 +613,7 @@ public class ImagesDialog extends BDialog
     
     PurgeDialog(boolean intent)
     {
-      super(parent, "Purge Images", true);
+      super(ImagesDialog.this, "Purge Images", true);
       
       thumb = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(1,15,1,1), null);
       text  = new LayoutInfo(LayoutInfo.CENTER,   LayoutInfo.NONE, new Insets(1,1,1,1),  null);

--- a/ArtOfIllusion/src/artofillusion/material/Material.java
+++ b/ArtOfIllusion/src/artofillusion/material/Material.java
@@ -115,11 +115,21 @@ public abstract class Material
   /** Create a duplicate of the material. */
   
   public abstract Material duplicate();
-  
-  /** Allow the user to interactively edit the material.  fr is a Frame which can be used as a
-      parent for Dialogs, and sc is the Scene which this Material is part of. */
-  
-  public abstract void edit(BFrame fr, Scene sc);
+
+  /** Allow the user to interactively edit the naterial.  parent is a WindowWidget which can be used as a
+   parent for Dialogs, and sc is the Scene which this Material is part of.  Subclasses should override
+   this to implement editing. */
+
+  public void edit(WindowWidget parent, Scene sc) {
+  }
+
+  /** This exists only for backward compatibility.  Subclasses should override the version that takes
+   a WindowWidget instead. */
+
+  @Deprecated
+  public void edit(BFrame fr, Scene sc) {
+    edit((WindowWidget) fr, sc);
+  }
 
   /** The following method writes the material's data to an output stream.  In addition to this
       method, every Material must include a constructor with the signature

--- a/ArtOfIllusion/src/artofillusion/material/ProceduralMaterial3D.java
+++ b/ArtOfIllusion/src/artofillusion/material/ProceduralMaterial3D.java
@@ -183,7 +183,7 @@ public class ProceduralMaterial3D extends Material3D implements ProcedureOwner
   }
 
   @Override
-  public void edit(BFrame fr, Scene sc)
+  public void edit(WindowWidget fr, Scene sc)
   {
     new ProcedureEditor(proc, this, sc);
   }

--- a/ArtOfIllusion/src/artofillusion/material/UniformMaterial.java
+++ b/ArtOfIllusion/src/artofillusion/material/UniformMaterial.java
@@ -118,7 +118,7 @@ public class UniformMaterial extends Material
   /* Allow the user to interactively edit the material. */
 
   @Override
-  public void edit(final BFrame fr, Scene sc)
+  public void edit(final WindowWidget parent, Scene sc)
   {
     final UniformMaterial newMaterial = (UniformMaterial) duplicate();
     BTextField nameField = new BTextField(name);
@@ -143,7 +143,7 @@ public class UniformMaterial extends Material
     transPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("Transparency"), newMaterial.transparencyColor);
+        new ColorChooser(transPatch, Translate.text("Transparency"), newMaterial.transparencyColor);
         transPatch.setBackground(newMaterial.transparencyColor.getColor());
         newMaterial.recalcColors();
         process.addEvent(renderCallback);
@@ -152,7 +152,7 @@ public class UniformMaterial extends Material
     colorPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("MaterialColor"), newMaterial.matColor);
+        new ColorChooser(colorPatch, Translate.text("MaterialColor"), newMaterial.matColor);
         colorPatch.setBackground(newMaterial.matColor.getColor());
         newMaterial.recalcColors();
         process.addEvent(renderCallback);
@@ -161,7 +161,7 @@ public class UniformMaterial extends Material
     scatPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("ScatteringColor"), newMaterial.scatteringColor);
+        new ColorChooser(scatPatch, Translate.text("ScatteringColor"), newMaterial.scatteringColor);
         scatPatch.setBackground(newMaterial.scatteringColor.getColor());
         newMaterial.recalcColors();
         process.addEvent(renderCallback);
@@ -186,7 +186,7 @@ public class UniformMaterial extends Material
     transSlider.addEventLink(ValueChangedEvent.class, valueListener);
     eccSlider.addEventLink(ValueChangedEvent.class, valueListener);
     shadowBox.addEventLink(ValueChangedEvent.class, valueListener);
-    ComponentsDialog dlg = new ComponentsDialog(fr, "", new Widget [] {
+    ComponentsDialog dlg = new ComponentsDialog(parent, "", new Widget [] {
         preview, nameField, colorPatch, transPatch, transSlider, densitySlider, scatSlider, scatPatch,
         eccSlider, refractField, shadowBox}, new String [] {null, Translate.text("Name"),
         Translate.text("EmissiveColor"), Translate.text("TransparentColor"), Translate.text("Transparency"), Translate.text("Density"),

--- a/ArtOfIllusion/src/artofillusion/object/DirectionalLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/DirectionalLight.java
@@ -214,7 +214,7 @@ public class DirectionalLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), color);
+        new ColorChooser(patch, Translate.text("lightColor"), color);
         patch.setBackground(color.getColor());
       }
     });
@@ -316,7 +316,7 @@ public class DirectionalLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), key.color);
+        new ColorChooser(patch, Translate.text("lightColor"), key.color);
         patch.setBackground(key.color.getColor());
       }
     });

--- a/ArtOfIllusion/src/artofillusion/object/PointLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/PointLight.java
@@ -182,7 +182,7 @@ public class PointLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), color);
+        new ColorChooser(patch, Translate.text("lightColor"), color);
         patch.setBackground(color.getColor());
       }
     });
@@ -319,7 +319,7 @@ public class PointLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), key.color);
+        new ColorChooser(patch, Translate.text("lightColor"), key.color);
         patch.setBackground(key.color.getColor());
       }
     });

--- a/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
+++ b/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
@@ -462,7 +462,7 @@ public class SceneCamera extends Object3D
         temp.fov = fovSlider.getValue();
         temp.depthOfField = dofField.getValue();
         temp.focalDist = fdField.getValue();
-        new CameraFilterDialog(parent, temp, info.getCoords());
+        new CameraFilterDialog(UIUtilities.findWindow(fovSlider), parent.getScene(), temp, info.getCoords());
         filter = temp.filter;
       }
     }, "processEvent");

--- a/ArtOfIllusion/src/artofillusion/object/SpotLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/SpotLight.java
@@ -306,7 +306,7 @@ public class SpotLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), color);
+        new ColorChooser(patch, Translate.text("lightColor"), color);
         patch.setBackground(color.getColor());
         preview.updateImage(angleSlider.getValue(), falloffSlider.getValue());
       }
@@ -469,7 +469,7 @@ public class SpotLight extends Light
     patch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(parentFrame, Translate.text("lightColor"), key.color);
+        new ColorChooser(patch, Translate.text("lightColor"), key.color);
         patch.setBackground(key.color.getColor());
         preview.updateImage(angleSlider.getValue(), falloffSlider.getValue());
       }

--- a/ArtOfIllusion/src/artofillusion/procedural/SpectrumModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/SpectrumModule.java
@@ -550,7 +550,7 @@ public class SpectrumModule extends ProceduralModule
 
     private void selectColor()
     {
-      new ColorChooser((BFrame) this.getParent(), Translate.text("selectColor"), color[selected]);
+      new ColorChooser(this, Translate.text("selectColor"), color[selected]);
       preview.setBackground(color[selected].getColor());
       canvas.repaint();
       preview.repaint();

--- a/ArtOfIllusion/src/artofillusion/texture/ImageMapTexture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/ImageMapTexture.java
@@ -285,7 +285,7 @@ public class ImageMapTexture extends Texture2D
   /** Allow the user to interactively edit the texture. */
 
   @Override
-  public void edit(BFrame fr, Scene sc)
+  public void edit(WindowWidget fr, Scene sc)
   {
     new Editor(fr, sc);
   }
@@ -354,13 +354,11 @@ public class ImageMapTexture extends Texture2D
     MaterialPreviewer preview;
     ActionProcessor renderProcessor;
     ImageMapTexture newTexture;
-    BFrame parent;
     Scene scene;
 
-    public Editor(BFrame fr, Scene sc)
+    public Editor(WindowWidget fr, Scene sc)
     {
       super(fr, true);
-      parent = fr;
       scene = sc;
       newTexture = (ImageMapTexture) duplicate();
       BorderContainer content = new BorderContainer();
@@ -385,10 +383,10 @@ public class ImageMapTexture extends Texture2D
       left.add(Translate.label("EmissiveColor"), 0, 5, leftGapLayout);
       LayoutInfo justLeftLayout = new LayoutInfo(LayoutInfo.WEST, LayoutInfo.NONE, null, null);
       left.add(nameField = new BTextField(ImageMapTexture.this.name, 15), 1, 1, new LayoutInfo(LayoutInfo.CENTER, LayoutInfo.HORIZONTAL, null, null));
-      left.add(diffColorPanel = newTexture.diffuseColor.getEditingPanel(parent, sc), 1, 2, justLeftLayout);
-      left.add(specColorPanel = newTexture.specularColor.getEditingPanel(parent, sc), 1, 3, justLeftLayout);
-      left.add(transColorPanel = newTexture.transparentColor.getEditingPanel(parent, sc), 1, 4, justLeftLayout);
-      left.add(emissColorPanel = newTexture.emissiveColor.getEditingPanel(parent, sc), 1, 5, justLeftLayout);
+      left.add(diffColorPanel = newTexture.diffuseColor.getEditingPanel(this, sc), 1, 2, justLeftLayout);
+      left.add(specColorPanel = newTexture.specularColor.getEditingPanel(this, sc), 1, 3, justLeftLayout);
+      left.add(transColorPanel = newTexture.transparentColor.getEditingPanel(this, sc), 1, 4, justLeftLayout);
+      left.add(emissColorPanel = newTexture.emissiveColor.getEditingPanel(this, sc), 1, 5, justLeftLayout);
       content.add(left, BorderContainer.WEST);
 
       // Add the right panel.
@@ -408,13 +406,13 @@ public class ImageMapTexture extends Texture2D
       right.add(Translate.label("Cloudiness"), 0, 5, leftGapLayout);
       right.add(Translate.label("BumpHeight"), 0, 6, leftGapLayout);
       right.add(Translate.label("Displacement"), 0, 7, leftGapLayout);
-      right.add(transPanel = newTexture.transparency.getEditingPanel(parent, sc), 1, 1);
-      right.add(specPanel = newTexture.specularity.getEditingPanel(parent, sc), 1, 2);
-      right.add(shinPanel = newTexture.shininess.getEditingPanel(parent, sc), 1, 3);
-      right.add(roughPanel = newTexture.roughness.getEditingPanel(parent, sc), 1, 4);
-      right.add(cloudPanel = newTexture.cloudiness.getEditingPanel(parent, sc), 1, 5);
-      right.add(bumpPanel = newTexture.bump.getEditingPanel(parent, sc), 1, 6);
-      right.add(displacePanel = newTexture.displacement.getEditingPanel(parent, sc), 1, 7);
+      right.add(transPanel = newTexture.transparency.getEditingPanel(this, sc), 1, 1);
+      right.add(specPanel = newTexture.specularity.getEditingPanel(this, sc), 1, 2);
+      right.add(shinPanel = newTexture.shininess.getEditingPanel(this, sc), 1, 3);
+      right.add(roughPanel = newTexture.roughness.getEditingPanel(this, sc), 1, 4);
+      right.add(cloudPanel = newTexture.cloudiness.getEditingPanel(this, sc), 1, 5);
+      right.add(bumpPanel = newTexture.bump.getEditingPanel(this, sc), 1, 6);
+      right.add(displacePanel = newTexture.displacement.getEditingPanel(this, sc), 1, 7);
       content.add(right, BorderContainer.EAST);
       diffColorPanel.addEventLink(ValueChangedEvent.class, this, "valueChanged");
       specColorPanel.addEventLink(ValueChangedEvent.class, this, "valueChanged");

--- a/ArtOfIllusion/src/artofillusion/texture/LayeredTexture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/LayeredTexture.java
@@ -118,7 +118,7 @@ public class LayeredTexture extends Texture
       ObjectTextureDialog. */
 
   @Override
-  public void edit(BFrame fr, Scene sc)
+  public void edit(WindowWidget fr, Scene sc)
   {
   }
 

--- a/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture2D.java
+++ b/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture2D.java
@@ -264,7 +264,7 @@ public class ProceduralTexture2D extends Texture2D implements ProcedureOwner
   }
 
   @Override
-  public void edit(BFrame fr, Scene sc)
+  public void edit(WindowWidget fr, Scene sc)
   {
     new ProcedureEditor(proc, this, sc);
   }

--- a/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture3D.java
+++ b/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture3D.java
@@ -265,7 +265,7 @@ public class ProceduralTexture3D extends Texture3D implements ProcedureOwner
   }
 
   @Override
-  public void edit(BFrame fr, Scene sc)
+  public void edit(WindowWidget fr, Scene sc)
   {
     new ProcedureEditor(proc, this, sc);
   }

--- a/ArtOfIllusion/src/artofillusion/texture/Texture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/Texture.java
@@ -114,11 +114,21 @@ public abstract class Texture
   
   public abstract Texture duplicate();
   
-  /** Allow the user to interactively edit the texture.  fr is a BFrame which can be used as a
-      parent for Dialogs, and sc is the Scene which this Texture is part of. */
+  /** Allow the user to interactively edit the texture.  parent is a WindowWidget which can be used as a
+      parent for Dialogs, and sc is the Scene which this Texture is part of.  Subclasses should override
+      this to implement editing. */
   
-  public abstract void edit(BFrame fr, Scene sc);
+  public void edit(WindowWidget parent, Scene sc) {
+  }
 
+  /** This exists only for backward compatibility.  Subclasses should override the version that takes
+      a WindowWidget instead. */
+
+  @Deprecated
+  public void edit(BFrame fr, Scene sc) {
+    edit((WindowWidget) fr, sc);
+  }
+  
   /** The following method writes the texture's data to an output stream.  In addition to this
       method, every Texture must include a constructor with the signature
   

--- a/ArtOfIllusion/src/artofillusion/texture/UniformTexture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/UniformTexture.java
@@ -141,7 +141,7 @@ public class UniformTexture extends Texture
   /** Allow the user to interactively edit the material. */
 
   @Override
-  public void edit(final BFrame fr, Scene sc)
+  public void edit(final WindowWidget parent, Scene sc)
   {
     BTextField nameField = new BTextField(name, 15);
     final ValueSlider transSlider = new ValueSlider(0.0, 1.0, 100, (double) transparency);
@@ -166,7 +166,7 @@ public class UniformTexture extends Texture
     diffPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("DiffuseColor"), newTexture.diffuseColor);
+        new ColorChooser(diffPatch, Translate.text("DiffuseColor"), newTexture.diffuseColor);
         diffPatch.setBackground(newTexture.diffuseColor.getColor());
         process.addEvent(renderCallback);
       }
@@ -174,7 +174,7 @@ public class UniformTexture extends Texture
     specPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("SpecularColor"), newTexture.specularColor);
+        new ColorChooser(specPatch, Translate.text("SpecularColor"), newTexture.specularColor);
         specPatch.setBackground(newTexture.specularColor.getColor());
         process.addEvent(renderCallback);
       }
@@ -182,7 +182,7 @@ public class UniformTexture extends Texture
     transPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("TransparentColor"), newTexture.transparentColor);
+        new ColorChooser(transPatch, Translate.text("TransparentColor"), newTexture.transparentColor);
         transPatch.setBackground(newTexture.transparentColor.getColor());
         process.addEvent(renderCallback);
       }
@@ -190,7 +190,7 @@ public class UniformTexture extends Texture
     emissPatch.addEventLink(MouseClickedEvent.class, new Object() {
       void processEvent()
       {
-        new ColorChooser(fr, Translate.text("EmissiveColor"), newTexture.emissiveColor);
+        new ColorChooser(emissPatch, Translate.text("EmissiveColor"), newTexture.emissiveColor);
         emissPatch.setBackground(newTexture.emissiveColor.getColor());
         process.addEvent(renderCallback);
       }
@@ -211,7 +211,7 @@ public class UniformTexture extends Texture
     shinSlider.addEventLink(ValueChangedEvent.class, valueListener);
     roughSlider.addEventLink(ValueChangedEvent.class, valueListener);
     clearSlider.addEventLink(ValueChangedEvent.class, valueListener);
-    ComponentsDialog dlg = new ComponentsDialog(fr, "", new Widget [] {
+    ComponentsDialog dlg = new ComponentsDialog(parent, "", new Widget [] {
         preview, nameField, diffPatch, specPatch, transPatch, emissPatch, transSlider, specSlider,
         shinSlider, roughSlider, clearSlider}, new String [] {null, Translate.text("Name"),
         Translate.text("DiffuseColor"), Translate.text("SpecularColor"), Translate.text("TransparentColor"),

--- a/ArtOfIllusion/src/artofillusion/ui/ColorChooser.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ColorChooser.java
@@ -53,14 +53,14 @@ public class ColorChooser extends BDialog
       recentColors.add(new RGBColor(1.0, 1.0, 1.0));
   }
   
-  public ColorChooser(BFrame parent, String title, RGBColor c)
+  public ColorChooser(Widget parent, String title, RGBColor c)
   {
     this(parent, title, c, true);
   }
 
-  public ColorChooser(BFrame parent, String title, RGBColor c, boolean show)
+  public ColorChooser(Widget parent, String title, RGBColor c, boolean show)
   {
-    super(parent, title, true);
+    super(UIUtilities.findWindow(parent), title, true);
     BorderContainer content = new BorderContainer();
     setContent(BOutline.createEmptyBorder(content, UIUtilities.getStandardDialogInsets()));
     oldColor = c;
@@ -135,7 +135,7 @@ public class ColorChooser extends BDialog
       }
     });
     setResizable(false);
-    UIUtilities.centerDialog(this, parent);
+    UIUtilities.centerDialog(this, UIUtilities.findWindow(parent));
     if (show)
       setVisible(true);
    }

--- a/ArtOfIllusion/src/artofillusion/ui/PropertyEditor.java
+++ b/ArtOfIllusion/src/artofillusion/ui/PropertyEditor.java
@@ -199,7 +199,7 @@ public class PropertyEditor
       if (color != null)
       {
         RGBColor oldColor = color.duplicate();
-        new ColorChooser(UIUtilities.findFrame(this), title, color);
+        new ColorChooser(this, title, color);
         if (!color.equals(oldColor))
         {
           setBackground(color.getColor());


### PR DESCRIPTION
In lots of places we were passing the top level window as the parent for dialogs, instead of the dialog they were opened from.  This caused lots of problems when using Oracle Java on Mac, including dialogs appearing in back of other windows and UI events being missed.

This goes a long way toward making it usable with Java 8 on Mac.  There probably are other cases of this I've missed.  We'll need to keep an eye out for them and fix them as they come up.