### PR TITLE
Creation depth of RootJoint corrected

### DIFF
--- a/ArtOfIllusion/src/artofillusion/animation/SkeletonTool.java
+++ b/ArtOfIllusion/src/artofillusion/animation/SkeletonTool.java
@@ -191,7 +191,7 @@ public class SkeletonTool extends EditingTool
         Joint j, parent = s.getJoint(mv.getSelectedJoint());
         if (parent == null)
           {
-            double distToJoint = cam.getDistToScreen();
+            double distToJoint = mv.getDistToPlane();
             clickPos = cam.convertScreenToWorld(clickPoint, distToJoint);
             objCoords.toLocal().transform(clickPos);
             j = new Joint(new CoordinateSystem(clickPos, Vec3.vz(), Vec3.vy()), null, "Root "+s.getNextJointID());


### PR DESCRIPTION
The creation depth of the root bone was wrong. After this it is the working depth of the view as expected. Works correctly both in parallel an perspective modes.

This seems to have slipped through my fingers in the views update.

- Bug fix. 
- Target 3.1.1
