### PR TITLE
initial twist angle

### DIFF
--- a/ArtOfIllusion/src/artofillusion/animation/Joint.java
+++ b/ArtOfIllusion/src/artofillusion/animation/Joint.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2002,2003 by Peter Eastman
+   Change Copyright (C) Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -41,6 +42,8 @@ public class Joint
       length = new DOF(0.0, Double.MAX_VALUE, d);
       calcAnglesFromCoords(false);
     }
+    if (twist.pos >  90) twist.pos -= 180;
+    if (twist.pos < -90) twist.pos += 180;
     length.fixed = true;
     angle1.loop = angle2.loop = twist.loop = true;
     id = -1;


### PR DESCRIPTION
Addressing a long term bug in creation of new bones.

The "twist" angle is in principle calculated correctly from the various directions and coordinates that are involved but often the resulting angle is 180° or -180° instead of 0° (or for example -123° instead of 57°).

The near 180 degree angles prevent using angular restrictions and often force the movements to happen over the ±180° limit, which is a bit difficult to handle. A typical place to set limits to twist angle would be a spine structure, where each bone may be allowed to move only a few degrees. To add restrictions you'd have to turn the bone around but if the bone already has children, that usually is not a reasonable option. 

- This makes sure that the initial Z-rotation of a new bone is always between -90° and 90°.
- This does not affect the the creation or functionality of any children of the joint.

Target release: The next to come.
