### PR TITLE
Refactor build definition to use global properties

### DIFF
--- a/ArtOfIllusion.xml
+++ b/ArtOfIllusion.xml
@@ -3,16 +3,19 @@
 <project name="ArtOfIllusion" default="dist" basedir=".">
 
   <!-- set global properties for this build -->
+  <property file="build.properties" />
+  <property name="srclib" value="${srclib}" />
+  <property name="dist" value="${dist}" />
+  <property name="docs" value="${docs}" />
+  <property name="lang.version" value="${lang.version}" />
+  <property name="java.args" value="${java.args}" />
+  <property name="java.encoding" value="${java.encoding}" />
+
   <property name="src" value="ArtOfIllusion/src" />
   <property name="build" value="ArtOfIllusion/build" />
-  <property name="docs" value="ArtOfIllusion/docs" />
-  <property name="lib" value="lib" />
-  <property name="dist" value="${basedir}/Live_Application" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
-
+  
   <!-- set of all library jars -->
-  <fileset id="libraries" dir="${lib}" includes="*.jar" />
+  <fileset id="libraries" dir="${srclib}" includes="*.jar" />
 
   <target name="init">
     <!-- Create the time stamp -->
@@ -26,8 +29,14 @@
     <pathconvert property="classpath" refid="libraries" />
 
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" destdir="${build}" encoding="UTF-8" classpath="${classpath}" debug="on" target="${JavaVersion}" source="${JavaVersion}" >
-      <compilerarg line="${args}"/>
+    <javac srcdir="${src}"
+	   destdir="${build}"
+	   encoding="${java.encoding}"
+	   classpath="${classpath}"
+	   debug="on"
+	   target="${lang.version}"
+	   source="${lang.version}" >
+      <compilerarg line="${java.args}"/>
     </javac>
   </target>
 
@@ -53,7 +62,7 @@
     <javadoc packagenames="artofillusion.*"
         sourcepath="${src}"
         classpath="${lib}/*.jar"
-	source="${JavaVersion}"
+	source="${lang.version}"
         defaultexcludes="yes"
 	destdir="${docs}/${ant.project.name}"
         author="true"

--- a/OSSpecific.xml
+++ b/OSSpecific.xml
@@ -3,14 +3,19 @@
 <project name="OSSpecific" default="dist" basedir=".">
 
   <!-- set global properties for this build -->
+
+  <property file="build.properties" />
+  <property name="srclib" value="${srclib}" />
+  <property name="dist" value="${dist}" />
+  <property name="docs" value="${docs}" />
+  <property name="jang.version" value="${lang.version}" />
+  <property name="java.args" value="${java.args}" />
+  <property name="java.encoding" value="${java.encoding}" />
+
   <property name="src" value="OSSpecific/src" />
   <property name="build" value="OSSpecific/build" />
-  <property name="docs" value="OSSpecific/docs" />
-  <property name="dist" value="Live_Application" />
   <property name="assemble" value="${dist}/Plugins" />
   <property name="aoijar" value="${dist}/ArtOfIllusion.jar" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
 
   <target name="init">
     <!-- Create the time stamp -->
@@ -24,8 +29,14 @@
 
   <target name="compile" depends="init">
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" destdir="${build}" encoding="UTF-8" classpath="${aoijar}" debug="on" target="${JavaVersion}" source="${JavaVersion}" >
-      <compilerarg line="${args}"/>
+    <javac srcdir="${src}"
+           destdir="${build}"
+	   encoding="${java.encoding}"
+	   classpath="${aoijar}"
+	   debug="on"
+	   target="${lang.version}"
+	   source="${lang.version}" >
+        <compilerarg line="${java.args}"/>
     </javac>
   </target>
 
@@ -39,7 +50,7 @@
     <javadoc packagenames="artofillusion.*"
         sourcepath="${src}"
 	classpath="${aoijar}"
-	source="${JavaVersion}"
+	source="${lang.version}"
         defaultexcludes="yes"
 	destdir="${docs}/${ant.project.name}"
         author="true"

--- a/Renderers.xml
+++ b/Renderers.xml
@@ -3,14 +3,17 @@
 <project name="Renderers" default="dist" basedir=".">
 
   <!-- set global properties for this build -->
-  <property name="src" value="Renderers/src" />
-  <property name="build" value="Renderers/build" />
-  <property name="docs" value="Renderers/docs" />
-  <property name="dist" value="Live_Application" />
+  <property file="build.properties" />
+  <property name="docs" value="${docs}" />
+  <property name="dist" value="${dist}" />
+  <property name="lang.version" value="${lang.version}" />
+  <property name="java.encoding" value="${java.encoding}" />
+  <property name="java.args" value="${java.args}" />
+
   <property name="assemble" value="${dist}/Plugins" />
   <property name="aoijar" value="${dist}/ArtOfIllusion.jar" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
+  <property name="src" value="Renderers/src" />
+  <property name="build" value="Renderers/build" />
 
   <target name="init">
     <!-- Create the time stamp -->
@@ -25,8 +28,14 @@
 
   <target name="compile" depends="init">
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" destdir="${build}" encoding="UTF-8" classpath="${aoijar}" debug="on" target="${JavaVersion}" source="${JavaVersion}" >
-      <compilerarg line="${args}"/>
+    <javac srcdir="${src}"
+  	   destdir="${build}"
+	   encoding="${java.encoding}"
+	   classpath="${aoijar}"
+	   debug="on"
+	   target="${lang.version}"
+	   source="${lang.version}" >
+      <compilerarg line="${java.args}"/>
     </javac>
   </target>
 
@@ -40,7 +49,7 @@
     <javadoc packagenames="artofillusion.*"
         sourcepath="${src}"
 	classpath="${aoijar}"
-	source="${JavaVersion}"
+	source="${lang.version}"
         defaultexcludes="yes"
         destdir="${docs}"
         author="true"

--- a/Tools.xml
+++ b/Tools.xml
@@ -4,14 +4,17 @@
 
 	
   <!-- set global properties for this build -->
+  <property file="build.properties" />
+  <property name="docs" value="${docs}" />
+  <property name="dist" value="${dist}" />
+  <property name="lang.version" value="${lang.version}" />
+  <property name="java.encoding" value="${java.encoding}" />
+  <property name="java.args" value="${java.args}" />
+
   <property name="src" value="Tools/src" />
   <property name="build" value="Tools/build" />
-  <property name="docs" value="Tools/docs" />
-  <property name="dist" value="Live_Application" />
   <property name="assemble" value="${dist}/Plugins" />
   <property name="aoijar" value="${dist}/ArtOfIllusion.jar" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
 
   <target name="init">
     <!-- Create the time stamp -->
@@ -26,8 +29,14 @@
 
   <target name="compile" depends="init">
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" destdir="${build}" encoding="UTF-8" classpath="${aoijar}" debug="on" target="${JavaVersion}" source="${JavaVersion}" >
-      <compilerarg line="${args}"/>
+   <javac srcdir="${src}"
+	  destdir="${build}"
+	  encoding="${java.encoding}"
+	  classpath="${aoijar}"
+	  debug="on"
+	  target="${lang.version}"
+	  source="${lang.version}" >
+      <compilerarg line="${java.args}"/>
     </javac>
   </target>
 
@@ -42,7 +51,7 @@
     <javadoc packagenames="artofillusion.*"
         sourcepath="${src}"
 	classpath="${aoijar}"
-	source="${JavaVersion}"
+	source="${lang.version}"
         defaultexcludes="yes"
         destdir="${docs}"
         author="true"

--- a/Translators.xml
+++ b/Translators.xml
@@ -3,14 +3,17 @@
 <project name="Translators" default="dist" basedir=".">
 
   <!-- set global properties for this build -->
+  <property file="build.properties" />    
+  <property name="docs" value="${docs}" />
+  <property name="dist" value="${dist}" />
+  <property name="lang.version" value="${lang.version}" />
+  <property name="java.encoding" value= "${java.encoding}" />
+  <property name="java.args" value="${java.args}" />
+
   <property name="src" value="Translators/src" />
   <property name="build" value="Translators/build" />
-  <property name="docs" value="Translators/docs" />
-  <property name="dist" value="Live_Application" />
   <property name="assemble" value="${dist}/Plugins" />
   <property name="aoijar" value="${dist}/ArtOfIllusion.jar" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
 
   <target name="init">
     <!-- Create the time stamp -->
@@ -25,8 +28,14 @@
 
   <target name="compile" depends="init">
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" destdir="${build}" encoding="UTF-8" classpath="${aoijar}" debug="on" target="${JavaVersion}" source="${JavaVersion}" >
-      <compilerarg line="${args}"/>
+    <javac srcdir="${src}"
+	   destdir="${build}"
+	   encoding="${java.encoding}"
+	   classpath="${aoijar}"
+	   debug="on"
+	   target="${lang.version}"
+	   source="${lang.version}" >
+      <compilerarg line="${java.args}"/>
     </javac>
   </target>
 
@@ -40,7 +49,7 @@
     <javadoc packagenames="artofillusion.*"
         sourcepath="${src}"
 	classpath="${aoijar}"
-	source="${JavaVersion}"
+	source="${lang.version}"
         defaultexcludes="yes"
         destdir="${docs}"
         author="true"

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,12 @@
+#Where to find binary dependencies
+srclib=lib
+
+#Location to place completed artifiacts
+dist=Live_Application
+
+lang.version=1.6
+java.encoding=UTF-8
+java.args=-nowarn
+
+# Where to place generated Javadoc
+docs=docs/Javadoc

--- a/build.xml
+++ b/build.xml
@@ -3,14 +3,16 @@
 <project name="ArtOfIllusion Full Suite" default="dist" basedir=".">
 
   <!-- set global properties for this build -->
-  <property name="lib" value="lib" />
-  <property name="dist" value="Live_Application" />
-  <property name="docs" value="docs/Javadoc" />
-  <property name="JavaVersion" value="1.6" />
-  <property name="args" value="-nowarn" />
+  <property file="build.properties" />
+  <property name="srclib" value="${srclib}" />
+  <property name="dist" value="${dist}" />
+  <property name="docs" value="${docs}" />
+  <property name="java.version" value="${java.version}" />
+  <property name="java.args" value="${java.args}" />
+  <property name="java.encoding" value="${java.encoding}" />
 
   <!-- set of all library jars -->
-  <fileset id="libraries" dir="${lib}" includes="*.jar" />
+  <fileset id="libraries" dir="${srclib}" includes="*.jar" />
 
   <!-- set of all subproject build files -->
   <fileset id="subproject.files" dir="." includes="*.xml" excludes="build.xml" />
@@ -31,14 +33,16 @@
   <!-- Generate working application artifacts -->
   <target name="dist" depends="init" description="Generate a working full-project application">
     <copy todir="${dist}/lib">
-      <fileset dir="${lib}" includes="*"/>
+      <fileset dir="${srclib}" includes="*"/>
     </copy>
 
     <!-- execute default target for all found Ant files -->
     <subant target="" >
       <property name="dist" value="${dist}" />
-      <property name="lib" value="${lib}"/>
-      <property name="args" value="${args}"/>
+      <property name="srclib" value="${srclib}"/>
+      <property name="java.version" value="${java.version}" />
+      <property name="java.args" value="${java.args}"/>
+      <property name="java.encoding" value="${java.encoding}" />
       <fileset refid="subproject.files" />
     </subant>
   </target>
@@ -49,8 +53,8 @@
    <mkdir dir="${docs}" />
    <javadoc packagenames="artofillusion.*"
      sourcepath="ArtOfIllusion/src:OSSpecific/src:Renderers/src:Tools/src:Translators/src"
-     classpath="${lib}/*.jar"
-     source="${JavaVersion}"
+     classpath="${srclib}/*.jar"
+     source="${java.version}"
      defaultexcludes="yes"
      destdir="${docs}"
      author="true"
@@ -76,7 +80,12 @@
       <pathelement location="Renderers/build" />
       <fileset refid="libraries" />
     </path>
-    <javac srcdir="Tests/src" destdir="Tests/build" classpathref="bin_paths" debug="on" target="${JavaVersion}" source="${JavaVersion}" />
+    <javac srcdir="Tests/src"
+           destdir="Tests/build"
+	   classpathref="bin_paths"
+	   debug="on"
+           target="${lang.version}"
+           source="${lang.version}" />
     <junit printsummary="on" haltonfailure="yes" fork="false">
       <classpath>
         <path refid="bin_paths"/>
@@ -110,18 +119,7 @@
       <arg value="${ant.file}" />
     </java>
     <echo>
-      The 'dist' target accepts the following properties as options:
-
-      dist: directory at which to base the live build. Defaults to ${dist}.
-      args: compile-time arguments to pass to javac. Useful for running
-      various lints, etc. Defaults to ${args}.
-
-      The 'docs' target accepts the following property as an option:
-
-      docs: directory in wish to place the Javadoc. Defaults to ${docs}.
-
-      JavaVersion: which version of the java language and runtime to target.
-      Defaults to ${JavaVersion}.
+      Build options are found in the file 'build.properties'
 
       To override any of these properties for a one time build, pass them to ant in the following form:
 


### PR DESCRIPTION
Should have done this the last time I messed about with the build files... can't remember why not.

Makes updating defaults much easier, and can still over-ride on the command line if needed.