### PR TITLE
Update module duplicate result type

### DIFF
--- a/ArtOfIllusion/src/artofillusion/procedural/BrickModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/BrickModule.java
@@ -259,7 +259,7 @@ public class BrickModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public BrickModule duplicate()
   {
     BrickModule mod = new BrickModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/CellsModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/CellsModule.java
@@ -258,10 +258,10 @@ public class CellsModule extends ProceduralModule
     return true;
   }
 
-  /** Create a duplicate of this module. */
+  /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public CellsModule duplicate()
   {
     CellsModule module = new CellsModule(new Point(bounds.x, bounds.y));
     module.setMetric(cells.getMetric());

--- a/ArtOfIllusion/src/artofillusion/procedural/ClipModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ClipModule.java
@@ -145,7 +145,7 @@ public class ClipModule extends ProceduralModule
     /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ClipModule duplicate()
   {
     ClipModule mod = new ClipModule(new Point(bounds.x, bounds.y));
     mod.min = min;

--- a/ArtOfIllusion/src/artofillusion/procedural/ColorModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ColorModule.java
@@ -92,7 +92,7 @@ public class ColorModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ColorModule duplicate()
   {
     ColorModule mod = new ColorModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/CommentModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/CommentModule.java
@@ -51,7 +51,7 @@ public class CommentModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public CommentModule duplicate()
   {
     CommentModule mod = new CommentModule(new Point(bounds.x, bounds.y), name);
     return mod;

--- a/ArtOfIllusion/src/artofillusion/procedural/CoordinateModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/CoordinateModule.java
@@ -121,7 +121,7 @@ public class CoordinateModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public CoordinateModule duplicate()
   {
     CoordinateModule mod = new CoordinateModule(new Point(bounds.x, bounds.y), coordinate);
 

--- a/ArtOfIllusion/src/artofillusion/procedural/ExprModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ExprModule.java
@@ -208,8 +208,7 @@ class ModuleLoader {
             return dummy();
         }
         try {
-            Object [] wrappedPoint = { new Point () };
-            mod = (Module) cons.newInstance (wrappedPoint);
+            mod = (Module) cons.newInstance (new Point ());
         } catch (InvocationTargetException e) {
             System.err.println ("Couldn't create a " + moduleClass.getName() + ": (InvocationTargetException)" + e.getTargetException ());
             return dummy();
@@ -332,7 +331,7 @@ public class ExprModule extends ProceduralModule
     /* Create a duplicate of this module. */
 
     @Override
-    public Module duplicate()
+    public ExprModule duplicate()
     {
         ExprModule mod = new ExprModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/FunctionModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/FunctionModule.java
@@ -387,7 +387,7 @@ public class FunctionModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public FunctionModule duplicate()
   {
     FunctionModule mod = new FunctionModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/GridModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/GridModule.java
@@ -219,7 +219,7 @@ public class GridModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public GridModule duplicate()
   {
     GridModule mod = new GridModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/ImageModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ImageModule.java
@@ -427,7 +427,7 @@ public class ImageModule extends ProceduralModule
   /** Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ImageModule duplicate()
   {
     ImageModule mod = new ImageModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/JitterModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/JitterModule.java
@@ -246,7 +246,7 @@ public class JitterModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public JitterModule duplicate()
   {
     JitterModule mod = new JitterModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/MarbleModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/MarbleModule.java
@@ -253,7 +253,7 @@ public class MarbleModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public MarbleModule duplicate()
   {
     MarbleModule mod = new MarbleModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/NoiseModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/NoiseModule.java
@@ -244,7 +244,7 @@ public class NoiseModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public NoiseModule duplicate()
   {
     NoiseModule mod = new NoiseModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/NumberModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/NumberModule.java
@@ -91,12 +91,12 @@ public class NumberModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public NumberModule duplicate()
   {
     NumberModule mod = new NumberModule(new Point(bounds.x, bounds.y));
 
     mod.value = value;
-    mod.name = ""+value;
+    mod.name = "" + value;
     return mod;
   }
 

--- a/ArtOfIllusion/src/artofillusion/procedural/ParameterModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ParameterModule.java
@@ -169,7 +169,7 @@ public class ParameterModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ParameterModule duplicate()
   {
     ParameterModule mod = new ParameterModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/RandomModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/RandomModule.java
@@ -250,7 +250,7 @@ public class RandomModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public RandomModule duplicate()
   {
     RandomModule mod = new RandomModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/ScaleShiftModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ScaleShiftModule.java
@@ -132,7 +132,7 @@ public class ScaleShiftModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ScaleShiftModule duplicate()
   {
     ScaleShiftModule mod = new ScaleShiftModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/SpectrumModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/SpectrumModule.java
@@ -228,7 +228,7 @@ public class SpectrumModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public SpectrumModule duplicate()
   {
     SpectrumModule mod = new SpectrumModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/TransformModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/TransformModule.java
@@ -292,7 +292,7 @@ public class TransformModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public TransformModule duplicate()
   {
     TransformModule mod = new TransformModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/TurbulenceModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/TurbulenceModule.java
@@ -242,7 +242,7 @@ public class TurbulenceModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public TurbulenceModule duplicate()
   {
     TurbulenceModule mod = new TurbulenceModule(new Point(bounds.x, bounds.y));
 

--- a/ArtOfIllusion/src/artofillusion/procedural/ViewAngleModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ViewAngleModule.java
@@ -70,7 +70,7 @@ public class ViewAngleModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public ViewAngleModule duplicate()
   {
     ViewAngleModule mod = new ViewAngleModule(new Point(bounds.x, bounds.y));
     mod.abs = abs;

--- a/ArtOfIllusion/src/artofillusion/procedural/WoodModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/WoodModule.java
@@ -238,7 +238,7 @@ public class WoodModule extends ProceduralModule
   /* Create a duplicate of this module. */
 
   @Override
-  public Module duplicate()
+  public WoodModule duplicate()
   {
     WoodModule module = new WoodModule(new Point(bounds.x, bounds.y));
 


### PR DESCRIPTION
Update procedural module's duplicate() method declaration to be more specific. This reduces dependencies count of deprecated Module class