### PR TITLE
View manipulation & graphics update and bug fix

### DIFF
--- a/ArtOfIllusion/src/artofillusion.properties
+++ b/ArtOfIllusion/src/artofillusion.properties
@@ -748,7 +748,13 @@ errorSavingPrefs=An error occurred while saving the settings: {0}
 useViewAnimations=Animate automatic moves
 maxAnimationDuration=Maximum duration (sec)
 animationFrameRate=Frame rate (Hz)
-
+DisplayViewFrustumOf=Display frustum shape of
+anyActiveView=any active view
+cameraView=a camera view
+ShowTravelScrollCues = Show scroll cues
+onIdle=on idle
+duringScrolling=during scrolling
+ShowTiltDial=Show tilt dial
 #
 # The Textures and Materials window
 #

--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -27,7 +27,7 @@ public class ApplicationPreferences
   private int defaultDisplayMode, undoLevels;
   private double interactiveTol, maxAnimationDuration, animationFrameRate;
   private boolean keepBackupFiles, useOpenGL, useCompoundMeshTool, reverseZooming, useViewAnimations;
-  private boolean drawActiveFrustum, drawCameraFrustum;
+  private boolean drawActiveFrustum, drawCameraFrustum, showTravelCuesOnIdle, showTravelCuesScrolling, showTiltDial;
   private Renderer objectPreviewRenderer, texturePreviewRenderer, defaultRenderer;
   
   /**
@@ -146,8 +146,11 @@ public class ApplicationPreferences
 	useViewAnimations = true;
 	maxAnimationDuration = 1.0;
 	animationFrameRate = 60.0;
-    drawActiveFrustum = true;
+    drawActiveFrustum = false;
     drawCameraFrustum = true;
+    showTravelCuesOnIdle = false;
+    showTravelCuesScrolling = true;
+    showTiltDial = false;
   }
 
   /** Parse the properties loaded from the preferences file. */
@@ -171,6 +174,9 @@ public class ApplicationPreferences
     animationFrameRate = parseDoubleProperty("animationFrameRate", animationFrameRate);
     drawActiveFrustum = parseBooleanProperty("drawActiveFrustum", drawActiveFrustum);
     drawCameraFrustum = parseBooleanProperty("drawCameraFrustum", drawCameraFrustum);
+    showTravelCuesOnIdle = parseBooleanProperty("showTravelCuesOnIdle", showTravelCuesOnIdle);
+    showTravelCuesScrolling = parseBooleanProperty("showTravelCuesScrolling", showTravelCuesScrolling);
+    showTiltDial = parseBooleanProperty("showTiltDial", showTiltDial);
 
     Translate.setLocale(parseLocaleProperty("language"));
     if (properties.getProperty("theme") == null)
@@ -526,5 +532,49 @@ public class ApplicationPreferences
   {
     drawCameraFrustum = draw;
     properties.put("drawCameraFrustum", Boolean.toString(draw));
+  }
+
+  /** Check if cues should be drawn "always" */
+
+  public final boolean getShowTravelCuesOnIdle()
+  {
+    return showTravelCuesOnIdle;
+  }
+
+  /** Set if cues should be drawn "always" */
+
+  public final void setShowTravelCuesOnIdle(boolean show)
+  {
+    showTravelCuesOnIdle = show;
+    properties.put("showTravelCuesOnIdle", Boolean.toString(show));
+  }
+
+  /** Check if cues should be drawn during scroll movement */
+
+  public final boolean getShowTravelCuesScrolling()
+  {
+    return showTravelCuesScrolling;
+  }
+
+  /** Set if cues should be drawn during scroll movement */
+
+  public final void setShowTravelCuesScrolling(boolean show)
+  {
+    showTravelCuesScrolling = show;
+    properties.put("showTravelCuesScrolling", Boolean.toString(show));
+  }
+ /** Check if the tilt dial is shown */
+
+  public final boolean getShowTiltDial()
+  {
+    return showTiltDial;
+  }
+
+  /** Set if the tilt dial is shown */
+
+  public final void setShowTiltDial(boolean show)
+  {
+    showTiltDial = show;
+    properties.put("showTiltDial", Boolean.toString(show));
   }
 }

--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 2002-2009 by Peter Eastman
-   Changes Copyright (C) 2016 by Petri Ihalainen
+   Changes Copyright (C) 2016-2019 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -27,8 +27,9 @@ public class ApplicationPreferences
   private int defaultDisplayMode, undoLevels;
   private double interactiveTol, maxAnimationDuration, animationFrameRate;
   private boolean keepBackupFiles, useOpenGL, useCompoundMeshTool, reverseZooming, useViewAnimations;
+  private boolean drawActiveFrustum, drawCameraFrustum;
   private Renderer objectPreviewRenderer, texturePreviewRenderer, defaultRenderer;
-
+  
   /**
    * Create a new ApplicationPreferences object, loading the preferences from a
    * file in the default location.
@@ -145,6 +146,8 @@ public class ApplicationPreferences
 	useViewAnimations = true;
 	maxAnimationDuration = 1.0;
 	animationFrameRate = 60.0;
+    drawActiveFrustum = true;
+    drawCameraFrustum = true;
   }
 
   /** Parse the properties loaded from the preferences file. */
@@ -162,11 +165,13 @@ public class ApplicationPreferences
     keepBackupFiles = parseBooleanProperty("keepBackupFiles", keepBackupFiles);
     useCompoundMeshTool = parseBooleanProperty("useCompoundMeshTool", useCompoundMeshTool);
     reverseZooming = parseBooleanProperty("reverseZooming", reverseZooming);
-	
+
     useViewAnimations = parseBooleanProperty("useViewAnimations", useViewAnimations);
     maxAnimationDuration = parseDoubleProperty("maxAnimationDuration", maxAnimationDuration);
     animationFrameRate = parseDoubleProperty("animationFrameRate", animationFrameRate);
-	
+    drawActiveFrustum = parseBooleanProperty("drawActiveFrustum", drawActiveFrustum);
+    drawCameraFrustum = parseBooleanProperty("drawCameraFrustum", drawCameraFrustum);
+
     Translate.setLocale(parseLocaleProperty("language"));
     if (properties.getProperty("theme") == null)
     {
@@ -491,5 +496,35 @@ public class ApplicationPreferences
   {
     animationFrameRate = rate;
 	properties.put("animationFrameRate", Double.toString(rate));
+  }
+
+  /** Check if the movement of the handled view should be visualized on other views */
+  
+  public final boolean getDrawActiveFrustum()
+  {
+    return drawActiveFrustum;
+  }
+  
+  /** Set if the movement of the handled view should be visualized on other views */
+  
+  public final void setDrawActiveFrustum(boolean draw)
+  {
+    drawActiveFrustum = draw;
+    properties.put("drawActiveFrustum", Boolean.toString(draw));
+  }
+  
+  /** Check if the movement of the handled camera should be visualized on other views */
+  
+  public final boolean getDrawCameraFrustum()
+  {
+    return drawCameraFrustum;
+  }
+
+  /** Set if the movement of the handled camera should be visualized on other views */
+  
+  public final void setDrawCameraFrustum(boolean draw)
+  {
+    drawCameraFrustum = draw;
+    properties.put("drawCameraFrustum", Boolean.toString(draw));
   }
 }

--- a/ArtOfIllusion/src/artofillusion/CurveViewer.java
+++ b/ArtOfIllusion/src/artofillusion/CurveViewer.java
@@ -43,24 +43,21 @@ public class CurveViewer extends MeshViewer
     for (int i = 0; i < wireframe.from.length; i++)
       renderLine(wireframe.vert[wireframe.from[i]], wireframe.vert[wireframe.to[i]], theCamera, lineColor);
 
-	//if (animation == null ||  !animation.changingPerspective()) // mismatch at animation
-	//{
-      for (int i = 0; i < v.length; i++)
-        if (!selected[i] && theCamera.getObjectToView().timesZ(v[i].r) > theCamera.getClipDistance())
-        {
-          Vec2 p = theCamera.getObjectToScreen().timesXY(v[i].r);
-          double z = theCamera.getObjectToView().timesZ(v[i].r);
-          renderBox(((int) p.x) - HANDLE_SIZE/2, ((int) p.y) - HANDLE_SIZE/2, HANDLE_SIZE, HANDLE_SIZE, z, lineColor);
-        }
-      Color col = (currentTool.hilightSelection() ? highlightColor : lineColor);
-      for (int i = 0; i < v.length; i++)
-        if (selected[i] && theCamera.getObjectToView().timesZ(v[i].r) > theCamera.getClipDistance())
-        {
-          Vec2 p = theCamera.getObjectToScreen().timesXY(v[i].r);
-          double z = theCamera.getObjectToView().timesZ(v[i].r);
-          renderBox(((int) p.x) - HANDLE_SIZE/2, ((int) p.y) - HANDLE_SIZE/2, HANDLE_SIZE, HANDLE_SIZE, z, col);
-        }
-	//}
+    for (int i = 0; i < v.length; i++)
+      if (!selected[i] && theCamera.getObjectToView().timesZ(v[i].r) > theCamera.getClipDistance())
+      {
+        Vec2 p = theCamera.getObjectToScreen().timesXY(v[i].r);
+        double z = theCamera.getObjectToView().timesZ(v[i].r);
+        renderBox(((int) p.x) - HANDLE_SIZE/2, ((int) p.y) - HANDLE_SIZE/2, HANDLE_SIZE, HANDLE_SIZE, z, lineColor);
+      }
+    Color col = (currentTool.hilightSelection() ? highlightColor : lineColor);
+    for (int i = 0; i < v.length; i++)
+      if (selected[i] && theCamera.getObjectToView().timesZ(v[i].r) > theCamera.getClipDistance())
+      {
+        Vec2 p = theCamera.getObjectToScreen().timesXY(v[i].r);
+        double z = theCamera.getObjectToView().timesZ(v[i].r);
+        renderBox(((int) p.x) - HANDLE_SIZE/2, ((int) p.y) - HANDLE_SIZE/2, HANDLE_SIZE, HANDLE_SIZE, z, col);
+      }
   }
 
   /** When the user presses the mouse, forward events to the current tool as appropriate.

--- a/ArtOfIllusion/src/artofillusion/CurveViewer.java
+++ b/ArtOfIllusion/src/artofillusion/CurveViewer.java
@@ -14,6 +14,7 @@ package artofillusion;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -82,9 +83,9 @@ public class CurveViewer extends MeshViewer
 
     // Determine which tool is active.
 
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
-    else if (altTool != null && e.isAltDown())
+    else if (altTool != null && mouseButtonTwo(e))
       activeTool = altTool;
     else
       activeTool = currentTool;

--- a/ArtOfIllusion/src/artofillusion/MaterialPreviewer.java
+++ b/ArtOfIllusion/src/artofillusion/MaterialPreviewer.java
@@ -16,6 +16,7 @@ import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.texture.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -347,9 +348,9 @@ public class MaterialPreviewer extends CustomWidget implements RenderListener
     Point dragPoint = e.getPoint();
     if (!clickPoint.equals(dragPoint))
     {
-      if (e.isMetaDown())
+      if (mouseButtonThree(e))
       {
-        if (e.isControlDown())
+         if (e.isControlDown())
           dragTransform = Mat4.translation(0.0, 0.0, (dragPoint.y-clickPoint.y)*0.01);
         else
           dragTransform = Mat4.translation((dragPoint.x-clickPoint.x)*0.01, (clickPoint.y-dragPoint.y)*0.01, 0.0);
@@ -380,9 +381,9 @@ public class MaterialPreviewer extends CustomWidget implements RenderListener
       return;
     Graphics g = getComponent().getGraphics();
     Point dragPoint = e.getPoint();
-    if (e.isMetaDown())
+    if (mouseButtonThree(e))
     {
-      if (e.isControlDown())
+       if (e.isControlDown())
         dragTransform = Mat4.translation(0.0, 0.0, (dragPoint.y-clickPoint.y)*0.01);
       else
         dragTransform = Mat4.translation((dragPoint.x-clickPoint.x)*0.01, (clickPoint.y-dragPoint.y)*0.01, 0.0);

--- a/ArtOfIllusion/src/artofillusion/MeshViewer.java
+++ b/ArtOfIllusion/src/artofillusion/MeshViewer.java
@@ -258,20 +258,13 @@ public abstract class MeshViewer extends ObjectViewer
 
 	CoordinateSystem newCoords = theCamera.getCameraCoordinates().duplicate();
 	int d = Math.min(getBounds().width, getBounds().height);
-
+	double newDistToPlane = 100*theCamera.getDistToScreen() / (double)d / 0.9 * boneLength;
+	newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane)));
+	double newScale;
 	if (perspective)
-	{
-		double newDistToPlane = 2000 / (double)d / 0.9 * boneLength;
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane)));
-
-		animation.start(newCoords, newCenter, scale, orientation, navigation);
-	}
+		newScale = 100.0;
 	else
-	{
-		newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-distToPlane)));
-		double newScale = (double)d * 0.9 / boneLength; // with minimum 5% margins
-
-		animation.start(newCoords, newCenter, newScale, orientation, navigation);
-	}
+		newScale = 100.0*theCamera.getDistToScreen()/newDistToPlane;
+	animation.start(newCoords, newCenter, newScale, orientation, navigation);
   }
 }

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -117,7 +117,12 @@ public class MoveViewTool extends EditingTool
 		}
 		if (view.getBoundCamera() != null)
 			view.getBoundCamera().getCoords().copyCoords(view.getCamera().getCameraCoordinates());
-		view.repaint();
+		view.frustumShape.update();
+		if (ArtOfIllusion.getPreferences().getDrawActiveFrustum() || 
+		   (ArtOfIllusion.getPreferences().getDrawCameraFrustum() && view.getBoundCamera() != null))
+			theWindow.updateImage();
+		else
+			view.repaint();
 		view.viewChanged(false);
 	}
 

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -115,6 +115,8 @@ public class MoveViewTool extends EditingTool
 					break;
 			}
 		}
+		if (view.getBoundCamera() != null)
+			view.getBoundCamera().getCoords().copyCoords(view.getCamera().getCameraCoordinates());
 		view.repaint();
 		view.viewChanged(false);
 	}
@@ -190,21 +192,25 @@ public class MoveViewTool extends EditingTool
 
 
 		if (controlDown) // zoom!
-		{ 	
+		{
+			double newDist;
+			Rectangle bounds = view.getBounds();
 			if (view.isPerspective())
 			{
-				CoordinateSystem coords = view.getCamera().getCameraCoordinates();
-				double newDist = oldDist*Math.pow(1.0/1.01, (double)dy);
-				Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
-				coords.setOrigin(newPos);
-				view.getCamera().setCameraCoordinates(coords);
-				view.setDistToPlane(newDist);
+				newDist = oldDist*Math.pow(1.0/1.01, (double)dy);
 			}
 			else
 			{
 				double newScale = oldScale*(Math.pow(1.01,(double)dy));
 				view.setScale(newScale);
+				cam.setScreenParamsParallel(newScale, bounds.width, bounds.height);
+				newDist = cam.getDistToScreen()*100.0/newScale;
 			}
+			view.setDistToPlane(newDist);
+			CoordinateSystem coords = view.getCamera().getCameraCoordinates();
+			Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-newDist));
+			coords.setOrigin(newPos);
+			view.getCamera().setCameraCoordinates(coords);
 		}
 		else // Move up-down-right-left
 		{

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -11,9 +11,11 @@
 
 package artofillusion;
 
+import static artofillusion.ViewerCanvas.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import artofillusion.texture.UVMappingWindow;
 import buoy.event.*;
 import java.awt.*;
@@ -65,8 +67,7 @@ public class MoveViewTool extends EditingTool
   {
     Camera cam = view.getCamera();
 
-	selectedNavigation = view.getNavigationMode();
-    controlDown = e.isControlDown();
+    selectedNavigation = view.getNavigationMode();
     clickPoint = e.getPoint();
     clickPos = cam.convertScreenToWorld(clickPoint, view.getDistToPlane());
     oldCoords = cam.getCameraCoordinates().duplicate();
@@ -74,15 +75,17 @@ public class MoveViewTool extends EditingTool
     oldRotCenter = new Vec3(view.getRotationCenter());
     oldScale = view.getScale();
     oldDist = view.getDistToPlane(); // distToPlane needs to be kept up to date
-	view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(oldDist)));
+    view.setRotationCenter(oldCoords.getOrigin().plus(oldCoords.getZDirection().times(oldDist)));
 	
-	if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
-	    !e.isAltDown() && !e.isMetaDown()){
-		if (view.getNavigationMode() > 3)
-			view.setNavigationMode(0);
-		else if (view.getNavigationMode() > 1)
-			view.setNavigationMode(view.getNavigationMode()-2, true);
-	}
+     if (theWindow != null
+         && theWindow.getToolPalette().getSelectedTool() == this
+         && mouseButtonOne(e))
+     {
+       if (view.getNavigationMode() > 3)
+         view.setNavigationMode(NAVIGATE_MODEL_SPACE);
+       else if (view.getNavigationMode() > 1)
+         view.setNavigationMode(view.getNavigationMode()-2, true);
+     }
 	view.mouseDown = true;
 	view.moving = true;
   }
@@ -90,18 +93,21 @@ public class MoveViewTool extends EditingTool
 	@Override
 	public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
 	{
-		// If the tool is selected in the tool palette
-		if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
-			dragMoveModel(e, view);
+		// If the MoveView tool is selected in the tool palette
+		if (theWindow != null
+                   && theWindow.getToolPalette().getSelectedTool() == this
+                   && mouseButtonOne(e))
+		  dragMoveModel(e, view);
+		// else work according to navigation mode selection
 		else
 		{
 			switch (view.getNavigationMode()) {
-				case ViewerCanvas.NAVIGATE_MODEL_SPACE:
-				case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
+				case NAVIGATE_MODEL_SPACE:
+				case NAVIGATE_MODEL_LANDSCAPE:
 					dragMoveModel(e, view);
 					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
-				case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
+				case NAVIGATE_TRAVEL_SPACE:
+				case NAVIGATE_TRAVEL_LANDSCAPE:
 					dragMoveTravel(e, view);
 					break;
 				default:
@@ -126,7 +132,8 @@ public class MoveViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown) // forward move!
+
+		if (mouseButtonThree(e) && e.isControlDown()) // forward move!
 		{ 	
 			Vec3 hDir;
 			if (view.getNavigationMode() == 3)
@@ -181,7 +188,9 @@ public class MoveViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown) // zoom!
+		
+
+		if (mouseButtonThree(e) && !mouseButtonTwo(e) && e.isControlDown()) // zoom!
 		{ 	
 			if (view.isPerspective())
 			{

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2007 by Peter Eastman
-   Changes copyright (C) 2016-2017 by Petri Ihalainen
+   Changes copyright (C) 2016-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -115,9 +115,8 @@ public class MoveViewTool extends EditingTool
 					break;
 			}
 		}
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		view.viewChanged(false);	
+		view.repaint();
+		view.viewChanged(false);
 	}
 
 	/* The view must be set to Perspective for travel modes! */
@@ -250,7 +249,6 @@ public class MoveViewTool extends EditingTool
         }
         theWindow.updateImage();
       }
-	wipeAuxGraphs();
 	view.viewChanged(false);
   }
 
@@ -265,38 +263,5 @@ public class MoveViewTool extends EditingTool
       undo.addCommand(UndoRecord.COPY_COORDS, new Object [] {coords, oldCoords});
       moveChildren(parent.getChildren()[i], transform, undo);
     }  
-  }
-
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (theWindow == null || theWindow instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : theWindow.getAllViews())
-	  	v.repaint();
-  }
-
-  private void setAuxGraphs(ViewerCanvas view)
-  {
-
-	if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-        if (v != view)
-	      v.auxGraphs.set(view, true);
-  }
-  
-  private void wipeAuxGraphs()
-  {
-    if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-		v.auxGraphs.wipe();
-  }
-
-  @Override
-  public void drawOverlay(ViewerCanvas view)
-  {
-     if (view.moving){
-       //view.drawLine(new Point (0,0), new Point (100, 100), Color.MAGENTA);
-	 }
   }
 }

--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -67,6 +67,7 @@ public class MoveViewTool extends EditingTool
   {
     Camera cam = view.getCamera();
 
+    controlDown = e.isControlDown();
     selectedNavigation = view.getNavigationMode();
     clickPoint = e.getPoint();
     clickPos = cam.convertScreenToWorld(clickPoint, view.getDistToPlane());
@@ -133,7 +134,7 @@ public class MoveViewTool extends EditingTool
 		dy = dragPoint.y-clickPoint.y;
 
 
-		if (mouseButtonThree(e) && e.isControlDown()) // forward move!
+		if (controlDown) // forward move!
 		{ 	
 			Vec3 hDir;
 			if (view.getNavigationMode() == 3)
@@ -188,9 +189,8 @@ public class MoveViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		
 
-		if (mouseButtonThree(e) && !mouseButtonTwo(e) && e.isControlDown()) // zoom!
+		if (controlDown) // zoom!
 		{ 	
 			if (view.isPerspective())
 			{

--- a/ArtOfIllusion/src/artofillusion/ObjectPreviewCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectPreviewCanvas.java
@@ -12,6 +12,7 @@ package artofillusion;
 
 import artofillusion.math.*;
 import artofillusion.object.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -161,7 +162,7 @@ public class ObjectPreviewCanvas extends ViewerCanvas
   {
     requestFocus();
     activeTool = currentTool;
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
     activeTool.mousePressed(e, this);
   }

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2008 by Peter Eastman
-   Modifications copyright (C) 2017 Petri Ihalainen
+   Modifications copyright (C) 2017-2019 Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -189,7 +189,6 @@ public abstract class ObjectViewer extends ViewerCanvas
         drawImage(renderedImage, 0, 0);
       else
         viewChanged(false);
-      drawOverlay();
       drawBorder();
       if (showAxes)
         drawCoordinateAxes();
@@ -224,12 +223,14 @@ public abstract class ObjectViewer extends ViewerCanvas
 
     // Finish up.
 
-    drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
+    if (controller instanceof ObjectEditorWindow)
+        for(ViewerCanvas v : ((ObjectEditorWindow)controller).getAllViews())
+            v.drawOverlay(this);
     if (showAxes)
-      drawCoordinateAxes();
+        drawCoordinateAxes();
     drawBorder();
   }
 

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -503,13 +503,4 @@ public abstract class ObjectViewer extends ViewerCanvas
     theCamera.setCameraCoordinates(cameraCoords);
     adjustCamera(isPerspective());
   }
-  
-   	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		((EditingWindow)controller).updateImage();
-	}
 }

--- a/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
+++ b/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 2002-2009 by Peter Eastman
-   Changes Copyright (C) 2016 by Petri Ihalainen
+   Changes Copyright (C) 2016-2019 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -27,6 +27,7 @@ public class PreferencesWindow
 {
   private BComboBox defaultRendChoice, objectRendChoice, texRendChoice, localeChoice, themeChoice, colorChoice, toolChoice;
   private ValueField interactiveTolField, undoField, animationDurationField, animationFrameRateField;
+  private BCheckBox drawActiveFrustumBox, drawCameraFrustumBox;
   private BCheckBox glBox, backupBox, reverseZoomBox, useViewAnimationsBox;
   private List<ThemeManager.ThemeInfo> themes;
   private static int lastTab;
@@ -77,10 +78,13 @@ public class PreferencesWindow
     prefs.setKeepBackupFiles(backupBox.getState());
     prefs.setReverseZooming(reverseZoomBox.getState());
     prefs.setUseViewAnimations(useViewAnimationsBox.getState());
-	prefs.setMaxAnimationDuration(animationDurationField.getValue());
-	prefs.setAnimationFrameRate(animationFrameRateField.getValue());
+    prefs.setMaxAnimationDuration(animationDurationField.getValue());
+    prefs.setAnimationFrameRate(animationFrameRateField.getValue());
+    prefs.setDrawActiveFrustum(drawActiveFrustumBox.getState());
+    prefs.setDrawCameraFrustum(drawCameraFrustumBox.getState());
+
     prefs.setUseCompoundMeshTool(toolChoice.getSelectedIndex() == 1);
-	
+
     ThemeManager.setSelectedTheme(themes.get(themeChoice.getSelectedIndex()));
     ThemeManager.setSelectedColorSet(ThemeManager.getSelectedTheme().getColorSets()[colorChoice.getSelectedIndex()]);
     prefs.savePreferences();
@@ -121,9 +125,8 @@ public class PreferencesWindow
     useViewAnimationsBox =  new BCheckBox(Translate.text("useViewAnimations"), prefs.getUseViewAnimations());
     animationDurationField = new ValueField(prefs.getMaxAnimationDuration(), ValueField.POSITIVE);
     animationFrameRateField = new ValueField(prefs.getAnimationFrameRate(), ValueField.POSITIVE);
-
-	//useViewAnimationsBox.addEventLink(ValueChangedEvent.class, this, "useViewAnimationsChanged");
-	//animationDurationField.addEventLink(ValueChangedEvent.class, this, "animationDurationChanged");
+    drawActiveFrustumBox = new BCheckBox(Translate.text("drawActiveFrustum"), prefs.getDrawActiveFrustum());
+    drawCameraFrustumBox = new BCheckBox(Translate.text("drawCameraFrustum"), prefs.getDrawCameraFrustum());
 
     themes = new ArrayList<ThemeManager.ThemeInfo>();
     for (ThemeManager.ThemeInfo theme: ThemeManager.getThemes())
@@ -178,8 +181,7 @@ public class PreferencesWindow
     }
 
     // Layout the panel.
-
-    FormContainer panel = new FormContainer(2, 16);
+    FormContainer panel = new FormContainer(2, 18);
     panel.setColumnWeight(1, 1.0);
     LayoutInfo labelLayout = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(2, 0, 2, 5), null);
     LayoutInfo widgetLayout = new LayoutInfo(LayoutInfo.WEST, LayoutInfo.BOTH, new Insets(2, 0, 2, 0), null);
@@ -206,13 +208,17 @@ public class PreferencesWindow
     panel.add(backupBox, 0, 10, 2, 1, centerLayout);
     panel.add(localeChoice, 1, 11, widgetLayout);
     panel.add(new BLabel(" "), 1, 12, labelLayout);
-	panel.add(useViewAnimationsBox, 1, 13, widgetLayout);
-	panel.add(Translate.label("maxAnimationDuration"), 0, 14, labelLayout);
-	panel.add(Translate.label("animationFrameRate"), 0, 15, labelLayout);
-	panel.add(animationDurationField, 1, 14, widgetLayout);
-	panel.add(animationFrameRateField, 1, 15, widgetLayout);
-	//animationDurationField.setEnabled(false);
-	//animationFrameRateField.setEnabled(false);
+    panel.add(useViewAnimationsBox, 1, 13, widgetLayout);
+    panel.add(Translate.label("maxAnimationDuration"), 0, 14, labelLayout);
+    panel.add(Translate.label("animationFrameRate"), 0, 15, labelLayout);
+    panel.add(animationDurationField, 1, 14, widgetLayout);
+    panel.add(animationFrameRateField, 1, 15, widgetLayout);
+    panel.add(drawActiveFrustumBox, 0, 16, 2 ,1, centerLayout);
+    panel.add(drawCameraFrustumBox, 0, 17, 2, 1, centerLayout);
+
+    drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState()); 
+    drawActiveFrustumBox.addEventLink(ValueChangedEvent.class, new Object(){void processEvent(){
+                         drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState());}});
     return panel;
   }
 

--- a/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
+++ b/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
@@ -27,10 +27,13 @@ public class PreferencesWindow
 {
   private BComboBox defaultRendChoice, objectRendChoice, texRendChoice, localeChoice, themeChoice, colorChoice, toolChoice;
   private ValueField interactiveTolField, undoField, animationDurationField, animationFrameRateField;
-  private BCheckBox drawActiveFrustumBox, drawCameraFrustumBox;
+  private BCheckBox drawActiveFrustumBox, drawCameraFrustumBox, showTravelCuesOnIdleBox, showTravelCuesScrollingBox;
+  private BCheckBox showTiltDialBox;
   private BCheckBox glBox, backupBox, reverseZoomBox, useViewAnimationsBox;
   private List<ThemeManager.ThemeInfo> themes;
   private static int lastTab;
+  private ApplicationPreferences prefs;
+  private boolean cameraFrustumState, travelCuesState;
   
   public PreferencesWindow(BFrame parent)
   {
@@ -56,7 +59,7 @@ public class PreferencesWindow
           done = false;
       }
     }
-    ApplicationPreferences prefs = ArtOfIllusion.getPreferences();
+    prefs = ArtOfIllusion.getPreferences();
     Locale languages[] = Translate.getAvailableLocales();
     List<Renderer> renderers = PluginRegistry.getPlugins(Renderer.class);
     if (renderers.size() > 0)
@@ -81,7 +84,10 @@ public class PreferencesWindow
     prefs.setMaxAnimationDuration(animationDurationField.getValue());
     prefs.setAnimationFrameRate(animationFrameRateField.getValue());
     prefs.setDrawActiveFrustum(drawActiveFrustumBox.getState());
-    prefs.setDrawCameraFrustum(drawCameraFrustumBox.getState());
+    prefs.setDrawCameraFrustum(cameraFrustumState);
+    prefs.setShowTravelCuesOnIdle(showTravelCuesOnIdleBox.getState());
+    prefs.setShowTravelCuesScrolling(travelCuesState);
+    prefs.setShowTiltDial(showTiltDialBox.getState());
 
     prefs.setUseCompoundMeshTool(toolChoice.getSelectedIndex() == 1);
 
@@ -125,8 +131,69 @@ public class PreferencesWindow
     useViewAnimationsBox =  new BCheckBox(Translate.text("useViewAnimations"), prefs.getUseViewAnimations());
     animationDurationField = new ValueField(prefs.getMaxAnimationDuration(), ValueField.POSITIVE);
     animationFrameRateField = new ValueField(prefs.getAnimationFrameRate(), ValueField.POSITIVE);
-    drawActiveFrustumBox = new BCheckBox(Translate.text("drawActiveFrustum"), prefs.getDrawActiveFrustum());
-    drawCameraFrustumBox = new BCheckBox(Translate.text("drawCameraFrustum"), prefs.getDrawCameraFrustum());
+    drawActiveFrustumBox = new BCheckBox(Translate.text("anyActiveView"), prefs.getDrawActiveFrustum());
+    cameraFrustumState = prefs.getDrawCameraFrustum();
+    drawCameraFrustumBox = new BCheckBox(Translate.text("cameraView"), cameraFrustumState);
+    showTravelCuesOnIdleBox = new BCheckBox(Translate.text("onIdle"), prefs.getShowTravelCuesOnIdle());
+    travelCuesState = prefs.getShowTravelCuesScrolling();
+    showTravelCuesScrollingBox = new BCheckBox(Translate.text("duringScrolling"), travelCuesState);
+    showTiltDialBox = new BCheckBox(Translate.text("ShowTiltDial"), prefs.getShowTiltDial());
+    
+    useViewAnimationsBox.addEventLink(ValueChangedEvent.class, 
+      new Object(){void processEvent()
+      {
+        animationDurationField.setEnabled(useViewAnimationsBox.getState());
+        animationFrameRateField.setEnabled(useViewAnimationsBox.getState());
+      }}
+    );
+
+    // Interaction between frustum checkboxes
+
+    drawActiveFrustumBox.addEventLink(ValueChangedEvent.class, 
+      new Object(){void processEvent()
+      {
+        drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState());
+        if (drawActiveFrustumBox.getState())
+          drawCameraFrustumBox.setState(drawActiveFrustumBox.getState());
+        else
+          drawCameraFrustumBox.setState(cameraFrustumState);
+      }}
+    );
+    drawCameraFrustumBox.addEventLink(ValueChangedEvent.class, 
+      new Object(){void processEvent()
+      {
+        cameraFrustumState = drawCameraFrustumBox.getState();
+      }}
+    );
+    if (drawActiveFrustumBox.getState())
+    {
+        drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState()); 
+        drawCameraFrustumBox.setState(drawActiveFrustumBox.getState()); 
+    }
+
+    // Interaction between scroll cue checkboxes
+
+    showTravelCuesOnIdleBox.addEventLink(ValueChangedEvent.class, 
+      new Object(){void processEvent()
+      {
+        showTravelCuesScrollingBox.setEnabled(! showTravelCuesOnIdleBox.getState());
+        if (showTravelCuesOnIdleBox.getState())
+          showTravelCuesScrollingBox.setState(showTravelCuesOnIdleBox.getState());
+        else
+          showTravelCuesScrollingBox.setState(travelCuesState);
+      }}
+    );
+    showTravelCuesScrollingBox.addEventLink(ValueChangedEvent.class, 
+      new Object(){void processEvent()
+      {
+        travelCuesState = showTravelCuesScrollingBox.getState();
+      }}
+    );
+    if (showTravelCuesOnIdleBox.getState())
+    {
+        showTravelCuesScrollingBox.setEnabled(! showTravelCuesOnIdleBox.getState()); 
+        showTravelCuesScrollingBox.setState(showTravelCuesOnIdleBox.getState()); 
+    }
 
     themes = new ArrayList<ThemeManager.ThemeInfo>();
     for (ThemeManager.ThemeInfo theme: ThemeManager.getThemes())
@@ -181,44 +248,54 @@ public class PreferencesWindow
     }
 
     // Layout the panel.
-    FormContainer panel = new FormContainer(2, 18);
-    panel.setColumnWeight(1, 1.0);
-    LayoutInfo labelLayout = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(2, 0, 2, 5), null);
+
+    FormContainer panel = new FormContainer(3, 20);
+    LayoutInfo labelLayout = new LayoutInfo(LayoutInfo.EAST, LayoutInfo.NONE, new Insets(2, 5, 2, 5), null);
     LayoutInfo widgetLayout = new LayoutInfo(LayoutInfo.WEST, LayoutInfo.BOTH, new Insets(2, 0, 2, 0), null);
     LayoutInfo centerLayout = new LayoutInfo(LayoutInfo.CENTER, LayoutInfo.NONE, new Insets(2, 0, 2, 0), null);
-    panel.add(Translate.label("defaultRenderer"), 0, 0, labelLayout);
-    panel.add(Translate.label("objPreviewRenderer"), 0, 1, labelLayout);
-    panel.add(Translate.label("texPreviewRenderer"), 0, 2, labelLayout);
-    panel.add(Translate.label("selectedTheme"), 0, 3, labelLayout);
-    panel.add(Translate.label("themeColorSet"), 0, 4, labelLayout);
-    panel.add(Translate.label("defaultMeshEditingTool"), 0, 5, labelLayout);
-    panel.add(Translate.label("interactiveSurfError"), 0, 6, labelLayout);
-    panel.add(Translate.label("maxUndoLevels"), 0, 7, labelLayout);
-    panel.add(Translate.label("language"), 0, 11, labelLayout);
-    panel.add(defaultRendChoice, 1, 0, widgetLayout);
-    panel.add(objectRendChoice, 1, 1, widgetLayout);
-    panel.add(texRendChoice, 1, 2, widgetLayout);
-    panel.add(themeChoice, 1, 3, widgetLayout);
-    panel.add(colorChoice, 1, 4, widgetLayout);
-    panel.add(toolChoice, 1, 5, widgetLayout);
-    panel.add(interactiveTolField, 1, 6, widgetLayout);
-    panel.add(undoField, 1, 7, widgetLayout);
-    panel.add(reverseZoomBox, 0, 8, 2, 1, centerLayout);
-    panel.add(glBox, 0, 9, 2, 1, centerLayout);
-    panel.add(backupBox, 0, 10, 2, 1, centerLayout);
-    panel.add(localeChoice, 1, 11, widgetLayout);
-    panel.add(new BLabel(" "), 1, 12, labelLayout);
-    panel.add(useViewAnimationsBox, 1, 13, widgetLayout);
-    panel.add(Translate.label("maxAnimationDuration"), 0, 14, labelLayout);
-    panel.add(Translate.label("animationFrameRate"), 0, 15, labelLayout);
-    panel.add(animationDurationField, 1, 14, widgetLayout);
-    panel.add(animationFrameRateField, 1, 15, widgetLayout);
-    panel.add(drawActiveFrustumBox, 0, 16, 2 ,1, centerLayout);
-    panel.add(drawCameraFrustumBox, 0, 17, 2, 1, centerLayout);
 
-    drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState()); 
-    drawActiveFrustumBox.addEventLink(ValueChangedEvent.class, new Object(){void processEvent(){
-                         drawCameraFrustumBox.setEnabled(! drawActiveFrustumBox.getState());}});
+    panel.setColumnWeight(0, 0.0);
+    panel.setColumnWeight(1, 0.0);
+    panel.setColumnWeight(2, 3.0);
+
+    panel.add(Translate.label("language"), 0, 0, labelLayout);
+    panel.add(Translate.label("defaultRenderer"), 0, 1, labelLayout);
+    panel.add(Translate.label("objPreviewRenderer"), 0, 2, labelLayout);
+    panel.add(Translate.label("texPreviewRenderer"), 0, 3, labelLayout);
+    panel.add(Translate.label("selectedTheme"), 0, 4, labelLayout);
+    panel.add(Translate.label("themeColorSet"), 0, 5, labelLayout);
+    panel.add(Translate.label("defaultMeshEditingTool"), 0, 6, labelLayout);
+    panel.add(Translate.label("maxUndoLevels"), 0, 7, labelLayout);
+    panel.add(Translate.label("interactiveSurfError"), 0,11, labelLayout);
+
+    panel.add(localeChoice, 1, 0, widgetLayout);
+    panel.add(defaultRendChoice, 1, 1, widgetLayout);
+    panel.add(objectRendChoice, 1, 2, widgetLayout);
+    panel.add(texRendChoice, 1, 3, widgetLayout);
+    panel.add(themeChoice, 1, 4, widgetLayout);
+    panel.add(colorChoice, 1, 5, widgetLayout);
+    panel.add(toolChoice, 1, 6, widgetLayout);
+    panel.add(undoField, 1, 7, widgetLayout);
+    panel.add(backupBox, 1, 8, 2, 1, widgetLayout);
+    panel.add(reverseZoomBox, 1, 9, 2, 1, widgetLayout);
+    panel.add(glBox, 1, 10, 2, 1, widgetLayout);
+    panel.add(interactiveTolField, 1, 11, widgetLayout);
+    panel.add(useViewAnimationsBox, 1, 12, 2, 1, widgetLayout);
+
+    panel.add(Translate.label("maxAnimationDuration"), 0, 13, labelLayout);
+    panel.add(Translate.label("animationFrameRate"), 0, 14, labelLayout);
+    panel.add(animationDurationField, 1, 13, widgetLayout);
+    panel.add(animationFrameRateField, 1, 14, widgetLayout);
+
+    panel.add(Translate.label("DisplayViewFrustumOf"), 0, 15, labelLayout);
+    panel.add(drawActiveFrustumBox, 1, 15, 2, 1, widgetLayout);
+    panel.add(drawCameraFrustumBox, 1, 16, 2, 1, widgetLayout);
+
+    panel.add(Translate.label("ShowTravelScrollCues"), 0, 17, labelLayout);
+    panel.add(showTravelCuesOnIdleBox, 1, 17, 2, 1, widgetLayout);
+    panel.add(showTravelCuesScrollingBox, 1, 18, 2, 1, widgetLayout);
+    panel.add(showTiltDialBox, 1, 19, 2, 1, widgetLayout);
+
     return panel;
   }
 

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -421,17 +421,13 @@ public class RotateViewTool extends EditingTool
   private void tilt(WidgetMouseEvent e, ViewerCanvas view, Point clickPoint)
   {
 	int d = Math.min(view.getBounds().width, view.getBounds().height);
-	r = d*0.45;
 	int cx = view.getBounds().width/2;
 	int cy = view.getBounds().height/2;
 	viewCenter = new Point(cx, cy);
 	
 	double aClick = Math.atan2(clickPoint.y-cy, clickPoint.x-cx);
-	p0 = new Point((int)(r*Math.cos(aClick)+cx), (int)(r*Math.sin(aClick))+cy);
-	
 	Point dragPoint = e.getPoint();
 	double aDrag = Math.atan2(dragPoint.y-cy, dragPoint.x-cx);
-	p1 = new Point((int)(r*Math.cos(aDrag))+cx, (int)(r*Math.sin(aDrag))+cy);
 	
 	Vec3 axis = viewToWorld.timesDirection(Vec3.vz());
 	
@@ -564,25 +560,22 @@ public class RotateViewTool extends EditingTool
 	}
   }
 
-  @Override
-  public void drawOverlay(ViewerCanvas view)
-  {
-    if (theWindow != null && view.tilting)
+	@Override
+	public void drawOverlay(ViewerCanvas view)
 	{
-	  for (int i=0; i<4; i++)
-		view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.teal);
-	  
-	  view.drawLine(viewCenter, -Math.PI/2.0, r*0.1, r, view.red);
-	  view.drawLine(viewCenter, Math.PI/2.0, r*0.1, r, view.red);
-	  view.drawLine(viewCenter, Math.PI, r*0.1, r, view.blue);
-	  view.drawLine(viewCenter, 0.0, r*0.1, r, view.blue);
-	  
-	  // draw dial lines
-	  for (int i=0; i<24; i++)
-		view.drawLine(viewCenter, Math.PI/12.0*i+angle, r/.45*.4, r, view.ghost);
+		r = 0.45 * Math.min(view.getBounds().width, view.getBounds().height);
 		
-	  view.drawCircle(viewCenter, r, 48, view.ghost);
-      view.drawCircle(viewCenter, r/.45*.4, 48, view.teal);
+		if (theWindow != null && view.tilting)
+		{
+			for (int i=0; i<4; i++)
+				view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.cueIdle);
+			view.drawLine(viewCenter, -Math.PI/2.0, r, r*1.1, view.red);
+			view.drawLine(viewCenter,  Math.PI/2.0, r, r*1.1, view.red);
+			view.drawLine(viewCenter,  Math.PI    , r, r*1.1, view.blue);
+			view.drawLine(viewCenter,  0.0        , r, r*1.1, view.blue);
+			for (int i=0; i<24; i++) 
+				view.drawLine(viewCenter, Math.PI/12.0*i+angle, r*.95, r, view.cueActive);
+			view.drawCircle(viewCenter, r, 48, view.cueActive);
+		}
 	}
-  }
 }

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -166,12 +166,12 @@ public class RotateViewTool extends EditingTool
 			tilt(e, view, clickPoint);
 			return;
 		}
-		else if (mouseButtonTwo(e))
+		else if (controlDown && e.isShiftDown())
 		{
 			rotateSpace(e, view, clickPoint);
 			return;
 		}
-		else if (mouseButtonThree(e) && e.isShiftDown())
+		else if (!controlDown && e.isShiftDown())
 		{
 			if (Math.abs(dx) > Math.abs(dy))
 			{
@@ -220,7 +220,8 @@ public class RotateViewTool extends EditingTool
 			tilt(e, view, clickPoint);
 			return;
 		}
-		else if (mouseButtonThree(e) && e.isShiftDown()){
+		else if (controlDown && e.isShiftDown())
+		{
 			panSpace(e, view, clickPoint);
 			return;
 		}

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2012 by Peter Eastman
-   Changes copyright (C) 2106-2017 by Petri Ihalainen
+   Changes copyright (C) 2016-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -144,9 +144,8 @@ public class RotateViewTool extends EditingTool
 					break;
 			}
 		}
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		view.viewChanged(false);	
+		view.repaint();
+		view.viewChanged(false);
 	}
 	
 	private void dragRotateTravelSpace(WidgetMouseEvent e, ViewerCanvas view)
@@ -401,7 +400,6 @@ public class RotateViewTool extends EditingTool
 	// This shouls be directly in the ViewerCanvas but it had a side-effect.
 	if (dragPoint.x == clickPoint.x && dragPoint.y == clickPoint.y)
 	    view.centerToPoint(dragPoint);
-	wipeAuxGraphs();
 	view.viewChanged(false);
   }
 
@@ -535,9 +533,6 @@ public class RotateViewTool extends EditingTool
 	int dx = dragPoint.x-clickPoint.x;
 	int dy = dragPoint.y-clickPoint.y;
 
-	//double dragAngleFw = dy*DRAG_SCALE;
-	//if (dragAngleFw > Math.PI) dragAngleFw = Math.PI;
-	//if (dragAngleFw < -Math.PI) dragAngleFw = -Math.PI;
 	Mat4 rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), dy*DRAG_SCALE);
 	rotation = Mat4.axisRotation(vertical, -dx*DRAG_SCALE).times(rotation);
     
@@ -564,34 +559,8 @@ public class RotateViewTool extends EditingTool
 		}
 		else
 			c.transformCoordinates(Mat4.translation(rotationCenter.x, rotationCenter.y, rotationCenter.z));
-    
 		view.getCamera().setCameraCoordinates(c);
 	}
-  }
-
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (theWindow == null || theWindow instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : theWindow.getAllViews())
-	  	v.repaint();
-  }
-
-  private void setAuxGraphs(ViewerCanvas view)
-  {
-
-	if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-        if (v != view)
-	      v.auxGraphs.set(view, true);
-  }
-  
-  private void wipeAuxGraphs()
-  {
-    if (theWindow != null)
-	  for (ViewerCanvas v : theWindow.getAllViews())
-		v.auxGraphs.wipe();
   }
 
   @Override
@@ -599,7 +568,6 @@ public class RotateViewTool extends EditingTool
   {
     if (theWindow != null && view.tilting)
 	{
-	  view.repaint();
 	  for (int i=0; i<4; i++)
 		view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.teal);
 	  

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -568,10 +568,9 @@ public class RotateViewTool extends EditingTool
 	@Override
 	public void drawOverlay(ViewerCanvas view)
 	{
-		r = 0.45 * Math.min(view.getBounds().width, view.getBounds().height);
-		
-		if (theWindow != null && view.tilting)
+		if (theWindow != null && view.tilting && ArtOfIllusion.getPreferences().getShowTiltDial())
 		{
+			r = 0.45 * Math.min(view.getBounds().width, view.getBounds().height);
 			for (int i=0; i<4; i++)
 				view.drawLine(viewCenter, Math.PI/2.0*i+angle, 0.0, r, view.cueIdle);
 			view.drawLine(viewCenter, -Math.PI/2.0, r, r*1.1, view.red);

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -146,7 +146,12 @@ public class RotateViewTool extends EditingTool
 		}
 		if (view.getBoundCamera() != null)
 			view.getBoundCamera().getCoords().copyCoords(view.getCamera().getCameraCoordinates());
-		view.repaint();
+		view.frustumShape.update();
+		if (ArtOfIllusion.getPreferences().getDrawActiveFrustum() || 
+		   (ArtOfIllusion.getPreferences().getDrawCameraFrustum() && view.getBoundCamera() != null))
+			theWindow.updateImage();
+		else
+			view.repaint();
 		view.viewChanged(false);
 	}
 	

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -11,9 +11,11 @@
 
 package artofillusion;
 
+import static artofillusion.ViewerCanvas.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import artofillusion.view.*;
 import artofillusion.texture.UVMappingWindow;
 import buoy.event.*;
@@ -86,10 +88,12 @@ public class RotateViewTool extends EditingTool
     rotationCenter = view.getRotationCenter();
 	distToRot = oldCoords.getOrigin().minus(rotationCenter).length();
 	
-	if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && 
-	    !e.isAltDown() && !e.isMetaDown()){
+	if (theWindow != null
+           && theWindow.getToolPalette().getSelectedTool() == this
+           && mouseButtonOne(e))
+	{
 		if (view.getNavigationMode() > 3)
-			view.setNavigationMode(0);
+			view.setNavigationMode(NAVIGATE_MODEL_SPACE);
 		else if (view.getNavigationMode() > 1)
 			view.setNavigationMode(view.getNavigationMode()-2, true);
 	}
@@ -101,11 +105,13 @@ public class RotateViewTool extends EditingTool
   	public void mouseDragged(WidgetMouseEvent e, ViewerCanvas view)
 	{
 		if (e.getPoint() != clickPoint && view.getBoundCamera() == null) // This is needed even if the mouse has not been dragged yet.
-			view.setOrientation(ViewerCanvas.VIEW_OTHER);
+			view.setOrientation(VIEW_OTHER);
 			
-		if (theWindow != null && theWindow.getToolPalette().getSelectedTool() == this && !e.isAltDown() && !e.isMetaDown())
+		if (theWindow != null
+                   && theWindow.getToolPalette().getSelectedTool() == this
+                   && mouseButtonOne(e))
 		{
-			if (view.getNavigationMode() == 0)
+			if (view.getNavigationMode() == NAVIGATE_MODEL_SPACE)
 				dragRotateSpace(e, view);
 			else if (view.getNavigationMode() == 1)
 			{
@@ -119,19 +125,19 @@ public class RotateViewTool extends EditingTool
 		{
 			switch (view.getNavigationMode()) 
 			{
-				case ViewerCanvas.NAVIGATE_MODEL_SPACE:
+				case NAVIGATE_MODEL_SPACE:
 					dragRotateSpace(e, view);
 					break;
-				case ViewerCanvas.NAVIGATE_MODEL_LANDSCAPE:
+				case NAVIGATE_MODEL_LANDSCAPE:
 					Vec3 zD = oldCoords.getZDirection();
 					fwMax = Math.PI*0.5+Math.asin(zD.y);
 					fwMin = -Math.PI*0.5+Math.asin(zD.y);
 					dragRotateLandscape(e, view);
 					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_SPACE:
+				case NAVIGATE_TRAVEL_SPACE:
 					dragRotateTravelSpace(e, view);
 					break;
-				case ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE:
+				case NAVIGATE_TRAVEL_LANDSCAPE:
 					dragRotateTravelLandscape(e, view);
 					break;
 				default:
@@ -154,18 +160,18 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown && !e.isShiftDown())
+		if (mouseButtonTwo(e) && controlDown)
 		{
 			view.tilting = true;
 			tilt(e, view, clickPoint);
 			return;
 		}
-		else if (controlDown && e.isShiftDown())
+		else if (mouseButtonTwo(e))
 		{
 			rotateSpace(e, view, clickPoint);
 			return;
 		}
-		else if (!controlDown && e.isShiftDown())
+		else if (mouseButtonThree(e) && e.isShiftDown())
 		{
 			if (Math.abs(dx) > Math.abs(dy))
 			{
@@ -208,13 +214,13 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown && !e.isShiftDown())
+		if (mouseButtonTwo(e) && controlDown)
 		{
 			view.tilting = true;
 			tilt(e, view, clickPoint);
 			return;
 		}
-		else if (controlDown && e.isShiftDown()){
+		else if (mouseButtonThree(e) && e.isShiftDown()){
 			panSpace(e, view, clickPoint);
 			return;
 		}

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -471,7 +471,7 @@ public class RotateViewTool extends EditingTool
 	int dy = dragPoint.y-clickPoint.y;
 	double dts = camera.getDistToScreen();
 	
-	if (view.getBoundCamera() != null){
+	if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera){
 		int yp = view.getBounds().height/2;
 		double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
 		dts = Math.tan(fa)*yp/100;

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -144,6 +144,8 @@ public class RotateViewTool extends EditingTool
 					break;
 			}
 		}
+		if (view.getBoundCamera() != null)
+			view.getBoundCamera().getCoords().copyCoords(view.getCamera().getCameraCoordinates());
 		view.repaint();
 		view.viewChanged(false);
 	}
@@ -334,11 +336,10 @@ public class RotateViewTool extends EditingTool
 		}
 		else
 		{
-			if (view.getBoundCamera() != null){
+			if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera)
+			{
 				int yp = view.getBounds().height/2;
 				double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
-				
-				// dts is equivalent to the "distToScreen" parameter on SceneCameras.
 				dts = Math.tan(fa)*yp/100;
 			}
 			rotation = Mat4.axisRotation(viewToWorld.timesDirection(Vec3.vx()), -dy*DRAG_SCALE/dts);
@@ -352,7 +353,7 @@ public class RotateViewTool extends EditingTool
 			c.transformCoordinates(rotation);
 
 			// Prevent tilting forward or back more than 90 degrees.
-			// almost works
+			// With scene camera not always correct
 			if (c.getUpDirection().y < 0.0)
 			{
 				Vec3 upD = new Vec3(c.getUpDirection().x,0.0,c.getUpDirection().z); 

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -309,12 +309,13 @@ public class SceneViewer extends ViewerCanvas
 
     // Finish up.
 
-	drawOverlay();
-	currentTool.drawOverlay(this);
-	if (activeTool != null)
-		activeTool.drawOverlay(this);
+    currentTool.drawOverlay(this);
+    if (activeTool != null)
+        activeTool.drawOverlay(this);
+    for(ViewerCanvas v : parentFrame.getAllViews())
+        v.drawOverlay(this);
     if (showAxes)
-      drawCoordinateAxes();
+        drawCoordinateAxes();
     drawBorder();
 }
 
@@ -552,7 +553,6 @@ public class SceneViewer extends ViewerCanvas
   protected void mouseDragged(WidgetMouseEvent e)
   {
 	mousePoint = e.getPoint();
-	drawOverlay();
     moveToGrid(e);
     if (!dragging)
     {

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -16,6 +16,7 @@ import artofillusion.image.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import artofillusion.view.*;
 import buoy.event.*;
 import buoy.widget.*;
@@ -348,9 +349,9 @@ public class SceneViewer extends ViewerCanvas
 
     // Determine which tool is active.
 
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
-    else if (altTool != null && e.isAltDown())
+    else if (altTool != null && mouseButtonTwo(e))
       activeTool = altTool;
     else
       activeTool = currentTool;

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -1,6 +1,6 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
    Changes copyright (C) 2016-2017 by Maksim Khramov
-   Changes copyright (C) 2017 by Petri Ihalainen
+   Changes copyright (C) 2017-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -34,7 +34,6 @@ public class SceneViewer extends ViewerCanvas
   Point clickPoint, dragPoint;
   ObjectInfo clickedObject;
   int deselect;
-  Vec3 nextCenter = new Vec3();
 
   public SceneViewer(Scene s, RowContainer p, EditingWindow fr)
   {
@@ -107,26 +106,44 @@ public class SceneViewer extends ViewerCanvas
     super.setOrientation(which);
     if (which > 5 && which < 6+cameras.size())
     {
-		ObjectInfo nextCamera = cameras.elementAt(which-6);
-		CoordinateSystem coords = nextCamera.coords.duplicate();
+        ObjectInfo nextCamera = cameras.elementAt(which-6);
+        CoordinateSystem nextCoords = nextCamera.coords.duplicate();
+        double workingDepth, projectionDist, nextScale;
+        Vec3 nextCenter;
 
-		if (nextCamera.getObject() instanceof SceneCamera){
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SceneCamera)nextCamera.getObject()).getDistToPlane())));
-		}
-		else if (nextCamera.getObject() instanceof SpotLight)
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((SpotLight)nextCamera.getObject()).getDistToPlane())));
-		else if (nextCamera.getObject() instanceof DirectionalLight)
-			nextCenter = new Vec3(coords.getOrigin().plus(coords.getZDirection().times(((DirectionalLight)nextCamera.getObject()).getDistToPlane())));
-		else
-			return;
+        // We seriously need a common interface for ViewControlledObjects
+        
+        if (nextCamera.getObject() instanceof SceneCamera)
+            workingDepth = ((SceneCamera)nextCamera.getObject()).getDistToPlane();
+        else if (nextCamera.getObject() instanceof SpotLight)
+            workingDepth = ((SpotLight)nextCamera.getObject()).getDistToPlane();
+        else if (nextCamera.getObject() instanceof DirectionalLight)
+            workingDepth = ((DirectionalLight)nextCamera.getObject()).getDistToPlane();
+        else
+            return;
+        nextCenter = nextCoords.getOrigin().plus(nextCoords.getZDirection().times(workingDepth));
 
-		animation.start(coords, rotationCenter, 100.0, which, navigation);
+        // SceneCamera does not obey the normal rules here. For now it is assumed to be always in perspective mode
+
+        if (boundCamera != null && boundCamera.getObject() instanceof SceneCamera)
+        {
+            double innerAngle = (Math.PI - Math.toRadians(((SceneCamera)boundCamera.getObject()).getFieldOfView()))/2.0;
+            projectionDist = Math.tan(innerAngle)*getBounds().height/2.0/100;
+        }
+        else
+            projectionDist = theCamera.getDistToScreen();
+        if (perspective)
+            nextScale = 100.0;
+        else
+            nextScale = 100.0*projectionDist/workingDepth;
+
+        animation.start(nextCoords, nextCenter, nextScale, which, navigation);
     }
     else
     {
       boundCamera = null;
-	  if (which > 5) // Would have thought that the super takes care of this but not always.
-		orientation = VIEW_OTHER;
+      if (which > 5) // Would have thought that the super takes care of this but not always.
+        orientation = VIEW_OTHER;
       viewChanged(false);
     }
   }
@@ -143,9 +160,6 @@ public class SceneViewer extends ViewerCanvas
     orientation = which;
 	perspective = persp;
 	navigation = navi;
-
-    if (boundCamera != null)
-        boundCamera.setCoords(theCamera.getCameraCoordinates().duplicate());
   }
 
   /** Estimate the range of depth values that the camera will need to render.  This need not be exact,

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -705,8 +705,6 @@ public class SceneViewer extends ViewerCanvas
 
   public void mouseClicked(MouseClickedEvent e)
   {
-	//super.mouseClicked(e);
-	
     if (e.getClickCount() == 2 && (activeTool.whichClicks() & EditingTool.OBJECT_CLICKS) != 0 && clickedObject != null && clickedObject.getObject().isEditable())
     {
       final Object3D obj = clickedObject.getObject();
@@ -723,15 +721,6 @@ public class SceneViewer extends ViewerCanvas
     }
   }
 
- 	@Override
-	protected void mouseMoved(MouseMovedEvent e)
-	{
-		mouseMoving = true;
-		mousePoint = e.getPoint();
-		mouseMoveTimer.restart();
-		parentFrame.updateImage(); // I wonder why, but that's how it works
-	}
-	
   /** This is called recursively to move any children of a bound camera. */
 
   private void moveChildren(ObjectInfo obj, Mat4 transform, UndoRecord undo)

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -84,7 +84,12 @@ public class ScrollViewTool
 		}
 		if (boundCamera != null)
 			boundCamera.getCoords().copyCoords(view.getCamera().getCameraCoordinates());
-		view.repaint();
+		view.frustumShape.update();
+		if (ArtOfIllusion.getPreferences().getDrawActiveFrustum() || 
+		   (ArtOfIllusion.getPreferences().getDrawCameraFrustum() && view.getBoundCamera() != null))
+			window.updateImage();
+		else
+			view.repaint();
 		view.viewChanged(false);
 	}
 
@@ -245,8 +250,4 @@ public class ScrollViewTool
             moveCameraChildren(parent.getChildren()[i], transform, undo);
 		}  
 	}
-	public void drawOverlay()
-    {
-        // This could draw a "ghost" of the bound camera and it's children during scroll
-    }
 }

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -65,9 +65,9 @@ public class ScrollViewTool
 		CoordinateSystem coords = camera.getCameraCoordinates();
         startZ  = new Vec3(coords.getZDirection());
         startUp = new Vec3(coords.getUpDirection());
-		view.setRotationCenter(coords.getOrigin().plus(coords.getZDirection().times(view.getDistToPlane())));
+		view.setRotationCenter(coords.getOrigin().plus(startZ.times(distToPlane)));
 		mousePoint = view.mousePoint = e.getPoint();
-		scrollTimer.restart(); // The timer takes case of teh graphics and updating the children of a camera object
+		scrollTimer.restart(); // The timer takes case of the graphics and updating the children of a camera object
 
 		switch (navigationMode) 
 		{
@@ -108,11 +108,11 @@ public class ScrollViewTool
 			distToPlane = camera.getDistToScreen()*100.0/view.getScale();
 			camera.setScreenParamsParallel(view.getScale(), bounds.width, bounds.height);
 		}
-		view.setDistToPlane(distToPlane);
 		CoordinateSystem coords = camera.getCameraCoordinates();
 		Vec3 newPos = view.getRotationCenter().plus(coords.getZDirection().times(-distToPlane));
 		coords.setOrigin(newPos);
 		camera.setCameraCoordinates(coords);
+		view.setDistToPlane(distToPlane);
 	}
 
 	private void scrollMoveTravel(MouseScrolledEvent e)
@@ -214,9 +214,6 @@ public class ScrollViewTool
 	{
         if (window != null && boundCamera != null)
         {
-            boundCamera.getCoords().copyCoords(camera.getCameraCoordinates());
-            if (boundCamera.getObject() instanceof SceneCamera) ((SceneCamera)boundCamera.getObject()).setDistToPlane(distToPlane);
-
             UndoRecord undo = new UndoRecord(window, false, UndoRecord.COPY_COORDS, new Object [] {boundCamera.getCoords(), startCoords});
             moveCameraChildren(boundCamera, boundCamera.getCoords().fromLocal().times(startCoords.toLocal()), undo);
             window.setUndoRecord(undo);

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 by Petri Ihalainen
+/* Copyright (C) 2017-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -29,7 +29,7 @@ public class ScrollViewTool
 	private ViewerCanvas view;
 	private Camera camera;
 	private double distToPlane;
-	private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY; // for graphics
+	private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY;
     private int navigationMode, scrollSteps, startOrientation;
     private Vec3 startZ, startUp;
 	private Rectangle bounds;
@@ -82,10 +82,7 @@ public class ScrollViewTool
 			default:
 				break;
 		}
-		
-		setAuxGraphs(view);
-		repaintAllViews(view);
-		//view.repaint
+		view.repaint();
 		view.viewChanged(false);
 	}
 
@@ -159,11 +156,6 @@ public class ScrollViewTool
 			oldPos = new Vec3(coords.getOrigin());
 			newPos = oldPos.plus(coords.getZDirection().times(deltaZ));
 			coords.setOrigin(newPos);
-			
-			if (scrollBlend < 0.5)
-				view.blendColorR = blendColor(view.green, view.yellow, scrollBlend*2.0);
-			else
-				view.blendColorR = blendColor(view.yellow, view.red, scrollBlend*2.0-1.0);
 		}
 		
 		else if (navigationMode == ViewerCanvas.NAVIGATE_TRAVEL_LANDSCAPE)
@@ -204,16 +196,6 @@ public class ScrollViewTool
 			newPos = oldPos.plus(hDir.times(deltaZ));
 			newPos = newPos.plus(vDir.times(deltaY));
 			coords.setOrigin(newPos);
-			
-			if (scrollBlendX < 0.5)
-				view.blendColorX = blendColor(view.green, view.yellow, scrollBlendX*2.0);
-			else
-				view.blendColorX = blendColor(view.yellow, view.red, scrollBlendX*2.0-1.0);
-			
-			if (scrollBlendY < 0.5)
-				view.blendColorY = blendColor(view.green, view.yellow, scrollBlendY*2.0);
-			else
-				view.blendColorY = blendColor(view.yellow, view.red, scrollBlendY*2.0-1.0);
 		}
 		else 
 			return;
@@ -236,8 +218,8 @@ public class ScrollViewTool
             moveCameraChildren(boundCamera, boundCamera.getCoords().fromLocal().times(startCoords.toLocal()), undo);
             window.setUndoRecord(undo);
         }
-		wipeAuxGraphs();
-        window.updateImage();
+        view.repaint();
+        //window.updateImage();
 	}
 
 	private Timer scrollTimer = new Timer(500, new ActionListener() 
@@ -250,15 +232,6 @@ public class ScrollViewTool
 			mouseStoppedScrolling();
 		}
 	});
-
-	private Color  blendColor(Color color0, Color color1, double blend)
-	{
-		int R = (int)(color0.getRed()*(1.0-blend) + color1.getRed()*blend);
-		int G = (int)(color0.getGreen()*(1.0-blend) + color1.getGreen()*blend);
-		int B = (int)(color0.getBlue()*(1.0-blend) + color1.getBlue()*blend);
-		
-		return new Color(R, G, B);
-	}
 
 	/** 
 	    This is called recursively to move any children of a bound camera. 
@@ -274,31 +247,6 @@ public class ScrollViewTool
             moveCameraChildren(parent.getChildren()[i], transform, undo);
 		}  
 	}
-
-  private void repaintAllViews(ViewerCanvas view)
-  {
-    if (window == null || window instanceof UVMappingWindow)
-	  view.repaint();
-    else
-	  for (ViewerCanvas v : window.getAllViews())
-	  	v.repaint();
-  }
-
-  private void setAuxGraphs(ViewerCanvas view)
-  {
-	if (window != null)
-	  for (ViewerCanvas v : window.getAllViews())
-        if (v != view)
-	      v.auxGraphs.set(view, true);
-  }
-  
-  private void wipeAuxGraphs()
-  {
-    if (window != null)
-	  for (ViewerCanvas v : window.getAllViews())
-		v.auxGraphs.wipe();
-  }
-
 	public void drawOverlay()
     {
         // This could draw a "ghost" of the bound camera and it's children during scroll

--- a/ArtOfIllusion/src/artofillusion/SplineMeshViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SplineMeshViewer.java
@@ -15,6 +15,7 @@ import artofillusion.animation.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import artofillusion.view.*;
 import buoy.event.*;
 import buoy.widget.*;
@@ -274,9 +275,9 @@ public class SplineMeshViewer extends MeshViewer
 
     // Determine which tool is active.
 
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
-    else if (altTool != null && e.isAltDown())
+    else if (altTool != null && mouseButtonTwo(e))
       activeTool = altTool;
     else
       activeTool = currentTool;

--- a/ArtOfIllusion/src/artofillusion/TriMeshViewer.java
+++ b/ArtOfIllusion/src/artofillusion/TriMeshViewer.java
@@ -17,6 +17,7 @@ import artofillusion.object.*;
 import artofillusion.object.TriangleMesh.*;
 import artofillusion.texture.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import artofillusion.view.*;
 import buoy.event.*;
 import buoy.widget.*;
@@ -296,9 +297,9 @@ public class TriMeshViewer extends MeshViewer
 
     // Determine which tool is active.
 
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
-    else if (altTool != null && e.isAltDown())
+    else if (altTool != null && mouseButtonTwo(e))
       activeTool = altTool;
     else
       activeTool = currentTool;

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1714,6 +1714,9 @@ public abstract class ViewerCanvas extends CustomWidget
 	private void drawNavigationCues()
 	{
 		if (tilting || moving || rotating) return;
+		if (! ArtOfIllusion.getPreferences().getShowTravelCuesOnIdle() && 
+		   (! ArtOfIllusion.getPreferences().getShowTravelCuesScrolling() || ! scrolling))
+			return;
 		
 		int d = Math.min(getBounds().width, getBounds().height);
 		Point viewCenter = getViewCenter();

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -692,14 +692,21 @@ public abstract class ViewerCanvas extends CustomWidget
       return;
     }
 
-    
-	// Change perspective without animation, if needed.
-    if (nextNavigation < 2) // ...?
-	  perspective = nextPerspective;
+    // Change perspective without animation. This is a bit blunt but softer  
+    // options would need a more complex set of conditions.
+
+    if (nextNavigation < 2)
+        perspective = nextPerspective;
     else
-	  perspective = true;
-	  
-    // Turn y up for landscape modes. Animated
+        perspective = true;
+    if (perspective)
+        scale = 100;
+    else
+        scale = 100.0*theCamera.getDistToScreen()/distToPlane;
+
+    // If changing from a 3D-mode to a landscape mode, 
+    // animate the turning of y-direction up.
+
     if ((navigation == 0 || navigation == 2) && (nextNavigation == 1 || nextNavigation == 3))
     {
 		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
@@ -742,42 +749,6 @@ public abstract class ViewerCanvas extends CustomWidget
 		viewChanged(false);
 	}
 	repaint();
-  }
-
-  /** Changing perspective without animation **/
-  
-  private void flipPerspectiveSwitch(boolean nextPerspective)
-  {
-	if (perspective == nextPerspective || perspectiveSwitch == nextPerspective)
-		return;
-	
-	if(nextPerspective)
-	{
-		// converting scale to distance
-		distToPlane = 100.0*theCamera.getDistToScreen()/scale;
-		scale = 100.0; // scale needs to be 100 in perspective mode or the magnification is incorrect.
-		
-		// repositioning camera
-		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-		Vec3 cz = new Vec3(coords.getZDirection());
-		Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
-		coords.setOrigin(cp);
-		theCamera.setCameraCoordinates(coords);	
-	}
-	else
-	{
-		// converting distance to scale
-		scale = 100.0*theCamera.getDistToScreen()/distToPlane;
-		distToPlane = 20.0; // to follow the convention
-		
-		// repositioning camera
-		CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
-		Vec3 cz = new Vec3(coords.getZDirection());
-		Vec3 cp = rotationCenter.plus(cz.times(-distToPlane));
-		coords.setOrigin(cp);
-		theCamera.setCameraCoordinates(coords);
-	}
-	perspectiveSwitch = perspective = nextPerspective;
   }
 
   /** Set the PopupMenuManager for this canvas. */

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
-   Changes Copyrignt (C) 2016-2019 Petri Ihalainen
+   Changes Copyrignt (C) 2016-2017 Petri Ihalainen
    Changes copyright (C) 2016-2018 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -53,9 +53,8 @@ public abstract class ViewerCanvas extends CustomWidget
 
   protected final ViewChangedEvent viewChangedEvent;
 
-  public static Color gray, ghost, red, green, blue, yellow, cone, teal, TEAL;
+  public static Color gray, ghost, red, green, blue, teal, TEAL;
   public Point mousePoint;
-  public AuxiliaryGraphics auxGraphs = new AuxiliaryGraphics();
   public boolean perspectiveControlEnabled = true;
   public boolean navigationTravelEnabled = true;
   public int lastSetNavigation = 0; // To get the mode right during animation preview
@@ -110,7 +109,6 @@ public abstract class ViewerCanvas extends CustomWidget
   public static final int NAVIGATE_TRAVEL_LANDSCAPE = 3;
   
   public boolean mouseDown, mouseMoving, tilting, moving, rotating, scrolling, dragging;
-  public Color blendColorR, blendColorX, blendColorY;
   
   /** Create a new ViewerCanvas */
   public ViewerCanvas()
@@ -151,10 +149,9 @@ public abstract class ViewerCanvas extends CustomWidget
     addEventLink(MouseReleasedEvent.class, this, "processMouseReleased");
     addEventLink(MouseDraggedEvent.class, this, "processMouseDragged");
     addEventLink(MouseMovedEvent.class, this, "processMouseDragged"); // Workaround for Mac OS X bug
-	addEventLink(MouseMovedEvent.class, this, "processMouseMoved");
+    addEventLink(MouseMovedEvent.class, this, "processMouseMoved");
     addEventLink(MouseScrolledEvent.class, this, "processMouseScrolled");
     addEventLink(MouseClickedEvent.class, this, "showPopupIfNeeded");
-    //addEventLink(MouseClickedEvent.class, this, "mouseClicked"); // Did not work as expected. See below....
     getComponent().addComponentListener(new ComponentListener()
     {
       @Override
@@ -228,7 +225,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   private void processMouseMoved(final MouseMovedEvent ev)
   {
-	if (mouseProcessor != null)
+    if (mouseProcessor != null)
       mouseProcessor.stopProcessing();
     mouseProcessor = new ActionProcessor();
     mouseProcessor.addEvent(new Runnable() {
@@ -242,7 +239,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   private void processMouseReleased(WidgetMouseEvent ev)
   {
-	if (mouseProcessor != null)
+    if (mouseProcessor != null)
     {
       mouseProcessor.stopProcessing();
       mouseProcessor = null;
@@ -251,7 +248,7 @@ public abstract class ViewerCanvas extends CustomWidget
   }
 
   /**
-	Processing scrollwheel events here. Subclasses may override.
+    Processing scrollwheel events here. Subclasses may override.
   */
   protected void processMouseScrolled(MouseScrolledEvent e)
   {
@@ -275,9 +272,6 @@ public abstract class ViewerCanvas extends CustomWidget
         scrollTool.mouseScrolled(scrollEvent, viewToProcess);
       }
     });
-    //// Should there be an ActionProcessor just in case?
-	//if (scrollTool != null)
-	//  scrollTool.mouseScrolled(e, this);
   }
 
   /** Subclasses should override this to handle events. */
@@ -682,7 +676,7 @@ public abstract class ViewerCanvas extends CustomWidget
 	  perspective = nextPerspective;
     else
 	  perspective = true;
-	
+	  
     // Turn y up for landscape modes. Animated
     if ((navigation == 0 || navigation == 2) && (nextNavigation == 1 || nextNavigation == 3))
     {
@@ -697,10 +691,10 @@ public abstract class ViewerCanvas extends CustomWidget
 		{
 			// When z.y == 1.0, z.x and z.x may still have a value in the 
 			// magnitude of 1E-15.
-			
 			z.x = z.z = 0.0; 
 			up.y = 0.0;
-			if (up.length() == 0.0) up.z = 1.0;// Just a precaution. Should never happen.
+			if (up.length() == 0.0) // Just a precaution. Should never happen.
+				up.z = 1.0;
 			up.normalize();
 			coords.setOrientation(z, up);
 			coords.setOrigin(rotationCenter.minus(z.times(distToPlane)));
@@ -712,7 +706,6 @@ public abstract class ViewerCanvas extends CustomWidget
 		else
 		{
 			// Start with up = vertical direction and turn it prpendicular to z
-			
 			up.x = up.z = 0.0;
 			up.y = 1.0;
 			up.subtract(z.times(up.dot(z)));
@@ -727,8 +720,8 @@ public abstract class ViewerCanvas extends CustomWidget
 		viewChanged(false);
 	}
   }
-  
-  /* Changing perspective without animation */
+
+  /** Changing perspective without animation **/
   
   private void flipPerspectiveSwitch(boolean nextPerspective)
   {
@@ -765,7 +758,6 @@ public abstract class ViewerCanvas extends CustomWidget
   }
 
   /** Set the PopupMenuManager for this canvas. */
-
   public void setPopupMenuManager(PopupMenuManager manager)
   {
     popupManager = manager;
@@ -782,31 +774,6 @@ public abstract class ViewerCanvas extends CustomWidget
     }
   }
 
-  /* 
-      Decide what to do when a mouse is clicked on the viewercanvas
-	  - Show pop-up menu
-	  - Center to a new point
-	  - Sub classes may override but should call super first
-	  I wonder if this needs an action processor?
-  */
-  //For some reason after this, when an object was opened for editing by double clicking it on the view, 
-  //the first time of pressing Cancel or OK launched an undo sequence. If the object was opened by 
-  //pop-up menu or by double clicking the object, the editor window behaved normally.
-  /*
-  protected void mouseClicked(MouseClickedEvent ev)
-  {
-    //if (popupManager != null && ev.getButton() == WidgetMouseEvent.BUTTON3 && ev.getClickCount() == 1)
-    if (popupManager != null && ev.isMetaDown() && ev.getClickCount() == 1)
-    {
-      Point pos = ev.getPoint();
-      popupManager.showPopupMenu(this, pos.x, pos.y);
-    }
-    if (ev.isAltDown() && ev.getClickCount() == 1)
-    //if (ev.getButton() == WidgetMouseEvent.BUTTON2 && ev.getClickCount() == 1)
-  	centerToPoint(ev.getPoint());
-  }
-  */
-
   /** Matching the camera with the cirrent state of the view */ // I guess?
   
   public void adjustCamera(boolean perspective)
@@ -816,7 +783,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
     if (boundCamera != null && boundCamera.getObject() instanceof SceneCamera){
       theCamera.setScreenTransform(((SceneCamera) boundCamera.getObject()).getScreenTransform(bounds.width, bounds.height), bounds.width, bounds.height);
-	}
+    }
     else if (perspective)
       theCamera.setScreenParams(0, scale, bounds.width, bounds.height);
     else
@@ -1318,7 +1285,6 @@ public abstract class ViewerCanvas extends CustomWidget
   protected void drawCoordinateAxes()
   {
     // Select a size for the coordinate axes.
-	// drawLine(new Point(200,1), new Point (100,100), Color.ORANGE);
 
     Rectangle bounds = getBounds();
     int axisLength = 50;
@@ -1721,11 +1687,7 @@ public abstract class ViewerCanvas extends CustomWidget
   {
     return Collections.unmodifiableMap(controlMap);
   }
-	
-	//---------------------------------------------------//
-	//   The cue graphics drawing starts here            //
-	//---------------------------------------------------//
-	
+
 	/** Get the centermost point of the screen */
 	public Point getViewCenter()
 	{
@@ -1735,12 +1697,7 @@ public abstract class ViewerCanvas extends CustomWidget
 		int cy = y/2;
 		return (new Point(cx, cy));
 	}
-	
-	private void drawMouseMoveGraphics()
-	{
-		// Nothing to draw currently
-	}
-  
+ 
 	private void drawNavigationGraphics()
 	{
 		if (tilting || moving || rotating) return;
@@ -1750,16 +1707,10 @@ public abstract class ViewerCanvas extends CustomWidget
 		Color color1, colorR, colorX, colorY;
 		
 		if (scrolling){
-			color1 = teal;
-			colorR = blendColorR;
-			colorX = blendColorX;
-			colorY = blendColorY;
+			color1 = gray;
 		}
 		else{
 			color1 = ghost;
-			colorR = ghost;
-			colorX = ghost;
-			colorY = ghost;
 		}
 		if (navigation == 2){
 			drawCircle(viewCenter, d*0.1, 30, color1);
@@ -1768,79 +1719,6 @@ public abstract class ViewerCanvas extends CustomWidget
 		if (navigation == 3){
 			drawSquare(viewCenter, d*0.1, color1);
 			drawSquare(viewCenter, d*0.4, color1);
-		}
-		
-		if (mousePoint == null) return; // This is very important!
-		
-		double mx, my;
-		mx = mousePoint.x-viewCenter.x;
-		my = mousePoint.y-viewCenter.y;
-		double angle = Math.atan2(my, mx);
-		double rMouse = Math.sqrt(mx*mx+my*my);
-		
-		// Draw the radial pointer
-		if (navigation == 2)
-		{
-			if(rMouse >= (double)d*.1)
-			{
-				drawLine(viewCenter, angle, d*.1, d*.4, colorR);
-				
-				Point point = mousePoint;
-				if (rMouse > (double)d*.4)
-				{
-					double r = (double)d*.4;
-					int px = (int)(Math.cos(angle)*(double)d*.4);
-					int py = (int)(Math.sin(angle)*(double)d*.4);
-					point = new Point(viewCenter.x+px, viewCenter.y+py);
-				}
-				drawCircle(point, 10.0, 12, colorR);
-			}
-			else
-				if (scrolling)
-					drawCircle(viewCenter, (double)d*.1, 30, green); // Just draw the center circle green if mouse is inside it.
-		}
-		// Draw vertical and horizontal ponters
-		if (navigation == 3)
-		{
-			int cx = viewCenter.x;
-			int cy = viewCenter.y;
-			
-			if (Math.abs(mx) >= d*.1){
-				drawLine(new Point(viewCenter.x+(int)((d*.1)*Math.signum(mx)), viewCenter.y), 
-				         new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y),
-						 colorX);
-				if (Math.abs(mx) <= d*.4)
-					drawCircle(new Point(viewCenter.x+(int)mx, viewCenter.y), 10.0, 8, colorX);
-				else
-					drawCircle(new Point(viewCenter.x+(int)((d*.4)*Math.signum(mx)), viewCenter.y), 10.0, 8, colorX);
-			}
-			else if(scrolling)
-			{
-				drawLine(new Point(cx+(int)(d*.1), (int)(cy+d*0.1)), 
-				         new Point(cx+(int)(d*.1), (int)(cy-d*0.1)), 
-				         green);
-				drawLine(new Point(cx-(int)(d*.1), (int)(cy+d*0.1)), 
-				         new Point(cx-(int)(d*.1), (int)(cy-d*0.1)), 
-				         green);
-			}
-			if (Math.abs(my) >= d*.1){
-				drawLine(new Point(viewCenter.x, viewCenter.y+(int)((d*.1)*Math.signum(my))), 
-				         new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))),
-						 colorY);
-				if (Math.abs(my) <= d*.4)
-					drawCircle(new Point(viewCenter.x, viewCenter.y+(int)my), 10.0, 8, colorY);
-				else
-					drawCircle(new Point(viewCenter.x, viewCenter.y+(int)((d*.4)*Math.signum(my))), 10.0, 8, colorY);
-			}
-			else if(scrolling)
-			{
-				drawLine(new Point((int)(cx+(int)(d*.1)), cy+(int)(d*.1)), 
-				         new Point((int)(cx-(int)(d*.1)), cy+(int)(d*.1)),
-				         blendColorY);
-				drawLine(new Point((int)(cx+(int)(d*.1)), cy-(int)(d*.1)), 
-				         new Point((int)(cx-(int)(d*.1)), cy-(int)(d*.1)),
-				         blendColorY);
-			}
 		}
 	}
 
@@ -1931,7 +1809,7 @@ public abstract class ViewerCanvas extends CustomWidget
 	private void setNavigationColors()
 	{
 		TEAL = new Color(0, 127, 127);
-		
+
 		gray   = new Color(Color.GRAY.getRed()/2+backgroundColor.getRed()/2,
                            Color.GRAY.getGreen()/2+backgroundColor.getGreen()/2,
                            Color.GRAY.getBlue()/2+backgroundColor.getBlue()/2);
@@ -1943,26 +1821,18 @@ public abstract class ViewerCanvas extends CustomWidget
 		red    = new Color(Color.RED.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.RED.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.RED.getBlue()*3/4+backgroundColor.getBlue()/4);
-						 
-		yellow = new Color(Color.YELLOW.getRed()*3/4+backgroundColor.getRed()/4,
-                           Color.YELLOW.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           Color.YELLOW.getBlue()*3/4+backgroundColor.getBlue()/4);
 						   
 		green  = new Color(Color.GREEN.getRed()*3/4+backgroundColor.getRed()/4,
                            Color.GREEN.getGreen()*3/4+backgroundColor.getGreen()/4,
                            Color.GREEN.getBlue()*3/4+backgroundColor.getBlue()/4);
 				 		 
-		blue   = new Color(Color.BLUE.getRed()*3/4+backgroundColor.getRed()/4,
-                           Color.BLUE.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           Color.BLUE.getBlue()*3/4+backgroundColor.getBlue()/4);
-				 		 
 		teal   = new Color(TEAL.getRed()*3/4+backgroundColor.getRed()/4,
                            TEAL.getGreen()*3/4+backgroundColor.getGreen()/4,
                            TEAL.getBlue()*3/4+backgroundColor.getBlue()/4);
 
-		cone   = new Color(Color.GREEN.getRed()/2+backgroundColor.getRed()/2,
-                           Color.GREEN.getGreen()/2+backgroundColor.getGreen()/2,
-                           Color.GREEN.getBlue()/2+backgroundColor.getBlue()/2);
+		blue   = new Color(Color.BLUE.getRed()*3/4+backgroundColor.getRed()/4,
+                           Color.BLUE.getGreen()*3/4+backgroundColor.getGreen()/4,
+                           Color.BLUE.getBlue()*3/4+backgroundColor.getBlue()/4);
 	}
 	
 	/* 
@@ -1978,194 +1848,10 @@ public abstract class ViewerCanvas extends CustomWidget
 		return new Color(R, G, B);
 	}
 	
-	/** Call all the methods that draw informative graphics on the screen */
+	/** Draw informative graphics on the screen */
 	public void drawOverlay()
 	{
 		if (mouseMoving || scrolling)
 			drawNavigationGraphics();
-		auxGraphs.render();
 	}
-	
-	/** 
-		This class creates and stores information for drawing view cones or other 
-		temporary 3D graphics and privides a method to draw them on the screen.
-	*/
-	public class AuxiliaryGraphics
-	{
-		private ArrayList<Vec3>   points;
-		private ArrayList<Vec3[]> lines;
-		private ArrayList<Color>  pointColors, lineColors;
-		
-		/** Create an empty AuxiliaryGraphics object */
-		public AuxiliaryGraphics()
-		{}
-
-		/* Create emply point list */
-		private void newPoints(){
-			points = new ArrayList<Vec3>();
-			pointColors = new ArrayList<Color>();
-		}
-			
-		/* Create emply point list */
-		private void newLines(){
-			lines = new ArrayList<Vec3[]>();
-			lineColors = new ArrayList<Color>();
-		}
-		/** 
-			Create contents using the given view<p>
-			
-			@param newGraphics tells to clear any previously stored graphics
-		*/
-		public void set(ViewerCanvas v, boolean newGraphics)
-		{
-			if(! showViewCone)
-				return;
-			if (newGraphics){
-				newPoints();
-				newLines();
-			}
-			
-			Camera ca = v.getCamera();
-			CoordinateSystem cs = ca.getCameraCoordinates();
-			Vec3 rc = v.getRotationCenter();
-			Vec3 cz = cs.getZDirection();
-			Vec3 cp = new Vec3(cs.getOrigin().plus(cz.times(0.0001))); // Need to move so that the camera can see it
-			double dp = v.getDistToPlane();
-
-			// rotation center 
-			add(new Vec3(rc), Color.GREEN);
-			
-			// view edges
-			Rectangle b = v.getBounds();
-			Vec3 c0, c1, c2, c3;
-			c0 = ca.convertScreenToWorld(new Point(0, 0), dp);
-			c1 = ca.convertScreenToWorld(new Point(b.width, 0), dp);
-			c2 = ca.convertScreenToWorld(new Point(b.width, b.height), dp);
-			c3 = ca.convertScreenToWorld(new Point(0, b.height), dp);
-			
-			// screen border
-			add(new Vec3[]{c0, c1}, cone);
-			add(new Vec3[]{c1, c2}, cone);
-			add(new Vec3[]{c2, c3}, cone);
-			add(new Vec3[]{c3, c0}, cone);
-			
-			if (v.isPerspective()){
-				// camera position
-				add(new Vec3(cp), Color.MAGENTA);
-				// corner lines
-				add(new Vec3[]{c0, cp}, cone);
-				add(new Vec3[]{c1, cp}, cone);
-				add(new Vec3[]{c2, cp}, cone);
-				add(new Vec3[]{c3, cp}, cone);
-			}
-			else{
-				Vec3 m0, m1, m2, m3, mh, cpp;
-				
-				// pseudo location for view point position
-				double cppDist = 100.0*ca.getDistToScreen()/v.getScale();
-				cpp = rc.minus(cz.times(cppDist*1.0));
-				add(cpp, Color.MAGENTA);
-				
-				m0 = c0.minus(cz.times(cppDist*(1-0.618033))); // "Golden mean.. :) "
-				m1 = c1.minus(cz.times(cppDist*(1-0.618033)));
-				m2 = c2.minus(cz.times(cppDist*(1-0.618033)));
-				m3 = c3.minus(cz.times(cppDist*(1-0.618033)));
-
-				add(new Vec3[]{m0, m1}, cone);
-				add(new Vec3[]{m1, m2}, cone);
-				add(new Vec3[]{m2, m3}, cone);
-				add(new Vec3[]{m3, m0}, cone);
-
-				add(new Vec3[]{c0, m0}, cone);
-				add(new Vec3[]{c1, m1}, cone);
-				add(new Vec3[]{c2, m2}, cone);
-				add(new Vec3[]{c3, m3}, cone);
-
-				add(new Vec3[]{m0, cpp}, gray);
-				add(new Vec3[]{m1, cpp}, gray);
-				add(new Vec3[]{m2, cpp}, gray);
-				add(new Vec3[]{m3, cpp}, gray);
-			}
-		}
-
-		/** Add a point */
-		public void add(Vec3 point, Color pointColor)
-		{
-			if (points == null)
-				newPoints();
-			points.add(point);
-			pointColors.add(pointColor);
-		}
-
-		/** Add a line */
-		public void add(Vec3[] lineEnds, Color lineColor)
-		{
-			if (lines == null)
-				newLines();
-			lines.add(lineEnds);
-			lineColors.add(lineColor);
-		}
-
-		/** Copy all information from an existing graphics object */
-		public void copy(AuxiliaryGraphics ext)
-		{
-			points = ext.getPoints();
-			pointColors = ext.getPointColors(); 
-			lines = ext.getLines();
-			lineColors = ext.getLineColors(); 
-		}
-
-		public ArrayList<Vec3> getPoints()
-		{
-			return points;
-		}
-
-		public ArrayList<Color> getPointColors()
-		{
-			return pointColors;
-		}
-
-		public ArrayList<Vec3[]> getLines()
-		{
-			return lines;
-		}
-
-		public ArrayList<Color> getLineColors()
-		{
-			return lineColors;
-		}
-
-		/** Render the object on screen */
-		public void render()
-		{
-		
-			Vec2 v0, v1;
-			Point p0, p1;
-			int pointRadius = 4;
-			if (points != null)
-				for(int i = 0; i < points.size(); i++){
-					renderPoint(points.get(i), pointColors.get(i), pointRadius);
-				}
-			if (lines != null)
-				for(int i = 0; i < lines.size(); i++){
-				
-					// renderLine of CanvasDrawer does not work right here. Object dependencies...
-
-					v0 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[0]));
-					v1 = new Vec2(theCamera.getWorldToScreen().timesXY(lines.get(i)[1]));
-					p0 = new Point((int)v0.x, (int)v0.y);
-					p1 = new Point((int)v1.x, (int)v1.y);
-					drawLine (p0, p1, lineColors.get(i));
-				}
-		}
-
-		/** Empty the object */
-		public void wipe()
-		{
-			points = null;
-			pointColors = null;
-			lines = null;
-			lineColors = null;
-		}
-	} // AuxiliaryGraphics
 }

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
-   Changes Copyrignt (C) 2016-2017 Petri Ihalainen
+   Changes Copyrignt (C) 2016-2019 Petri Ihalainen
    Changes copyright (C) 2016-2018 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -433,8 +433,8 @@ public abstract class ViewerCanvas extends CustomWidget
 			return;
 		}
 
-		// I wonder if this is right....
-		if (boundCamera != null){
+		// SceneCamera has logic of it's own, so just jump there!
+		if (boundCamera != null && boundCamera.getObject() instanceof SceneCamera){
 			perspective = perspectiveSwitch = nextPerspective;
 			return;
 		}
@@ -442,8 +442,8 @@ public abstract class ViewerCanvas extends CustomWidget
 		if (animation.animatingMove() || animation.changingPerspective()) 
 			return;
 
-		perspectiveSwitch = nextPerspective;			
-		animation.start(nextPerspective, navigation, theCamera.getCameraCoordinates()); // , refDistToPlane, navigation);
+		perspectiveSwitch = nextPerspective;
+		animation.start(nextPerspective);
 	}
 
 	/** 
@@ -629,9 +629,17 @@ public abstract class ViewerCanvas extends CustomWidget
   }
 
   /** Get the distance from camera to drawing plane */
+  
   public double getDistToPlane()
   {
-	return distToPlane;
+    if (boundCamera != null)
+        if (boundCamera.getObject() instanceof SceneCamera)
+            return ((SceneCamera)boundCamera.getObject()).getDistToPlane();
+        else if (boundCamera.getObject() instanceof SpotLight)
+            return ((SpotLight)boundCamera.getObject()).getDistToPlane();
+        else if (boundCamera.getObject() instanceof DirectionalLight)
+            return ((DirectionalLight)boundCamera.getObject()).getDistToPlane();
+    return distToPlane;
   }
 
   /** Get the currently used navigation mode */

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -53,7 +53,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
   protected final ViewChangedEvent viewChangedEvent;
 
-  public static Color gray, ghost, red, green, blue, teal, TEAL;
+  public static Color gray, red, green, blue, CUE, cueActive, cueIdle;
   public Point mousePoint;
   public boolean perspectiveControlEnabled = true;
   public boolean navigationTravelEnabled = true;
@@ -175,7 +175,7 @@ public abstract class ViewerCanvas extends CustomWidget
     orientation = 0;
     perspective = false;
     scale = 100.0;
-	setNavigationColors();
+    setCueColors();
 	mouseMoveTimer.setCoalesce(false);
   }
 
@@ -1697,27 +1697,27 @@ public abstract class ViewerCanvas extends CustomWidget
 		return (new Point(cx, cy));
 	}
  
-	private void drawNavigationGraphics()
+	private void drawNavigationCues()
 	{
 		if (tilting || moving || rotating) return;
 		
 		int d = Math.min(getBounds().width, getBounds().height);
 		Point viewCenter = getViewCenter();
-		Color color1, colorR, colorX, colorY;
+		Color cueColor;
 		
 		if (scrolling){
-			color1 = gray;
+			cueColor = cueActive;
 		}
 		else{
-			color1 = ghost;
+			cueColor = cueIdle;
 		}
 		if (navigation == 2){
-			drawCircle(viewCenter, d*0.1, 30, color1);
-			drawCircle(viewCenter, d*0.4, 60, color1);
+			drawCircle(viewCenter, d*0.1, 30, cueColor);
+			drawCircle(viewCenter, d*0.4, 60, cueColor);
 		}
 		if (navigation == 3){
-			drawSquare(viewCenter, d*0.1, color1);
-			drawSquare(viewCenter, d*0.4, color1);
+			drawSquare(viewCenter, d*0.1, cueColor);
+			drawSquare(viewCenter, d*0.4, cueColor);
 		}
 	}
 
@@ -1805,35 +1805,29 @@ public abstract class ViewerCanvas extends CustomWidget
 	}
 	
 	/* These colors are used on the navigation cue graphics */
-	private void setNavigationColors()
+	private void setCueColors()
 	{
-		TEAL = new Color(0, 127, 127);
-
-		gray   = new Color(Color.GRAY.getRed()/2+backgroundColor.getRed()/2,
-                           Color.GRAY.getGreen()/2+backgroundColor.getGreen()/2,
-                           Color.GRAY.getBlue()/2+backgroundColor.getBlue()/2);
-						 
-		ghost  = new Color(Color.GRAY.getRed()/3+backgroundColor.getRed()*2/3,
-                           Color.GRAY.getGreen()/3+backgroundColor.getGreen()*2/3,
-                           Color.GRAY.getBlue()/3+backgroundColor.getBlue()*2/3);
-						 
-		red    = new Color(Color.RED.getRed()*3/4+backgroundColor.getRed()/4,
-                           Color.RED.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           Color.RED.getBlue()*3/4+backgroundColor.getBlue()/4);
-						   
-		green  = new Color(Color.GREEN.getRed()*3/4+backgroundColor.getRed()/4,
-                           Color.GREEN.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           Color.GREEN.getBlue()*3/4+backgroundColor.getBlue()/4);
-				 		 
-		teal   = new Color(TEAL.getRed()*3/4+backgroundColor.getRed()/4,
-                           TEAL.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           TEAL.getBlue()*3/4+backgroundColor.getBlue()/4);
-
-		blue   = new Color(Color.BLUE.getRed()*3/4+backgroundColor.getRed()/4,
-                           Color.BLUE.getGreen()*3/4+backgroundColor.getGreen()/4,
-                           Color.BLUE.getBlue()*3/4+backgroundColor.getBlue()/4);
+		CUE       = new Color(0, 127, 255);
+		cueIdle   = new Color(CUE.getRed()  *1/4+backgroundColor.getRed()  *3/4,
+		                      CUE.getGreen()*1/4+backgroundColor.getGreen()*3/4,
+		                      CUE.getBlue() *1/4+backgroundColor.getBlue() *3/4);
+		cueActive = new Color(CUE.getRed()  *1/2+backgroundColor.getRed()  *1/2,
+		                      CUE.getGreen()*1/2+backgroundColor.getGreen()*1/2,
+		                      CUE.getBlue() *1/2+backgroundColor.getBlue() *1/2);
+		gray      = new Color(Color.GRAY.getRed()  *1/2+backgroundColor.getRed()  *1/2,
+		                      Color.GRAY.getGreen()*1/2+backgroundColor.getGreen()*1/2,
+		                      Color.GRAY.getBlue() *1/2+backgroundColor.getBlue() *1/2);
+		red       = new Color(Color.RED.getRed()   *3/4+backgroundColor.getRed()  *1/4,
+		                      Color.RED.getGreen() *3/4+backgroundColor.getGreen()*1/4,
+		                      Color.RED.getBlue()  *3/4+backgroundColor.getBlue() *1/4);
+		green     = new Color(Color.GREEN.getRed()   *3/4+backgroundColor.getRed()  *1/4,
+		                      Color.GREEN.getGreen() *3/4+backgroundColor.getGreen()*1/4,
+		                      Color.GREEN.getBlue()  *3/4+backgroundColor.getBlue() *1/4);
+		blue      = new Color(Color.BLUE.getRed()  *3/4+backgroundColor.getRed()  *1/4,
+		                      Color.BLUE.getGreen()*3/4+backgroundColor.getGreen()*1/4,
+		                      Color.BLUE.getBlue() *3/4+backgroundColor.getBlue() *1/4);
 	}
-	
+
 	/* 
 	 * Blend between two colors. 
 	 * The 'blend' is the balance of the color in range 0.0 - 1.0 from color0 to color1
@@ -1850,7 +1844,7 @@ public abstract class ViewerCanvas extends CustomWidget
 	/** Draw informative graphics on the screen */
 	public void drawOverlay()
 	{
-		if (mouseMoving || scrolling)
-			drawNavigationGraphics();
+		setCueColors(); // This shoud be set at preferences change
+		drawNavigationCues();
 	}
 }

--- a/ArtOfIllusion/src/artofillusion/animation/TrackGraph.java
+++ b/ArtOfIllusion/src/artofillusion/animation/TrackGraph.java
@@ -12,6 +12,7 @@ package artofillusion.animation;
 
 import artofillusion.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -276,7 +277,7 @@ public class TrackGraph extends CustomWidget implements TrackDisplay
     undo = null;
     dragPos = null;
     draggingBox = false;
-    effectiveMode = (ev.isMetaDown() ? Score.SCROLL_AND_SCALE : mode);
+    effectiveMode = (mouseButtonThree(ev) ? Score.SCROLL_AND_SCALE : mode);
     if (effectiveMode != Score.SELECT_AND_MOVE)
       return;
 

--- a/ArtOfIllusion/src/artofillusion/animation/TracksPanel.java
+++ b/ArtOfIllusion/src/artofillusion/animation/TracksPanel.java
@@ -12,6 +12,7 @@ package artofillusion.animation;
 
 import artofillusion.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -187,7 +188,7 @@ public class TracksPanel extends CustomWidget implements TrackDisplay
     undo = null;
     dragPos = null;
     draggingBox = false;
-    effectiveMode = (ev.isMetaDown() ? Score.SCROLL_AND_SCALE : mode);
+    effectiveMode = (mouseButtonThree(ev) ? Score.SCROLL_AND_SCALE : mode);
     if (effectiveMode != Score.SELECT_AND_MOVE)
       return;
     if (row < 0 || row >= obj.length || !(obj[row] instanceof Track))

--- a/ArtOfIllusion/src/artofillusion/object/DirectionalLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/DirectionalLight.java
@@ -178,11 +178,13 @@ public class DirectionalLight extends Light
     super(in, theScene);
 
     short version = in.readShort();
-    if (version < 0 || version > 2)
+    if (version < 0 || version > 3)
       throw new InvalidObjectException("");
     setParameters(new RGBColor(in), in.readFloat(), version == 0 ? TYPE_NORMAL : in.readShort(), 0.0f);
     setRadius(version > 1 ? in.readDouble() : 0.0);
-	//distToPlane = in.readDouble();
+    if (version >= 3)
+      distToPlane = in.readDouble();
+
     bounds = new BoundingBox(-0.15, 0.15, -0.15, 0.15, -0.15, 0.25);
   }
 
@@ -191,13 +193,12 @@ public class DirectionalLight extends Light
   {
     super.writeToFile(out, theScene);
 
-    out.writeShort(2);
+    out.writeShort(3);
     color.writeToFile(out);
     out.writeFloat(intensity);
     out.writeShort(type);
     out.writeDouble(radius);
-    //out.writeDouble(distToPlane);
-	
+    out.writeDouble(distToPlane);
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
+++ b/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
@@ -522,9 +522,10 @@ public class SceneCamera extends Object3D
     super(in, theScene);
 
     short version = in.readShort();
-    if (version < 0 ||version > 2)
+    if (version < 0 ||version > 3)
       throw new InvalidObjectException("");
-	//distToPlane = in.readDouble();
+    if (version >= 3)
+      distToPlane = in.readDouble();
     fov = in.readDouble();
     depthOfField = in.readDouble();
     focalDist = in.readDouble();
@@ -559,8 +560,8 @@ public class SceneCamera extends Object3D
   {
     super.writeToFile(out, theScene);
 
-    out.writeShort(2);
-	//out.writeDouble(distToPlane);
+    out.writeShort(3);
+    out.writeDouble(distToPlane);
     out.writeDouble(fov);
     out.writeDouble(depthOfField);
     out.writeDouble(focalDist);

--- a/ArtOfIllusion/src/artofillusion/object/SpotLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/SpotLight.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 2000-2007 by Peter Eastman
-   Modifications Copyright 2016 by Petri Ihalainen
+   Changes Copyright 2016-2019 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -218,13 +218,15 @@ public class SpotLight extends Light
     super(in, theScene);
 
     short version = in.readShort();
-    if (version < 0 || version > 1)
+    if (version < 0 || version > 2)
       throw new InvalidObjectException("");
     setParameters(new RGBColor(in), in.readFloat(), version == 0 ? (in.readBoolean() ? TYPE_AMBIENT : TYPE_NORMAL) : in.readShort(), in.readFloat());
     setRadius(in.readDouble());
     setAngle(in.readDouble());
     setFalloff(in.readDouble());
-	//distToPlane = in.readDouble();
+    if (version >= 2)
+      distToPlane = in.readDouble();
+
     bounds = new BoundingBox(-0.2, 0.2, -0.2, 0.2, -0.2, 0.2);
   }
 
@@ -233,7 +235,7 @@ public class SpotLight extends Light
   {
     super.writeToFile(out, theScene);
 
-    out.writeShort(1);
+    out.writeShort(2);
     color.writeToFile(out);
     out.writeFloat(intensity);
     out.writeShort(type);
@@ -241,7 +243,7 @@ public class SpotLight extends Light
     out.writeDouble(radius);
     out.writeDouble(angle);
     out.writeDouble(falloff);
-    //out.writeDouble(distToPlane);
+    out.writeDouble(distToPlane);
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/texture/UVMappingViewer.java
+++ b/ArtOfIllusion/src/artofillusion/texture/UVMappingViewer.java
@@ -15,6 +15,7 @@ import artofillusion.animation.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+import static artofillusion.ui.UIUtilities.*;
 import buoy.event.*;
 import buoy.widget.*;
 
@@ -298,9 +299,9 @@ public class UVMappingViewer extends MeshViewer
 
     // Determine which tool is active.
 
-    if (metaTool != null && e.isMetaDown())
+    if (metaTool != null && mouseButtonThree(e))
       activeTool = metaTool;
-    else if (altTool != null && e.isAltDown())
+    else if (altTool != null && mouseButtonTwo(e))
       activeTool = altTool;
     else
       activeTool = currentTool;

--- a/ArtOfIllusion/src/artofillusion/ui/TreeList.java
+++ b/ArtOfIllusion/src/artofillusion/ui/TreeList.java
@@ -14,7 +14,7 @@ package artofillusion.ui;
 import artofillusion.*;
 import buoy.event.*;
 import buoy.widget.*;
-
+import static artofillusion.ui.UIUtilities.*;
 import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
@@ -492,7 +492,7 @@ public class TreeList extends CustomWidget
     }
     okToInsert = false;
     boolean selectionChanged = false;
-    if (allowMultiple && (ev.isControlDown() || ev.isMetaDown()) && !ev.isPopupTrigger() && ev.getButton() == 1)
+    if (allowMultiple && (ev.isControlDown() || ev.isMetaDown()) && !ev.isPopupTrigger() && mouseButtonOne(ev))
     {
       setSelected(el, !el.isSelected());
       selectionChanged = true;
@@ -741,7 +741,7 @@ public class TreeList extends CustomWidget
 
   private void mouseClicked(MouseClickedEvent ev)
   {
-    if (ev.getClickCount() == 1 && ev.isAltDown())
+    if (ev.getClickCount() == 1 && mouseButtonTwo(ev))
 	{
     	window.getView().fitToObjects(((LayoutWindow)window).getSelectedObjects());
     	return;

--- a/ArtOfIllusion/src/artofillusion/ui/UIUtilities.java
+++ b/ArtOfIllusion/src/artofillusion/ui/UIUtilities.java
@@ -11,7 +11,10 @@
 package artofillusion.ui;
 
 import buoy.widget.*;
+import buoy.event.WidgetMouseEvent;
 import java.awt.*;
+import static java.awt.event.InputEvent.*;
+import static java.awt.event.MouseEvent.*;
 import java.util.*;
 import java.util.List;
 import javax.swing.*;
@@ -250,5 +253,38 @@ public class UIUtilities
         list.add(child);
         addChildrenToList(child, list);
       }
+  }
+
+  /**
+   * Test event for specified mouse/modifier key combination.
+   * This regularizes 3-button and 1-button + modifier support across
+   * multiple platforms.
+   */
+
+  public static boolean mouseMapButtonOne(WidgetMouseEvent e)
+  {
+    int mods = e.getModifiersEx();
+    return ((mods & BUTTON1_DOWN_MASK) != 0 || e.getButton() == BUTTON1) &&
+            ((mods & (META_DOWN_MASK | ALT_DOWN_MASK)) == 0);
+  }
+
+  public static boolean mouseMapButtonTwo(WidgetMouseEvent e)
+  {
+    int mods = e.getModifiersEx();
+    return (
+             ((mods & BUTTON2_DOWN_MASK) != 0 || e.getButton() == BUTTON2) &&
+             ((mods & BUTTON1_DOWN_MASK) == 0)
+	   )
+           || ((mods & ALT_DOWN_MASK) != 0);
+  }
+
+  public static boolean mouseMapButtonThree(WidgetMouseEvent e)
+  {
+    int mods = e.getModifiersEx();
+    return (
+             ((mods & BUTTON3_DOWN_MASK) != 0 || e.getButton() == BUTTON3) &&
+             ((mods & BUTTON1_DOWN_MASK) == 0)
+           )
+           || ((mods & META_DOWN_MASK) != 0);
   }
 }

--- a/ArtOfIllusion/src/artofillusion/ui/UIUtilities.java
+++ b/ArtOfIllusion/src/artofillusion/ui/UIUtilities.java
@@ -261,14 +261,14 @@ public class UIUtilities
    * multiple platforms.
    */
 
-  public static boolean mouseMapButtonOne(WidgetMouseEvent e)
+  public static boolean mouseButtonOne(WidgetMouseEvent e)
   {
     int mods = e.getModifiersEx();
     return ((mods & BUTTON1_DOWN_MASK) != 0 || e.getButton() == BUTTON1) &&
             ((mods & (META_DOWN_MASK | ALT_DOWN_MASK)) == 0);
   }
 
-  public static boolean mouseMapButtonTwo(WidgetMouseEvent e)
+  public static boolean mouseButtonTwo(WidgetMouseEvent e)
   {
     int mods = e.getModifiersEx();
     return (
@@ -278,7 +278,7 @@ public class UIUtilities
            || ((mods & ALT_DOWN_MASK) != 0);
   }
 
-  public static boolean mouseMapButtonThree(WidgetMouseEvent e)
+  public static boolean mouseButtonThree(WidgetMouseEvent e)
   {
     int mods = e.getModifiersEx();
     return (

--- a/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
@@ -190,10 +190,6 @@ public class ViewAnimation
         if (viewHasCamera)
             window.setModified();
         else
-
-		// auxGraphs shows up wrong. Possibly numerical accuaracy issue.
-		// setAuxGraphs();
-
 		step++;
 	}
 
@@ -382,7 +378,6 @@ public class ViewAnimation
 		view.repaint();
         if (viewHasCamera)
             window.setModified();
-		setAuxGraphs();
 		step++;
 	}
 
@@ -399,7 +394,6 @@ public class ViewAnimation
 		changingPerspective = false;
 		animatingMove = false;
 
-		wipeAuxGraphs();
 		view.finishAnimation(endOrientation, endPerspective, endNavigation); // using set-methods for these would loop back to animation
         if (viewHasCamera)
         {
@@ -408,9 +402,9 @@ public class ViewAnimation
         }
         else
         {
-		view.viewChanged(false);
-		view.repaint();
-	}
+			view.viewChanged(false);
+			view.repaint();
+		}
     }
 
 	/** 
@@ -435,19 +429,5 @@ public class ViewAnimation
         // This only works for the 'animate' boolean to take effect immediately
 		// Don't know why?
 		animate = ArtOfIllusion.getPreferences().getUseViewAnimations();
-	}
-
-	/* Set view cone craphis */
-	public void setAuxGraphs()
-	{
-		for (ViewerCanvas v : window.getAllViews())
-			if (v != view)
-				v.auxGraphs.set(view, true);
-	}
-
-	public void wipeAuxGraphs()
-	{
-		for (ViewerCanvas v : window.getAllViews())
-			v.auxGraphs.wipe();
 	}
 }

--- a/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
@@ -106,26 +106,16 @@ public class ViewAnimation
 		endRotationCenter = view.getRotationCenter();
 		endOrientation = view.getOrientation();
 		endNavigation = view.getNavigationMode();
-		endDistToScreen = camera.getDistToScreen();
 		refDistToScreen = endDistToScreen = camera.getDistToScreen();
-		if (view.isPerspective())
-			refDistToPlane = view.getDistToPlane();
-		else
-			refDistToPlane = 100.0/view.getScale()*camera.getDistToScreen();
-		
-
+		refDistToPlane = view.getDistToPlane();
 		endCoords = camera.getCameraCoordinates().duplicate();
-		if(nextPerspective){
-			endCoords.setOrigin(view.getRotationCenter().plus(endCoords.getZDirection().times(-refDistToPlane)));
+		if(nextPerspective)
 			endScale = 100.0;
-		}
-		else{
-			endCoords.setOrigin(view.getRotationCenter().plus(endCoords.getZDirection().times(-20)));
+		else
 			endScale = 100.0*refDistToScreen/refDistToPlane;
-		}
-		
 		checkPreferences(); // This only works for the 'animate'
-		if (! animate){
+		if (! animate)
+		{
 			endAnimation(); // Go directly to the last frame
 			return;
 		}

--- a/ArtOfIllusion/src/artofillusion/view/ViewerPerspectiveControl.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewerPerspectiveControl.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 2007-2009 by Peter Eastman
-   Modifications copyright (C) 2017 Petri Ihalainen
+   Modifications copyright (C) 2017-2019 Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -30,30 +30,24 @@ public class ViewerPerspectiveControl implements ViewerControl
       Translate.text("Perspective"),
       Translate.text("Parallel")
     });
-	
+
     perspectiveChoice.setSelectedIndex(1);
-	
+
     view.addEventLink(ViewChangedEvent.class, new Object() {
       void processEvent()
       {
         if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera){
-		  view.setPerspective(true);
-		  perspectiveChoice.setSelectedIndex(view.isPerspectiveSwitch() ? 0 : 1);
           perspectiveChoice.setEnabled(false);
-		}
-        else if (view.getRenderMode() == ViewerCanvas.RENDER_RENDERED)
-          perspectiveChoice.setEnabled(false);
-		else if (view.getNavigationMode() > 1)
-		{
-		  perspectiveChoice.setEnabled(false);
-		  perspectiveChoice.setSelectedIndex(view.isPerspectiveSwitch() ? 0 : 1);
-        }
-        else
-        {
-          perspectiveChoice.setEnabled(true);
+          view.setPerspective(((SceneCamera)view.getBoundCamera().getObject()).isPerspective());
           perspectiveChoice.setSelectedIndex(view.isPerspectiveSwitch() ? 0 : 1);
         }
-		perspectiveChoice.setEnabled(view.perspectiveControlEnabled);
+        else if (view.getRenderMode() == ViewerCanvas.RENDER_RENDERED)
+          perspectiveChoice.setEnabled(false);
+        else
+        {
+          perspectiveChoice.setEnabled(view.perspectiveControlEnabled);
+          perspectiveChoice.setSelectedIndex(view.isPerspectiveSwitch() ? 0 : 1);
+        }
       }
     });
 

--- a/ArtOfIllusion/src/artofillusion_fi.properties
+++ b/ArtOfIllusion/src/artofillusion_fi.properties
@@ -747,6 +747,13 @@ errorSavingPrefs=Asetuksia tallennettaessa tapahtui virhe: {0}
 useViewAnimations=Animoi pikaliikkeet
 maxAnimationDuration=Animaation maksimi kesto (s)
 animationFrameRate=Animaation kuvataajuus (Hz)
+DisplayViewFrustumOf=Näytä näkymän keila 
+anyActiveView=aina aktiivisesta näymästä
+cameraView=kamerallisesta näkymästä
+ShowTravelScrollCues=Näytä rullausviheet 
+onIdle=odottaessa
+duringScrolling=rullatessa
+ShowTiltDial=Näytä kallistusasteikko
 
 #
 # The Textures and Materials window


### PR DESCRIPTION
Hi everybody! 

I call this one done. This \<edit\>is a response to\</edit\> #64 at least partially. And in spite of the branch name it is a bit more than just a graphics update.

Splitting this into several PRs would not have worked as all the commits rely on the earlier ones and I really had to start from the basics (befc7a7, which I should have done in the first place). After attempting a few work-arounds this produced the cleanest out come without methods just to fight the core logic.

- View cameras behave better now and you can continue where you left off after save and reopen -- they remember their last working depth in the view.
- SceneCamera perspective setting overrides the view perspective setting.
- Children of  camera objects should now follow their parent in animated moves better than before
- Scroll cues for fly and drive mode are now less "jumpy". You still need to know, what they mean though.
-\<edit\>Should probably add an off-switch to those too, but IMO those modes need a visible indicator that the behavior is different from the usual.\</edit\>
- View frustum display can be turned off entirely of left on for camera views. I believe that option to be helpful.

SceneCamera still has it's own logic (from 3.0) in parallel viewing mode. It can and should be brought closer to the other views and I think It could have a control to set the actual plot y-size in the scene instead of just the fov-setting but that is a different project. Tilting for tray/drive is not in either. That will also have to be another project.

Please have a look, and let me know if something needs fixing or explaining.

