### PR TITLE
Bad method removal

### DIFF
--- a/ArtOfIllusion/src/artofillusion/view/ViewerNavigationControl.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewerNavigationControl.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2017 by Petri Ihalainen
+/* Copyright (C) 2016-2019 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -32,11 +32,6 @@ public class ViewerNavigationControl implements ViewerControl
 	public String getName()
 	{
 		return Translate.text("Navigation");
-	}
-	
-	public Object getItem(int index)
-	{
-		return this.getItem(index);
 	}
 	
 	public static class NavigationChoice extends BComboBox


### PR DESCRIPTION
Removing a sick method. It was never called, so it did not cause any issues but it definitely should not be there.

I have no idea how that got there, but the most likely scenario I can think of is, that it was a left-over line from something else and I just patched without thinking to get it through the compiler  ... and then forgot.
