### PR TITLE
A bug fix to view manipulation

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1431,7 +1431,8 @@ public abstract class ViewerCanvas extends CustomWidget
     Vec3 pointInSpace = finder.newPoint(this, pointOnView);
     CoordinateSystem coords = theCamera.getCameraCoordinates().duplicate();
     Vec3 cz = coords.getZDirection();
-    distToPlane = coords.getOrigin().minus(pointInSpace).length();
+    if (perspective)
+      distToPlane = coords.getOrigin().minus(pointInSpace).length();
     Vec3 cp = pointInSpace.plus(cz.times(-distToPlane));
     coords.setOrigin(cp);
 


### PR DESCRIPTION
I have noticed, when playing wit zoom, center click, perspective etc... that sometimes the view is not responding the way I expected but I could not exacty tell where it went wrong and the problem always seemed to fix itself by the following view manipulation actions.

Now I found it! 

This makes sure that changing from parallel to perspective keeps screen dimensions unchanged at working depth, after you have selected a new point of focus by center click. This is the way it was originally supposed to be.
