### PR TITLE
Restoring pan/rotate switch

### DIFF
--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2012 by Peter Eastman
-   Changes copyright (C) 2106-2017 by Petri Ihalainen
+   Changes copyright (C) 2016-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -107,13 +107,13 @@ public class RotateViewTool extends EditingTool
 		if (e.getPoint() != clickPoint && view.getBoundCamera() == null) // This is needed even if the mouse has not been dragged yet.
 			view.setOrientation(VIEW_OTHER);
 			
-		if (theWindow != null
-                   && theWindow.getToolPalette().getSelectedTool() == this
-                   && mouseButtonOne(e))
+		if (theWindow != null && 
+		    theWindow.getToolPalette().getSelectedTool() == this && 
+		    mouseButtonOne(e))
 		{
 			if (view.getNavigationMode() == NAVIGATE_MODEL_SPACE)
 				dragRotateSpace(e, view);
-			else if (view.getNavigationMode() == 1)
+			else
 			{
 				Vec3 zD = oldCoords.getZDirection();
 				fwMax = Math.PI*0.5+Math.asin(zD.y);
@@ -349,7 +349,7 @@ public class RotateViewTool extends EditingTool
 		}
 		else
 		{
-			if (view.getBoundCamera() != null){
+			if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera){
 				int yp = view.getBounds().height/2;
 				double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
 				
@@ -485,7 +485,7 @@ public class RotateViewTool extends EditingTool
 	int dy = dragPoint.y-clickPoint.y;
 	double dts = camera.getDistToScreen();
 	
-	if (view.getBoundCamera() != null){
+	if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera){
 		int yp = view.getBounds().height/2;
 		double fa = Math.PI/2.0 - ((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()/2.0/180.0*Math.PI;
 		dts = Math.tan(fa)*yp/100;

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -160,37 +160,44 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown &&  !e.isShiftDown())
-		{
-			view.tilting = true;
-			tilt(e, view, clickPoint);
-			return;
-		}
-		else if (controlDown && e.isShiftDown())
-		{
-			rotateSpace(e, view, clickPoint);
-			return;
-		}
-		else if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
+		// Action selection by modifer keys
+
+		if (controlDown)
+			if (e.isShiftDown())
 			{
-				axis = viewToWorld.timesDirection(Vec3.vy());
-				angle = dx * DRAG_SCALE / view.getCamera().getDistToScreen();
+				rotateSpace(e, view, clickPoint);
+				return;
 			}
 			else
 			{
-				axis = viewToWorld.timesDirection(Vec3.vx());
-				angle = -dy * DRAG_SCALE / view.getCamera().getDistToScreen();
+				view.tilting = true;
+				tilt(e, view, clickPoint);
+				return;
 			}
-		}
-		else
-		{
-			axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-			angle = axis.length() / view.getCamera().getDistToScreen();
-			axis.normalize(); //  = axis.times(1.0/angle);
-			axis = viewToWorld.timesDirection(axis);
-		}
+		else 
+			if (e.isShiftDown())
+				if (Math.abs(dx) > Math.abs(dy))
+				{
+					axis = viewToWorld.timesDirection(Vec3.vy());
+					angle = dx * DRAG_SCALE / view.getCamera().getDistToScreen();
+				}
+				else
+				{
+					axis = viewToWorld.timesDirection(Vec3.vx());
+					angle = -dy * DRAG_SCALE / view.getCamera().getDistToScreen();
+				}
+			else
+			{
+				// The default case
+				
+				axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+				angle = axis.length() / view.getCamera().getDistToScreen();
+				axis.normalize(); //  = axis.times(1.0/angle);
+				axis = viewToWorld.timesDirection(axis);
+			}
+
+		// Modifier keys checked
+
 		if (angle != 0)
 		{
 			c.transformCoordinates(Mat4.translation(-location.x, -location.y, -location.z));
@@ -214,37 +221,44 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (controlDown && !e.isShiftDown())
-		{
-			view.tilting = true;
-			tilt(e, view, clickPoint);
-			return;
-		}
-		else if (controlDown && e.isShiftDown())
-		{
-			panSpace(e, view, clickPoint);
-			return;
-		}
-		else if (!controlDown && e.isShiftDown())
-		{
-			if (Math.abs(dx) > Math.abs(dy))
+		// Action selection by modifer keys
+
+		if (controlDown)
+			if (e.isShiftDown())
 			{
-				axis = viewToWorld.timesDirection(Vec3.vy());
-				angle = dx * DRAG_SCALE;
+				panSpace(e, view, clickPoint);
+				return;
 			}
 			else
 			{
-				axis = viewToWorld.timesDirection(Vec3.vx());
-				angle = -dy * DRAG_SCALE;
+				view.tilting = true;
+				tilt(e, view, clickPoint);
+				return;
 			}
-		}
 		else
-		{
-			axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
-			angle = axis.length();
-			axis = axis.times(1.0/angle);
-			axis = viewToWorld.timesDirection(axis);
-		}
+			if (e.isShiftDown())
+				if (Math.abs(dx) > Math.abs(dy))
+				{
+					axis = viewToWorld.timesDirection(Vec3.vy());
+					angle = dx * DRAG_SCALE;
+				}
+				else
+				{
+					axis = viewToWorld.timesDirection(Vec3.vx());
+					angle = -dy * DRAG_SCALE;
+				}
+			else
+			{
+				// This is the deault action
+				
+				axis = new Vec3(-dy*DRAG_SCALE, dx*DRAG_SCALE, 0.0);
+				angle = axis.length();
+				axis = axis.times(1.0/angle);
+				axis = viewToWorld.timesDirection(axis);
+			}
+
+		// Modifier keys checked
+
 		if (angle != 0.0)
 		{
 			c.transformCoordinates(Mat4.translation(-rotationCenter.x, -rotationCenter.y, -rotationCenter.z));

--- a/ArtOfIllusion/src/artofillusion/RotateViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/RotateViewTool.java
@@ -160,7 +160,7 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (mouseButtonTwo(e) && controlDown)
+		if (controlDown &&  !e.isShiftDown())
 		{
 			view.tilting = true;
 			tilt(e, view, clickPoint);
@@ -214,7 +214,7 @@ public class RotateViewTool extends EditingTool
 		dx = dragPoint.x-clickPoint.x;
 		dy = dragPoint.y-clickPoint.y;
 
-		if (mouseButtonTwo(e) && controlDown)
+		if (controlDown && !e.isShiftDown())
 		{
 			view.tilting = true;
 			tilt(e, view, clickPoint);


### PR DESCRIPTION
This basically resumes two methods of the state they were in before the Java-9 adaptation. Nothing is new. The latter commit presents the exact same logic in a more conventional form.

Both commits have been tested both on Java 8 and Java 11.

