### PR TITLE
Minimum zoom distance

### DIFF
--- a/ArtOfIllusion/src/artofillusion/MoveViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/MoveViewTool.java
@@ -208,11 +208,11 @@ public class MoveViewTool extends EditingTool
       Rectangle bounds = view.getBounds();
       if (view.isPerspective())
       {
-        newDist = oldDist*Math.pow(1.0/1.01, (double)dy);
+        newDist = Math.max(oldDist*Math.pow(1.0/1.01, (double)dy), ViewerCanvas.MINIMUM_ZOOM_DISTANCE);
       }
       else
       {
-        double newScale = oldScale*(Math.pow(1.01,(double)dy));
+        double newScale = Math.min(oldScale*(Math.pow(1.01,(double)dy)), cam.getDistToScreen()*100/ViewerCanvas.MINIMUM_ZOOM_DISTANCE);
         view.setScale(newScale);
         cam.setScreenParamsParallel(newScale, bounds.width, bounds.height);
         newDist = cam.getDistToScreen()*100.0/newScale;

--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 by Petri Ihalainen
+/* Copyright (C) 2017-2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -28,7 +28,7 @@ public class ScrollViewTool
   private EditingWindow window;
   private ViewerCanvas view;
   private Camera camera;
-  private double distToPlane;
+  private double distToPlane, scale;
   private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY;
   private int navigationMode, scrollSteps, startOrientation;
   private Vec3 startZ, startUp;
@@ -50,6 +50,7 @@ public class ScrollViewTool
     v.mouseMoving = false;
     view = v;
     view.scrolling = true;
+    scale = view.getScale();
     distToPlane = view.getDistToPlane();
     navigationMode = view.getNavigationMode();
     bounds = view.getBounds();
@@ -106,11 +107,20 @@ public class ScrollViewTool
     if (ArtOfIllusion.getPreferences().getReverseZooming())
       amount *= -1;
     if (view.isPerspective())
+    {
       distToPlane = distToPlane*Math.pow(1.01, amount);
+      distToPlane = Math.max(distToPlane, ViewerCanvas.MINIMUM_ZOOM_DISTANCE);
+    }
     else
     {
-      view.setScale(view.getScale()*Math.pow(1.0/1.01, amount));
-      distToPlane = camera.getDistToScreen()*100.0/view.getScale();
+      scale = view.getScale()*Math.pow(1.0/1.01, amount);
+      distToPlane = camera.getDistToScreen()*100.0/scale;
+      if (distToPlane < ViewerCanvas.MINIMUM_ZOOM_DISTANCE)
+      {
+        distToPlane = ViewerCanvas.MINIMUM_ZOOM_DISTANCE;
+        scale = camera.getDistToScreen()*100.0/distToPlane;
+      }
+      view.setScale(scale);
       camera.setScreenParamsParallel(view.getScale(), bounds.width, bounds.height);
     }
     CoordinateSystem coords = camera.getCameraCoordinates();

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -109,6 +109,8 @@ public abstract class ViewerCanvas extends CustomWidget
   public static final int NAVIGATE_TRAVEL_SPACE = 2;
   public static final int NAVIGATE_TRAVEL_LANDSCAPE = 3;
 
+  public static final double MINIMUM_ZOOM_DISTANCE = 1.0E-12; // Closer than this numerical errors start to show
+
   public boolean mouseDown, mouseMoving, tilting, moving, rotating, scrolling, dragging;
 
   /** Create a new ViewerCanvas */
@@ -900,6 +902,7 @@ public abstract class ViewerCanvas extends CustomWidget
     double scalex = bounds.width/(double) screenBounds.width;
     double scaley = bounds.height/(double) screenBounds.height;
     double minScale = (scalex < scaley ? scalex : scaley);
+    minScale = Math.min(minScale, theCamera.getDistToScreen()*100.0/MINIMUM_ZOOM_DISTANCE);
     if (isPerspective())
     {
       // Perspective mode, so adjust the camera position.
@@ -936,6 +939,10 @@ public abstract class ViewerCanvas extends CustomWidget
     Vec3 size = b.getSize();
     double diag = Math.sqrt(size.x*size.x+size.y*size.y+size.z*size.z);
     double newDistToPlane = 100*theCamera.getDistToScreen() / (double)d / 0.9 * diag;
+
+    // The calling I know of have limits of their own but this method is available for others.
+
+    newDistToPlane = Math.max(newDistToPlane, MINIMUM_ZOOM_DISTANCE);
     newCoords.setOrigin(newCenter.plus(newCoords.getZDirection().times(-newDistToPlane-(b.maxz-b.minz) * 0.5)));
     double newScale;
     if (perspective)
@@ -1007,7 +1014,7 @@ public abstract class ViewerCanvas extends CustomWidget
     CoordinateSystem newCoords;
     BoundingBox b;
     double br, z; // box radius, view z coordinate
-    Vec3 bc;   // box center
+    Vec3 bc;      // box center
     Vec3 cx, cy, cz, newCenter;
     cz = theCamera.getCameraCoordinates().getZDirection();
     cy = theCamera.getCameraCoordinates().getUpDirection();
@@ -1059,7 +1066,9 @@ public abstract class ViewerCanvas extends CustomWidget
     }
     else
       projectionDist = theCamera.getDistToScreen();
+
     double newDistToPlane = 100*projectionDist/(double)d/0.9*Math.max(maxx-minx, maxy-miny)+(maxz-minz)*0.5;
+    newDistToPlane = Math.max(newDistToPlane, MINIMUM_ZOOM_DISTANCE); // Attempt to zoom to zero size blanks the view.
     double newScale;
     if (perspective)
       newScale = 100.0;


### PR DESCRIPTION
This prevents zooming into "crash zone".

`Fit View to Selection` selection, when the selected object(s) return a zero-sized bounding box would blank the view. Now the minimum distance from Camera to drawing plane is set to 1.0E-12.  Surprisingly with this magnification and the view set to parallel mode you can still create primitives and rotate the view normally. Some display modes (transparent and shaded) don't work correctly any more though.

The limit is set to the scroll wheel zoom and the magnification field of the ViewerCanvas. It is _possible_ to scroll wheel to 1.0E-12 distance of a point (= 2.0E15 scaling) but it _does_ take some patience....
