### PR TITLE
ObjectList hide/show fix

### DIFF
--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -1,6 +1,6 @@
 /* Copyright (C) 1999-2015 by Peter Eastman
    Changes copyright (C) 2016-2017 by Maksim Khramov
-   Changes copyright (C) 2017 by Petri Ihalainen
+   Changes copyright (C) 2017-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -65,7 +65,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
   UndoStack undoStack;
   int numViewsShown, currentView;
   private ActionProcessor uiEventProcessor;
-  private boolean modified, sceneChangePending;
+  private boolean modified, sceneChangePending, objectListShown;
   private KeyEventPostProcessor keyEventHandler;
   private SceneChangedEvent sceneChangedEvent;
   private List<ModellingTool> modellingTools;
@@ -84,6 +84,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     sceneChangedEvent = new SceneChangedEvent(this);
     uiEventProcessor = new ActionProcessor();
     createItemList();
+    objectListShown = true;
 
     // Create the four SceneViewer panels.
 
@@ -1081,7 +1082,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     addTrackMenu.setEnabled(numSelObjects > 0);
     distortionMenu.setEnabled(sel.length > 0);
     
-    viewMenuItem[1].setText(Translate.text(itemTreeScroller.getBounds().width == 0 || itemTreeScroller.getBounds().height == 0 ? "menu.showObjectList" : "menu.hideObjectList"));
+    viewMenuItem[1].setText(Translate.text(!objectListShown ? "menu.showObjectList" : "menu.hideObjectList"));
     viewMenuItem[2].setText(Translate.text(view.getShowAxes() ? "menu.hideCoordinateAxes" : "menu.showCoordinateAxes"));
     viewMenuItem[3].setEnabled(view.getTemplateImage() != null); // Show template
     viewMenuItem[3].setText(Translate.text(view.getTemplateShown() ? "menu.hideTemplate" : "menu.showTemplate"));
@@ -1339,6 +1340,7 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
 
   public void setObjectListVisible(boolean visible)
   {
+    objectListShown = visible; // in case this method is called from outside
     setDockableWidgetVisible((DockableWidget) itemTreeScroller.getParent(), visible);
   }
 
@@ -1642,8 +1644,6 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
           new RenderSetupDialog(this, theScene);
         else if (command.equals("renderImmediately"))
           RenderSetupDialog.renderImmediately(this, theScene);
-        else if (command.equals("hideObjectList"))
-          setObjectListVisible(itemTreeScroller.getBounds().width == 0 || itemTreeScroller.getBounds().height == 0);
         else if (command.equals("images"))
           new ImagesDialog(this, theScene, null);
       }
@@ -1666,6 +1666,8 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
         updateImage();
         updateMenus();
       }
+      else if (command.equals("hideObjectList"))
+        setObjectListVisible(objectListShown = !objectListShown);
       else if (command.equals("fitToSelection"))
         getView().fitToObjects(getSelectedObjects());
       else if (command.equals("fitToAll"))

--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -602,7 +602,6 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     displayMenu.add(displayItem[5] = Translate.checkboxMenuItem("renderedDisplay", this, "displayModeCommand", theView[0].getRenderMode() == ViewerCanvas.RENDER_RENDERED));
 
     viewMenu.add(viewMenuItem[0] = Translate.menuItem("fourViews", this, "toggleViewsCommand"));
-    viewMenu.add(viewMenuItem[1] = Translate.menuItem("hideObjectList", this, "actionPerformed"));
     viewMenu.add(Translate.menuItem("grid", this, "setGridCommand"));
     viewMenu.add(viewMenuItem[2] = Translate.menuItem("showCoordinateAxes", this, "actionPerformed"));
     viewMenu.add(viewMenuItem[3] = Translate.menuItem("showTemplate", this, "actionPerformed"));
@@ -611,6 +610,9 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     viewMenu.add(viewMenuItem[4] = Translate.menuItem("fitToSelection", this, "actionPerformed"));
     viewMenu.add(viewMenuItem[5] = Translate.menuItem("fitToAll", this, "actionPerformed"));
     viewMenu.add(viewMenuItem[6] = Translate.menuItem("alignWithClosestAxis", this, "actionPerformed"));
+    viewMenu.addSeparator();
+    viewMenu.add(viewMenuItem[1] = Translate.menuItem("hideObjectList", this, "actionPerformed"));
+
     //viewMenu.addSeparator();
     //viewMenu.add(viewMenuItem[7] = Translate.menuItem("viewSettings", this, "actionPerformed"));
   }
@@ -705,12 +707,12 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     animationMenu.add(animationMenuItem[10] = Translate.menuItem("pathFromCurve", this, "actionPerformed"));
     animationMenu.add(animationMenuItem[11] = Translate.menuItem("bindToParent", this, "bindToParentCommand"));
     animationMenu.addSeparator();
-    animationMenu.add(animationMenuItem[12] = Translate.menuItem("showScore", this, "actionPerformed"));
-    animationMenu.add(Translate.menuItem("previewAnimation", this, "actionPerformed"));
-    animationMenu.addSeparator();
     animationMenu.add(Translate.menuItem("forwardFrame", this, "actionPerformed"));
     animationMenu.add(Translate.menuItem("backFrame", this, "actionPerformed"));
     animationMenu.add(Translate.menuItem("jumpToTime", this, "jumpToTimeCommand"));
+    animationMenu.addSeparator();
+    animationMenu.add(Translate.menuItem("previewAnimation", this, "actionPerformed"));
+    animationMenu.add(animationMenuItem[12] = Translate.menuItem("showScore", this, "actionPerformed"));
   }
 
   private void createSceneMenu()
@@ -1081,13 +1083,13 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     animationMenuItem[12].setText(Translate.text(theScore.getBounds().height == 0 || theScore.getBounds().width == 0 ? "menu.showScore" : "menu.hideScore"));
     addTrackMenu.setEnabled(numSelObjects > 0);
     distortionMenu.setEnabled(sel.length > 0);
-    
+
     viewMenuItem[1].setText(Translate.text(!objectListShown ? "menu.showObjectList" : "menu.hideObjectList"));
     viewMenuItem[2].setText(Translate.text(view.getShowAxes() ? "menu.hideCoordinateAxes" : "menu.showCoordinateAxes"));
     viewMenuItem[3].setEnabled(view.getTemplateImage() != null); // Show template
     viewMenuItem[3].setText(Translate.text(view.getTemplateShown() ? "menu.hideTemplate" : "menu.showTemplate"));
     viewMenuItem[4].setEnabled(sel.length > 0); // Frame Selection With Camera
-    
+
     displayItem[0].setState(view.getRenderMode() == ViewerCanvas.RENDER_WIREFRAME);
     displayItem[1].setState(view.getRenderMode() == ViewerCanvas.RENDER_FLAT);
     displayItem[2].setState(view.getRenderMode() == ViewerCanvas.RENDER_SMOOTH);


### PR DESCRIPTION
First part of  #31.

Two things were wrong:
- The command was in the wrong block
- Visibility was recognized by the size of `itemTreeScroller` _(width or height == 0)_. However the size of the element itself was not changing, when the split-bar was forced to the edge. --> It was thought always to be shown. Now there is a boolean to remember the user's choice. _(Maybe not the ultimate clever solution, but works for now.)_

The command only applies to the panel, that the object list is part of and if the list is afloat, the command does nothing.

EDIT:

> the size of the element was not changing

The visibility of the score is detected the same way and that one works. 