### PR TITLE
NVIDIA crash bug tackle

### DIFF
--- a/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
+++ b/ArtOfIllusion/src/artofillusion/view/GLCanvasDrawer.java
@@ -1,4 +1,6 @@
-/* Copyright (C) 2005-2017 by Peter Eastman
+/* 
+Copyright (C) 2005-2017 by Peter Eastman
+Modifications copyright (C) 2019 Petri Ihalainen
 
 This program is free software; you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -943,6 +945,11 @@ public class GLCanvasDrawer implements CanvasDrawer
           useTextureRectangle = false;
         }
       }
+
+      // Tackling Nvidia bug 2019
+      FloatBuffer fb = Buffers.newDirectFloatBuffer(1);
+      gl.glVertexPointer(2, GL.GL_FLOAT, 0, fb);
+      gl.glNormalPointer(GL.GL_FLOAT, 0, fb);
     }
 
     @Override
@@ -974,9 +981,9 @@ public class GLCanvasDrawer implements CanvasDrawer
       if (view.isPerspective())
         minDepth = view.getCamera().getDistToScreen()/20.0;
       else
-        minDepth = Math.min(-0.01, depthRange[0]);
+        minDepth = Math.min(0.0, depthRange[0]);
+      maxDepth = Math.max(minDepth, depthRange[1])+0.01;
       minDepth -= 0.01;
-      maxDepth = depthRange[1]+0.01;
       if (view.getTemplateShown())
         drawImage(template, 0, 0);
       gl.glClear(GL.GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
Handling a bug in GL/Nvidia/Win10 environment that caused Java to crash. This is by no means a "fix" to the bug, that is outside our reach. This just prevents the unhandled error from happening by setting some initial values to an entity that the Nvidia drivers seem to expect to find.

Changes of #143 are included here, but this branch is derived from the master.

**Target 3.1.1**
