### PR TITLE
3D-Manipulator improvements

### DIFF
--- a/ArtOfIllusion/src/artofillusion/MoveScaleRotateMeshTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveScaleRotateMeshTool.java
@@ -69,7 +69,7 @@ public class MoveScaleRotateMeshTool extends MeshEditingTool
   public void drawOverlay(ViewerCanvas view)
   {
     BoundingBox selectionBounds = findSelectionBounds(view.getCamera());
-    if (!dragInProgress && manipulator.getViewMode() == Compound3DManipulator.NPQ_MODE && selectionBounds != null)
+    if (!dragInProgress && manipulator.getViewMode() == Compound3DManipulator.PQN_MODE && selectionBounds != null)
     {
       // Calculate the axis directions.
 
@@ -89,7 +89,7 @@ public class MoveScaleRotateMeshTool extends MeshEditingTool
       else
         updir = avgNorm.cross(Vec3.vy());
       updir.normalize();
-      manipulator.setNPQAxes(avgNorm, updir, avgNorm.cross(updir));
+      manipulator.setPQNAxes(updir.cross(avgNorm), updir, avgNorm);
     }
     manipulator.draw(view, selectionBounds);
     if (!dragInProgress)
@@ -210,7 +210,7 @@ public class MoveScaleRotateMeshTool extends MeshEditingTool
       if (mode == Compound3DManipulator.XYZ_MODE)
         manipulator.setViewMode(Compound3DManipulator.UV_MODE);
       else if (mode == Compound3DManipulator.UV_MODE)
-        manipulator.setViewMode(Compound3DManipulator.NPQ_MODE);
+        manipulator.setViewMode(Compound3DManipulator.PQN_MODE);
       else
         manipulator.setViewMode(Compound3DManipulator.XYZ_MODE);
       theWindow.updateImage();

--- a/ArtOfIllusion/src/artofillusion/MoveScaleRotateMeshTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveScaleRotateMeshTool.java
@@ -184,12 +184,12 @@ public class MoveScaleRotateMeshTool extends MeshEditingTool
     int selected[] = controller.getSelectionDistance();
     Vec3 v[] = new Vec3 [baseVertPos.length];
     for (int i = 0; i < v.length; i++)
-      {
-        if (selected[i] == 0)
-          v[i] = transform.times(baseVertPos[i]).minus(baseVertPos[i]);
-        else
-          v[i] = new Vec3();
-      }
+    {
+      if (selected[i] == 0)
+        v[i] = transform.times(baseVertPos[i]).minus(baseVertPos[i]);
+      else
+        v[i] = new Vec3();
+    }
     if (theFrame instanceof MeshEditorWindow)
       ((MeshEditorWindow) theFrame).adjustDeltas(v);
     for (int i = 0; i < v.length; i++)

--- a/ArtOfIllusion/src/artofillusion/MoveScaleRotateObjectTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveScaleRotateObjectTool.java
@@ -141,18 +141,24 @@ public class MoveScaleRotateObjectTool extends EditingTool
       int dx = dragPoint.x - clickPoint.x;
       int dy = dragPoint.y - clickPoint.y;
       if (e.isShiftDown() && !e.isControlDown())
-        {
-          if (Math.abs(dx) > Math.abs(dy))
-            dy = 0;
-          else
-            dx = 0;
-        }
+      {
+        if (Math.abs(dx) > Math.abs(dy))
+          dy = 0;
+        else
+          dx = 0;
+      }
       Vec3 v;
       if (e.isControlDown())
         v = view.getCamera().getCameraCoordinates().getZDirection().times(-dy*0.01);
       else
         v = view.getCamera().findDragVector(clickedObject.getCoords().getOrigin(), dx, dy);
-      handleDragged(manipulator.new HandleDraggedEvent(view, Compound3DManipulator.MOVE, Compound3DManipulator.ALL, screenBounds, selectionBounds, e, Mat4.translation(v.x, v.y, v.z)));
+      handleDragged(manipulator.new HandleDraggedEvent(view, 
+                                                       Compound3DManipulator.MOVE, 
+                                                       Compound3DManipulator.ALL, 
+                                                       screenBounds, 
+                                                       selectionBounds, 
+                                                       e, 
+                                                       Mat4.translation(v.x, v.y, v.z)));
     }
     else
       manipulator.mouseDragged(e, view);

--- a/ArtOfIllusion/src/artofillusion/MoveScaleRotateObjectTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveScaleRotateObjectTool.java
@@ -91,13 +91,13 @@ public class MoveScaleRotateObjectTool extends EditingTool
   public void drawOverlay(ViewerCanvas view)
   {
     BoundingBox selectionBounds = findSelectionBounds(view.getCamera());
-    if (!dragInProgress && manipulator.getViewMode() == Compound3DManipulator.NPQ_MODE && selectionBounds != null)
+    if (!dragInProgress && manipulator.getViewMode() == Compound3DManipulator.PQN_MODE && selectionBounds != null)
     {
       // Calculate the axis directions.
 
       ObjectInfo firstObj = getWindow().getSelectedObjects().iterator().next();
       CoordinateSystem coords = firstObj.getCoords();
-      manipulator.setNPQAxes(coords.getUpDirection().cross(coords.getZDirection()), coords.getUpDirection(), coords.getZDirection());
+      manipulator.setPQNAxes(coords.getUpDirection().cross(coords.getZDirection()), coords.getUpDirection(), coords.getZDirection());
     }
     manipulator.draw(view, selectionBounds);
     if (!dragInProgress)
@@ -370,7 +370,7 @@ public class MoveScaleRotateObjectTool extends EditingTool
       if (mode == Compound3DManipulator.XYZ_MODE)
         manipulator.setViewMode(Compound3DManipulator.UV_MODE);
       else if (mode == Compound3DManipulator.UV_MODE)
-        manipulator.setViewMode(Compound3DManipulator.NPQ_MODE);
+        manipulator.setViewMode(Compound3DManipulator.PQN_MODE);
       else
         manipulator.setViewMode(Compound3DManipulator.XYZ_MODE);
       theWindow.updateImage();

--- a/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
@@ -344,8 +344,17 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     }
     else
     {
-      handleSize = HANDLE_SIZE / view.getScale();
-      len = axisLength / view.getScale();
+      if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera)
+      {
+        double projectionDist = calculateProjectionDistance(view);
+        handleSize = HANDLE_SIZE/projectionDist/5.0;
+        len = axisLength/projectionDist/5.0;
+      }
+      else
+      {
+        handleSize = HANDLE_SIZE/view.getScale();
+        len = axisLength/view.getScale();
+      }
     }
     worldToScreen = view.getCamera().getWorldToScreen();
 
@@ -987,14 +996,11 @@ public class Compound3DManipulator extends EventSource implements Manipulator
 
   private double calculateProjectionDistance(ViewerCanvas view)
   {
-    if (! view.isPerspective())
-      return view.getCamera().getDistToScreen();
-
     double projectionDist;
     if (view.getBoundCamera() != null && view.getBoundCamera().getObject() instanceof SceneCamera)
     {
       double edgeAngle = (Math.PI - Math.toRadians(((SceneCamera)view.getBoundCamera().getObject()).getFieldOfView()))/2.0;
-      projectionDist = Math.tan(edgeAngle)/Camera.DEFAULT_DISTANCE_TO_SCREEN*view.getBounds().height/view.getScale()*10;
+      projectionDist = Math.tan(edgeAngle)/Camera.DEFAULT_DISTANCE_TO_SCREEN*view.getBounds().height/10.0;
     }
     else
       projectionDist = view.getCamera().getDistToScreen();

--- a/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
@@ -398,7 +398,7 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     //when in NPQ mode, the manipulator must not change position during dragging
     boolean freezeManipulator = ( dragging && (dragHandleType == ROTATE || dragHandleType == SCALE));
     if (!freezeManipulator)
-        center = view.getCamera().getViewToWorld().times(selectionBounds.getCenter());
+      center = view.getCamera().getViewToWorld().times(selectionBounds.getCenter());
 
     //now compute axis extremities and widget positions
     findHandleLocations(center, view);
@@ -424,19 +424,19 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     //draw rotation feedback if appropriate
     if (dragging && dragHandleType == ROTATE)
     {
-        Vec3[] pt = currentRotationHandle.getRotationFeedback(rotAngle);
-        Vec2 pt2d;
-        int[] x = new int[pt.length];
-        int[] y = new int[pt.length];
-        for (int j = 0; j < pt.length; j++)
-        {
-            pt2d = worldToScreen.timesXY(center.plus(pt[j].times(len)));
-            x[j] = (int) pt2d.x;
-            y[j] = (int) pt2d.y;
-        }
-        Polygon p = new Polygon(x, y, x.length);
-        view.drawShape(p, Color.darkGray);
-        view.fillShape( p, Color.gray);
+      Vec3[] pt = currentRotationHandle.getRotationFeedback(rotAngle);
+      Vec2 pt2d;
+      int[] x = new int[pt.length];
+      int[] y = new int[pt.length];
+      for (int j = 0; j < pt.length; j++)
+      {
+        pt2d = worldToScreen.timesXY(center.plus(pt[j].times(len)));
+        x[j] = (int) pt2d.x;
+        y[j] = (int) pt2d.y;
+      }
+      Polygon p = new Polygon(x, y, x.length);
+      view.drawShape(p, Color.darkGray);
+      view.fillShape( p, Color.gray);
     }
 
     // Draw the axes.
@@ -471,39 +471,40 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     view.drawImage(centerhandle, boxes[CENTER_INDEX].x, boxes[CENTER_INDEX].y);
     for (int i = 0; i < 2; i++)
     {
-        view.drawImage(handles[X_MOVE_INDEX +i], boxes[X_MOVE_INDEX +i].x, boxes[X_MOVE_INDEX +i].y);
+      view.drawImage(handles[X_MOVE_INDEX +i], boxes[X_MOVE_INDEX +i].x, boxes[X_MOVE_INDEX +i].y);
     }
     for (int i = 0; i < 2; i++)
     {
-        view.drawImage(handles[Y_MOVE_INDEX +i], boxes[Y_MOVE_INDEX +i].x, boxes[Y_MOVE_INDEX +i].y);
+      view.drawImage(handles[Y_MOVE_INDEX +i], boxes[Y_MOVE_INDEX +i].x, boxes[Y_MOVE_INDEX +i].y);
     }
     if (viewMode != UV_MODE)
         for (int i = 0; i < 2; i++)
     {
-        view.drawImage(handles[Z_MOVE_INDEX +i], boxes[Z_MOVE_INDEX +i].x, boxes[Z_MOVE_INDEX +i].y);
+      view.drawImage(handles[Z_MOVE_INDEX +i], boxes[Z_MOVE_INDEX +i].x, boxes[Z_MOVE_INDEX +i].y);
     }
     else
     {
-        int udeltax =  boxes[X_SCALE_INDEX].x + HANDLE_SIZE/2 - centerPoint.x;
-        int udeltay =  boxes[X_SCALE_INDEX].y + HANDLE_SIZE/2 - centerPoint.y;
-        int vdeltax =  boxes[Y_SCALE_INDEX].x + HANDLE_SIZE/2 - centerPoint.x;
-        int vdeltay =  boxes[Y_SCALE_INDEX].y + HANDLE_SIZE/2 - centerPoint.y;
-        extraUVBox.x = udeltax + vdeltax + centerPoint.x - HANDLE_SIZE/2;
-        extraUVBox.y = udeltay + vdeltay + centerPoint.y - HANDLE_SIZE/2;
-        Vec3 handlePos = center.plus(xaxis.times(len + handleSize*2.0)).plus(yaxis.times(len + handleSize*2.0));
-        Vec2 screenHandle = worldToScreen.timesXY(handlePos);
-        extraUVBox.x = (int) screenHandle.x - HANDLE_SIZE/2;
-        extraUVBox.y = (int) screenHandle.y - HANDLE_SIZE/2;
-        view.drawImage(handles[X_SCALE_INDEX], extraUVBox.x, extraUVBox.y);
+      int udeltax =  boxes[X_SCALE_INDEX].x + HANDLE_SIZE/2 - centerPoint.x;
+      int udeltay =  boxes[X_SCALE_INDEX].y + HANDLE_SIZE/2 - centerPoint.y;
+      int vdeltax =  boxes[Y_SCALE_INDEX].x + HANDLE_SIZE/2 - centerPoint.x;
+      int vdeltay =  boxes[Y_SCALE_INDEX].y + HANDLE_SIZE/2 - centerPoint.y;
+      extraUVBox.x = udeltax + vdeltax + centerPoint.x - HANDLE_SIZE/2;
+      extraUVBox.y = udeltay + vdeltay + centerPoint.y - HANDLE_SIZE/2;
+      Vec3 handlePos = center.plus(xaxis.times(len + handleSize*2.0)).plus(yaxis.times(len + handleSize*2.0));
+      Vec2 screenHandle = worldToScreen.timesXY(handlePos);
+      extraUVBox.x = (int) screenHandle.x - HANDLE_SIZE/2;
+      extraUVBox.y = (int) screenHandle.y - HANDLE_SIZE/2;
+      view.drawImage(handles[X_SCALE_INDEX], extraUVBox.x, extraUVBox.y);
     }
 
     //draw the rotation handles
     for (int i = 0; i < activeRotationHandleSet.length; ++i)
     {
-        RotationHandle rotHandle = activeRotationHandleSet[i];
-        for (int j = 0; j < rotHandle.points3d.length-1; j++)
-            view.drawLine(new Point((int) rotHandle.points2d[j].x, (int) rotHandle.points2d[j].y),
-                    new Point((int) rotHandle.points2d[j+1].x, (int) rotHandle.points2d[j+1].y), rotHandle.color);
+      RotationHandle rotHandle = activeRotationHandleSet[i];
+      for (int j = 0; j < rotHandle.points3d.length-1; j++)
+        view.drawLine(new Point((int) rotHandle.points2d[j].x,   (int) rotHandle.points2d[j].y),
+                      new Point((int) rotHandle.points2d[j+1].x, (int) rotHandle.points2d[j+1].y), 
+                      rotHandle.color);
     }
   }
 
@@ -522,27 +523,27 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     Point p = ev.getPoint();
     for (int i = 6; i >= 0; i--)
     {
-        if (viewMode == UV_MODE && ( i == Z_MOVE_INDEX || i == Z_SCALE_INDEX) )
-            continue;
-        if (boxes[i].contains(p))
+      if (viewMode == UV_MODE && ( i == Z_MOVE_INDEX || i == Z_SCALE_INDEX) )
+        continue;
+      if (boxes[i].contains(p))
+      {
+        if (i == CENTER_INDEX)
         {
-            if (i == CENTER_INDEX)
-            {
-                dragAxis = ALL;
-                dragHandleType = MOVE;
-                dragStartPosition = center;
-            }
-            else
-            {
-                dragHandleType = boxHandleType[i];
-                dragAxis = boxAxis[i];
-            }
-            orAxisLength = axisLength;
-            dragging = true;
-            baseClick = new Point(ev.getPoint());
-            dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
-            return true;
+          dragAxis = ALL;
+          dragHandleType = MOVE;
+          dragStartPosition = center;
         }
+        else
+        {
+          dragHandleType = boxHandleType[i];
+          dragAxis = boxAxis[i];
+        }
+        orAxisLength = axisLength;
+        dragging = true;
+        baseClick = new Point(ev.getPoint());
+        dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
+        return true;
+      }
     }
     //select proper rotation handles
     RotationHandle[] rotHandles = null;
@@ -555,28 +556,28 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     //and detect if click happened in one of them
     for (int i = 0; i < rotHandles.length; i++)
     {
-        if ( (rotSegment = rotHandles[i].findClickTarget(p, view.getCamera())) != -1)
-        {
-            currentRotationHandle = rotHandles[i];
-            dragHandleType = ROTATE;
-            dragAxis = currentRotationHandle.axis;
-            dragging = true;
-            baseClick = new Point(ev.getPoint());
-            dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
-            rotAngle = 0;
-            return true;
-        }
+      if ( (rotSegment = rotHandles[i].findClickTarget(p, view.getCamera())) != -1)
+      {
+        currentRotationHandle = rotHandles[i];
+        dragHandleType = ROTATE;
+        dragAxis = currentRotationHandle.axis;
+        dragging = true;
+        baseClick = new Point(ev.getPoint());
+        dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
+        rotAngle = 0;
+        return true;
+      }
     }
     //check for extra UV handle
     if (viewMode == UV_MODE && extraUVBox.contains(p))
     {
-        dragHandleType = SCALE;
-        dragAxis = UV;
-        orAxisLength = axisLength;
-        dragging = true;
-        baseClick = new Point(ev.getPoint());
-        dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
-        return true;
+      dragHandleType = SCALE;
+      dragAxis = UV;
+      orAxisLength = axisLength;
+      dragging = true;
+      baseClick = new Point(ev.getPoint());
+      dispatchEvent(new HandlePressedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev));
+      return true;
     }
     return false;
   }
@@ -667,9 +668,9 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     rotAngle = vector.dot(disp)/70;
     if (isShiftDown)
     {
-        rotAngle *= (180.0/(5*Math.PI));
-        rotAngle = Math.round(rotAngle);
-        rotAngle *= (5*Math.PI)/180;
+      rotAngle *= (180.0/(5*Math.PI));
+      rotAngle = Math.round(rotAngle);
+      rotAngle *= (5*Math.PI)/180;
     }
     Mat4 mat = Mat4.axisRotation(currentRotationHandle.rotAxis, rotAngle);
     if (rotateAroundSelectionCenter)
@@ -688,55 +689,55 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     Vec2 current = new Vec2(p.x - centerPoint.x, p.y - centerPoint.y);
     double scale = base.dot(current);
     if (base.length() < 1)
-        scale = 1;
+      scale = 1;
     else
-        scale /= (base.length()*base.length());
+      scale /= (base.length()*base.length());
     if (isCtrlDown)
     {
-        axisLength = orAxisLength*scale;
-        scale = 1;
-        view.repaint();
+      axisLength = orAxisLength*scale;
+      scale = 1;
+      view.repaint();
     }
     else
     {
-        scaleX = scaleY = scaleZ = 1;
-        if (dragAxis == X || dragAxis == U || dragAxis == N)
+      scaleX = scaleY = scaleZ = 1;
+      if (dragAxis == X || dragAxis == U || dragAxis == N)
+      {
+        scaleX = scale;
+        if (isShiftDown)
+          scaleY = scaleZ = scaleX;
+      }
+      else if (dragAxis == Y || dragAxis == V || dragAxis == P)
+      {
+        scaleY = scale;
+        if (isShiftDown)
+          scaleX = scaleZ = scaleY;
+      }
+      else if (dragAxis == Z || dragAxis == Q)
+      {
+        scaleZ = scale;
+        if (isShiftDown)
+          scaleY = scaleX = scaleZ;
+      }
+      else if (dragAxis == UV)
+      {
+        scaleX = x2DaxisNormed.dot(current)/x2DaxisNormed.dot(base);
+        scaleY = y2DaxisNormed.dot(current)/y2DaxisNormed.dot(base);
+        if (isShiftDown)
         {
-          scaleX = scale;
-          if (isShiftDown)
-              scaleY = scaleZ = scaleX;
+          if (scaleX < 1 && scaleY < 1)
+            scaleX = scaleZ = scaleY = Math.min(scaleX, scaleY);
+          else
+            scaleX = scaleZ = scaleY = Math.max(scaleX, scaleY);
         }
-        else if (dragAxis == Y || dragAxis == V || dragAxis == P)
-        {
-          scaleY = scale;
-          if (isShiftDown)
-              scaleX = scaleZ = scaleY;
-        }
-        else if (dragAxis == Z || dragAxis == Q)
-        {
-          scaleZ = scale;
-          if (isShiftDown)
-              scaleY = scaleX = scaleZ;
-        }
-        else if (dragAxis == UV)
-        {
-          scaleX = x2DaxisNormed.dot(current)/x2DaxisNormed.dot(base);
-          scaleY = y2DaxisNormed.dot(current)/y2DaxisNormed.dot(base);
-          if (isShiftDown)
-          {
-            if (scaleX < 1 && scaleY < 1)
-              scaleX = scaleZ = scaleY = Math.min(scaleX, scaleY);
-            else
-              scaleX = scaleZ = scaleY = Math.max(scaleX, scaleY);
-          }
-        }
-        CoordinateSystem coords = new CoordinateSystem(center, zaxis, yaxis);
-        Mat4 m = Mat4.scale(scaleX, scaleY, scaleZ).times(coords.toLocal());
-        m = coords.fromLocal().times(m);
-        if (dragAxis == UV)
-          dispatchEvent(new HandleDraggedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev, m, scaleX, scaleY));
-        else
-          dispatchEvent(new HandleDraggedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev, m, scale, 0.0));
+      }
+      CoordinateSystem coords = new CoordinateSystem(center, zaxis, yaxis);
+      Mat4 m = Mat4.scale(scaleX, scaleY, scaleZ).times(coords.toLocal());
+      m = coords.fromLocal().times(m);
+      if (dragAxis == UV)
+        dispatchEvent(new HandleDraggedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev, m, scaleX, scaleY));
+      else
+        dispatchEvent(new HandleDraggedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev, m, scale, 0.0));
     }
   }
 
@@ -780,150 +781,150 @@ public class Compound3DManipulator extends EventSource implements Manipulator
 
   private class RotationHandle
   {
-      private Axis axis;
-      private int segments;
-      protected Color color;
-      protected Vec3[] points3d;
-      protected Vec2[] points2d;
-      protected Vec3 rotAxis, refAxis;
+    private Axis axis;
+    private int segments;
+    protected Color color;
+    protected Vec3[] points3d;
+    protected Vec2[] points2d;
+    protected Vec3 rotAxis, refAxis;
 
-      /**
-       * Creates a Rotation Handle with a given number of segments
-       *
-       * @param segments The number of segmetns that describe the rotation circle
-       * @param axis The rotation axis
-       */
-      public RotationHandle(int segments, Axis axis, Color color )
+    /**
+     * Creates a Rotation Handle with a given number of segments
+     *
+     * @param segments The number of segmetns that describe the rotation circle
+     * @param axis The rotation axis
+     */
+    public RotationHandle(int segments, Axis axis, Color color )
+    {
+      this.segments = segments;
+      this.color = color;
+      this.axis = axis;
+      points3d = new Vec3[segments+1];
+      points2d = new Vec2[segments+1];
+      if (axis == X || axis == U || axis == N)
+        setAxis(xaxis, yaxis);
+      else if (axis == Y || axis == V || axis == P)
+        setAxis(yaxis, zaxis);
+      else
+        setAxis(zaxis, xaxis);
+//      switch (axis)
+//      {
+//        case XAXIS :
+//          setAxis(xaxis, yaxis);
+//          break;
+//        case YAXIS :
+//          setAxis(yaxis, zaxis);
+//          break;
+//        case ZAXIS :
+//          setAxis(zaxis, xaxis);
+//          break;
+//      }
+    }
+
+    /**
+     * sets the axis of the handle
+     * @param rotAxis The rotation axis
+     * @param refAxis The axis where arc drawing begins.
+     * Used when asking for a rotation feedback polygon
+     */
+    public void setAxis(Vec3 rotAxis, Vec3 refAxis)
+    {
+      this.rotAxis = rotAxis;
+      this.refAxis = refAxis;
+      Mat4 m = Mat4.axisRotation(rotAxis, 2*Math.PI/segments);
+      Vec3 v = new Vec3(refAxis);
+      for (int i = 0; i <= segments; i++)
+        points3d[i] = v = m.times(v);
+    }
+
+
+    /**
+     * Given an angle, this method returns a 3D polygon which can be used to
+     * tell the user the rotation amount when drawn on the canvas
+     * @param angle
+     * @return The 2d points deinfing the polygon
+     */
+
+    public Vec3[] getRotationFeedback(double angle)
+    {
+      Vec3[] points = new Vec3[segments+1];
+
+      points[0] = new Vec3();
+      Mat4 m = null;
+      Vec3 v = null;
+      m = Mat4.axisRotation(rotAxis, angle/segments);
+      v = new Vec3(refAxis);
+      points[1] = v;
+      for (int i = 1; i < segments; i++)
+        points[i+1] = v = m.times(v);
+      return points;
+    }
+
+    /**
+     * This method tells if the mouse has been been clicked on a rotation handle
+     *
+     * @param pos The point where the mouse was clicked
+     * @param camera The view camera
+     * @return The number of the segment being clicked on or -1 if the mouse has not been
+     * clicked on the handle
+     */
+    public int findClickTarget(Point pos, Camera camera)
+    {
+      double u, v, w, z;
+      double closestz = Double.MAX_VALUE;
+      int which = -1;
+      for ( int i = 0; i < points2d.length - 1; i++ )
       {
-          this.segments = segments;
-          this.color = color;
-          this.axis = axis;
-          points3d = new Vec3[segments+1];
-          points2d = new Vec2[segments+1];
-          if (axis == X || axis == U || axis == N)
-            setAxis(xaxis, yaxis);
-          else if (axis == Y || axis == V || axis == P)
-            setAxis(yaxis, zaxis);
-          else
-            setAxis(zaxis, xaxis);
-//          switch (axis)
-//          {
-//              case XAXIS :
-//                  setAxis(xaxis, yaxis);
-//                  break;
-//              case YAXIS :
-//                  setAxis(yaxis, zaxis);
-//                  break;
-//              case ZAXIS :
-//                  setAxis(zaxis, xaxis);
-//                  break;
-//          }
-      }
+        Vec2 v1 = points2d[i];
+        Vec2 v2 = points2d[i+1];
+        if ( ( pos.x < v1.x - HANDLE_SIZE / 4 && pos.x < v2.x - HANDLE_SIZE / 4 ) ||
+             ( pos.x > v1.x + HANDLE_SIZE / 4 && pos.x > v2.x + HANDLE_SIZE / 4 ) ||
+             ( pos.y < v1.y - HANDLE_SIZE / 4 && pos.y < v2.y - HANDLE_SIZE / 4 ) ||
+             ( pos.y > v1.y + HANDLE_SIZE / 4 && pos.y > v2.y + HANDLE_SIZE / 4 ) )
+          continue;
 
-      /**
-       * sets the axis of the handle
-       * @param rotAxis The rotation axis
-       * @param refAxis The axis where arc drawing begins.
-       * Used when asking for a rotation feedback polygon
-       */
-      public void setAxis(Vec3 rotAxis, Vec3 refAxis)
-      {
-          this.rotAxis = rotAxis;
-          this.refAxis = refAxis;
-          Mat4 m = Mat4.axisRotation(rotAxis, 2*Math.PI/segments);
-          Vec3 v = new Vec3(refAxis);
-          for (int i = 0; i <= segments; i++)
-               points3d[i] = v = m.times(v);
-      }
+        // Determine the distance of the click point from the line.
 
-
-      /**
-       * Given an angle, this method returns a 3D polygon which can be used to
-       * tell the user the rotation amount when drawn on the canvas
-       * @param angle
-       * @return The 2d points deinfing the polygon
-       */
-
-      public Vec3[] getRotationFeedback(double angle)
-      {
-          Vec3[] points = new Vec3[segments+1];
-
-          points[0] = new Vec3();
-          Mat4 m = null;
-          Vec3 v = null;
-          m = Mat4.axisRotation(rotAxis, angle/segments);
-          v = new Vec3(refAxis);
-          points[1] = v;
-          for (int i = 1; i < segments; i++)
-              points[i+1] = v = m.times(v);
-          return points;
-      }
-
-      /**
-       * This method tells if the mouse has been been clicked on a rotation handle
-       *
-       * @param pos The point where the mouse was clicked
-       * @param camera The view camera
-       * @return The number of the segment being clicked on or -1 if the mouse has not been
-       * clicked on the handle
-       */
-      public int findClickTarget(Point pos, Camera camera)
-      {
-          double u, v, w, z;
-          double closestz = Double.MAX_VALUE;
-          int which = -1;
-          for ( int i = 0; i < points2d.length - 1; i++ )
+        if ( Math.abs( v1.x - v2.x ) > Math.abs( v1.y - v2.y ) )
+        {
+          if ( v2.x > v1.x )
           {
-              Vec2 v1 = points2d[i];
-              Vec2 v2 = points2d[i+1];
-              if ( ( pos.x < v1.x - HANDLE_SIZE / 4 && pos.x < v2.x - HANDLE_SIZE / 4 ) ||
-                      ( pos.x > v1.x + HANDLE_SIZE / 4 && pos.x > v2.x + HANDLE_SIZE / 4 ) ||
-                      ( pos.y < v1.y - HANDLE_SIZE / 4 && pos.y < v2.y - HANDLE_SIZE / 4 ) ||
-                      ( pos.y > v1.y + HANDLE_SIZE / 4 && pos.y > v2.y + HANDLE_SIZE / 4 ) )
-                  continue;
-
-              // Determine the distance of the click point from the line.
-
-              if ( Math.abs( v1.x - v2.x ) > Math.abs( v1.y - v2.y ) )
-              {
-                  if ( v2.x > v1.x )
-                  {
-                      v = ( (double) pos.x - v1.x ) / ( v2.x - v1.x );
-                      u = 1.0 - v;
-                  }
-                  else
-                  {
-                      u = ( (double) pos.x - v2.x ) / ( v1.x - v2.x );
-                      v = 1.0 - u;
-                  }
-                  w = u * v1.y + v * v2.y - pos.y;
-              }
-              else
-              {
-                  if ( v2.y > v1.y )
-                  {
-                      v = ( (double) pos.y - v1.y ) / ( v2.y - v1.y );
-                      u = 1.0 - v;
-                  }
-                  else
-                  {
-                      u = ( (double) pos.y - v2.y ) / ( v1.y - v2.y );
-                      v = 1.0 - u;
-                  }
-                  w = u * v1.x + v * v2.x - pos.x;
-              }
-              if ( Math.abs( w ) > HANDLE_SIZE / 2 )
-                  continue;
-              z = u * camera.getObjectToView().timesZ( points3d[i] ) +
-                      v * camera.getObjectToView().timesZ( points3d[i+1] );
-              if ( z < closestz )
-              {
-                  closestz = z;
-                  which = i;
-              }
+            v = ( (double) pos.x - v1.x ) / ( v2.x - v1.x );
+            u = 1.0 - v;
           }
-          return which;
+          else
+          {
+            u = ( (double) pos.x - v2.x ) / ( v1.x - v2.x );
+            v = 1.0 - u;
+          }
+          w = u * v1.y + v * v2.y - pos.y;
+        }
+        else
+        {
+          if ( v2.y > v1.y )
+          {
+            v = ( (double) pos.y - v1.y ) / ( v2.y - v1.y );
+            u = 1.0 - v;
+          }
+          else
+          {
+            u = ( (double) pos.y - v2.y ) / ( v1.y - v2.y );
+            v = 1.0 - u;
+          }
+          w = u * v1.x + v * v2.x - pos.x;
+        }
+        if ( Math.abs( w ) > HANDLE_SIZE / 2 )
+          continue;
+        z = u * camera.getObjectToView().timesZ( points3d[i] ) +
+            v * camera.getObjectToView().timesZ( points3d[i+1] );
+        if ( z < closestz )
+        {
+          closestz = z;
+          which = i;
+        }
       }
+      return which;
+    }
   }
 
   /**

--- a/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
@@ -455,6 +455,14 @@ public class Compound3DManipulator extends EventSource implements Manipulator
 
     findHandleLocations(center, view);
 
+    // Don't draw if the selection too close or behind the viewing point
+    if (view.isPerspective())
+      if (center.
+          minus(view.getCamera().getCameraCoordinates().getOrigin()).
+          dot(view.getCamera().getCameraCoordinates().getZDirection())
+          < 0.5)
+        return;
+
     //draw rotation feedback if appropriate
     if (dragging && dragHandleType == ROTATE)
     {


### PR DESCRIPTION
Here are some improvements to the Compound3DManipulator.
- Handle distance to the axes stays constant regardless of the size of the manipulator
- UV-directions are now U to right and V up
- NPQ mode renamed PQN mode. _The N stands for normal in model coordinates and object-Z in scene._
- In parallel viewing the move follows the handle correctly also, when there is depth movement included.
- In perspective mode the move and the manipulator tend to get ahead or be left behind of the mouse depending on the relative direction. To have it precisely follow the mouse looks like a very complex process. _(I tested a bit but I'm literally back at the drawing board with it)_
- <strike>In perspective mode it is not a 100% success otherwise either but hopefully better than before.</strike> Actually it works as intended.
- Removed some unused or redundant code but there is more in that department to do. 

If you find something wrong, let me know.  On my behalf this could be merged as is but I may push updates too as soon as I get any done.

Future plans: 
- Drawing order logic. I know how, but this tempts me to get into a pretty thorough remake of a lot of other things first.
- Closer look at the data structure in general. (Like get rid of the `Manipulator` interface, which is not designed for a 3D-manipulator.)
