### PR TITLE
Fix Illegal reflection - ToolTips

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -141,24 +141,10 @@ public class ArtOfIllusion
     catch (Exception ex)
     {
     }
+
     JPopupMenu.setDefaultLightWeightPopupEnabled(false);
     ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
-    try
-    {
-      // Due to the strange way PopupFactory is implemented, we need to use reflection to make sure
-      // we *really* get heavyweight popups from the very start.
 
-      Class<PopupFactory> popup = PopupFactory.class;
-      Field heavyweight = popup.getDeclaredField("HEAVY_WEIGHT_POPUP");
-      Method setPopupType = popup.getDeclaredMethod("setPopupType", Integer.TYPE);
-      heavyweight.setAccessible(true);
-      setPopupType.setAccessible(true);
-      setPopupType.invoke(PopupFactory.getSharedInstance(), heavyweight.get(null));
-    }
-    catch (Exception ex)
-    {
-      // Don't worry about it.
-    }
     TitleWindow title = new TitleWindow();
     PluginRegistry.addCategory(Plugin.class);
     PluginRegistry.addCategory(Renderer.class);


### PR DESCRIPTION
@peastman It's been a while since I saw any issues with tooltip z-order on Windows or Linux.

I suspect that Newer JVMs may have improved their handling in this respect. Could you check with a Mac? Might this also have been related to the window parenting issue?

I'd leave it in place, but the more recent, more aggressive deprecation/removal policies make it likely that we will need to deal with this sooner or later. Thoughts/feedback appreciated.