### PR TITLE
Reconnect delete-key

### DIFF
--- a/ArtOfIllusion/src/keystrokes.xml
+++ b/ArtOfIllusion/src/keystrokes.xml
@@ -14,6 +14,22 @@
 			else
 				window.deleteCommand();
 		}
+	<keystroke name="Delete Selection" code="127" modifiers="0" >if (window instanceof LayoutWindow)
+		{
+			score = window.getScore();
+			if (score.getSelectedKeyframes().length == 0)
+				window.clearCommand();
+			else
+				score.deleteSelectedKeyframes();
+		}
+		else if (window instanceof MeshEditorWindow)
+		{
+			if (window.getToolPalette().getSelectedTool() instanceof artofillusion.animation.SkeletonTool)
+				window.deleteJointCommand();
+			else
+				window.deleteCommand();
+		}
+	</keystroke>
 	</keystroke>
 	<keystroke name="Display Mode: Flat" code="50" modifiers="0">window.getView().setRenderMode(ViewerCanvas.RENDER_FLAT);window.updateMenus();</keystroke>
 	<keystroke name="Display Mode: Smooth" code="51" modifiers="0">window.getView().setRenderMode(ViewerCanvas.RENDER_SMOOTH); window.updateMenus();</keystroke>


### PR DESCRIPTION
In the early versions of AoI delete was under Delete key as you would expect. At some point it was moved to the Backspace-key, which still after all the years is confusing to me and I believe to most users anyway....

This PR adds the function back to Delete-key as well. There's nothing wrong with using BS for the same purpose but a dedicated key, that ROW uses, should not be blank.

..So now it would be much like any text processor. Either Del or BS will delete the current selection.
