### PR TITLE
Change to full TOC in manual sidebar

### DIFF
--- a/docs/manual/conf.py
+++ b/docs/manual/conf.py
@@ -95,7 +95,7 @@ html_static_path = ['_static']
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-# html_sidebars = {}
+html_sidebars = {'**': ['globaltoc.html', 'relations.html', 'searchbox.html']}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
This I kind of feel strongly about, no matter what other decisions we make regarding templates, formatting, etc:

The sidebar should have a global toc! I want to see what my options are in whatever I'm reading!