### PR TITLE
GLCanvasDrawer initial blank view fix

### DIFF
--- a/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
@@ -974,9 +974,9 @@ public class GLCanvasDrawer implements CanvasDrawer
       if (view.isPerspective())
         minDepth = view.getCamera().getDistToScreen()/20.0;
       else
-        minDepth = Math.min(-0.01, depthRange[0]);
+        minDepth = Math.min(0.0, depthRange[0]);
+      maxDepth = Math.max(minDepth, depthRange[1])+0.01;
       minDepth -= 0.01;
-      maxDepth = depthRange[1]+0.01;
       if (view.getTemplateShown())
         drawImage(template, 0, 0);
       gl.glClear(GL.GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
This is a fix to a (minor) long term bug, that seems to have been there for ever:

If the scene is new, it only contains Camera 1 and Light 1 and their bounding box in behind the cut-off distance in perspective mode. --> Camera view is rendered blank, without the coordinate symbol or view border drawn.

The view being left blank would seem to indicate, that there is an uncaught exception/error somewhere. The view does recover as soon as you do something with it and I don't see any exception traps anywhere, so my best guess is, that the error is somewhere between the GLDrawer and GL itself.

This fix makes sure, that there is enough 'renderable' space between the camera point and the screen. 

**Target realease 3.1.1**

