### PR TITLE
Raytrace large objects

### DIFF
--- a/Renderers/src/artofillusion/raytracer/OctreeNode.java
+++ b/Renderers/src/artofillusion/raytracer/OctreeNode.java
@@ -106,23 +106,23 @@ public class OctreeNode
         if (splitz)
           child[1] = new OctreeNode(minx, midx, miny, midy, midz, maxz, obj, objBounds, this);
         if (splity)
-          {
-            child[2] = new OctreeNode(minx, midx, midy, maxy, minz, midz, obj, objBounds, this);
-            if (splitz)
-              child[3] = new OctreeNode(minx, midx, midy, maxy, midz, maxz, obj, objBounds, this);
-          }
+        {
+          child[2] = new OctreeNode(minx, midx, midy, maxy, minz, midz, obj, objBounds, this);
+          if (splitz)
+            child[3] = new OctreeNode(minx, midx, midy, maxy, midz, maxz, obj, objBounds, this);
+        }
         if (splitx)
+        {
+          child[4] = new OctreeNode(midx, maxx, miny, midy, minz, midz, obj, objBounds, this);
+          if (splitz)
+            child[5] = new OctreeNode(midx, maxx, miny, midy, midz, maxz, obj, objBounds, this);
+          if (splity)
           {
-            child[4] = new OctreeNode(midx, maxx, miny, midy, minz, midz, obj, objBounds, this);
+            child[6] = new OctreeNode(midx, maxx, midy, maxy, minz, midz, obj, objBounds, this);
             if (splitz)
-              child[5] = new OctreeNode(midx, maxx, miny, midy, midz, maxz, obj, objBounds, this);
-            if (splity)
-              {
-                child[6] = new OctreeNode(midx, maxx, midy, maxy, minz, midz, obj, objBounds, this);
-                if (splitz)
-                  child[7] = new OctreeNode(midx, maxx, midy, maxy, midz, maxz, obj, objBounds, this);
-              }
+              child[7] = new OctreeNode(midx, maxx, midy, maxy, midz, maxz, obj, objBounds, this);
           }
+        }
         obj = null;
       }
   }
@@ -158,42 +158,42 @@ public class OctreeNode
 
     current = this;
     while (current.obj == null)
+    {
+      if (pos.x > current.midx)
       {
-        if (pos.x > current.midx)
-          {
-            if (pos.y > current.midy)
-              {
-                if (pos.z > current.midz)
-                    current = current.child[7];
-                else
-                    current = current.child[6];
-            }
-            else
-              {
-                if (pos.z > current.midz)
-                    current = current.child[5];
-                else
-                    current = current.child[4];
-              }
-          }
+        if (pos.y > current.midy)
+        {
+          if (pos.z > current.midz)
+            current = current.child[7];
+          else
+            current = current.child[6];
+        }
         else
-          {
-            if (pos.y > current.midy)
-              {
-                if (pos.z > current.midz)
-                    current = current.child[3];
-                else
-                    current = current.child[2];
-              }
-            else
-              {
-                if (pos.z > current.midz)
-                    current = current.child[1];
-                else
-                    current = current.child[0];
-              }
+        {
+          if (pos.z > current.midz)
+            current = current.child[5];
+          else
+            current = current.child[4];
         }
       }
+      else
+      {
+        if (pos.y > current.midy)
+        {
+          if (pos.z > current.midz)
+              current = current.child[3];
+          else
+              current = current.child[2];
+        }
+        else
+        {
+          if (pos.z > current.midz)
+              current = current.child[1];
+          else
+              current = current.child[0];
+        }
+      }
+    }
     return current;
   }
 
@@ -329,83 +329,83 @@ public class OctreeNode
     // Find the point where the ray enters this node (if it does at all).
 
     if (dir.x == 0.0)
-      {
-        if (orig.x < minx || orig.x > maxx)
-          return null;
-      }
+    {
+      if (orig.x < minx || orig.x > maxx)
+        return null;
+    }
     else
+    {
+      t1 = (minx-orig.x)/dir.x;
+      t2 = (maxx-orig.x)/dir.x;
+      if (t1 < t2)
       {
-        t1 = (minx-orig.x)/dir.x;
-        t2 = (maxx-orig.x)/dir.x;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || maxt < 0.0)
-          return null;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || maxt < 0.0)
+        return null;
+    }
     if (dir.y == 0.0)
-      {
-        if (orig.y < miny || orig.y > maxy)
-          return null;
-      }
+    {
+      if (orig.y < miny || orig.y > maxy)
+        return null;
+    }
     else
+    {
+      t1 = (miny-orig.y)/dir.y;
+      t2 = (maxy-orig.y)/dir.y;
+      if (t1 < t2)
       {
-        t1 = (miny-orig.y)/dir.y;
-        t2 = (maxy-orig.y)/dir.y;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || maxt < 0.0)
-          return null;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || maxt < 0.0)
+        return null;
+    }
     if (dir.z == 0.0)
-      {
-        if (orig.z < minz || orig.z > maxz)
-          return null;
-      }
+    {
+      if (orig.z < minz || orig.z > maxz)
+        return null;
+    }
     else
+    {
+      t1 = (minz-orig.z)/dir.z;
+      t2 = (maxz-orig.z)/dir.z;
+      if (t1 < t2)
       {
-        t1 = (minz-orig.z)/dir.z;
-        t2 = (maxz-orig.z)/dir.z;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || maxt < 0.0)
-          return null;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || maxt < 0.0)
+        return null;
+    }
 
     // Push it just inside this node.
 

--- a/Renderers/src/artofillusion/raytracer/RTCube.java
+++ b/Renderers/src/artofillusion/raytracer/RTCube.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2004-2013 by Peter Eastman
+   Modification copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -25,6 +26,7 @@ public class RTCube extends RTObject
   protected double param[];
   private boolean bumpMapped, transform;
   protected Mat4 toLocal, fromLocal;
+  private double objectTol;
 
   public static final double TOL = 1e-12;
 
@@ -103,6 +105,11 @@ public class RTCube extends RTObject
     }
     bumpMapped = cube.getTexture().hasComponent(Texture.BUMP_COMPONENT);
     this.toLocal = toLocal;
+    
+    objectTol = xsize;
+    if (ysize > objectTol) objectTol = ysize;
+    if (zsize > objectTol) objectTol = zsize;
+    objectTol *= TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -128,6 +135,9 @@ public class RTCube extends RTObject
   {
     Vec3 rorig = r.getOrigin(), rdir = r.getDirection();
     Vec3 origin, direction;
+    double rayTol = rorig.length()*Raytracer.TOL*0.01;
+    double intTol = objectTol > rayTol ? objectTol : rayTol;
+
     if (transform)
     {
       origin = r.tempVec1;
@@ -167,7 +177,7 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < intTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     if (direction.y == 0.0)
@@ -193,7 +203,7 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < intTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     if (direction.z == 0.0)
@@ -219,12 +229,12 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < intTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     int numIntersections;
     Vec3 v1 = r.tempVec1, v2 = r.tempVec2, trueNorm = r.tempVec3;
-    if (mint < TOL)
+    if (mint < intTol)
     {
       v1.set(rorig.x+maxt*rdir.x, rorig.y+maxt*rdir.y, rorig.z+maxt*rdir.z);
       mint = maxt;

--- a/Renderers/src/artofillusion/raytracer/RTCylinder.java
+++ b/Renderers/src/artofillusion/raytracer/RTCylinder.java
@@ -47,53 +47,53 @@ public class RTCylinder extends RTObject
     cone = false;
     transform = true;
     if (vy.y == 1.0)
-      {
-        if (vx.x == 1.0 || vx.x == -1.0)
-          {
-            rx = size.x/2.0;
-            rz = size.z/2.0;
-            transform = false;
-          }
-        else if (vx.z == 1.0 || vx.z == -1.0)
-          {
-            rx = size.z/2.0;
-            rz = size.x/2.0;
-            transform = false;
-          }
-        if (transform == false && ratio == 0.0)
-          cone = true;
-      }
-    else if (vy.y == -1.0 && ratio != 0.0)
-      {
-        if (vx.x == 1.0 || vx.x == -1.0)
-          {
-            rx = size.x/2.0;
-            rz = size.z/2.0;
-            transform = false;
-          }
-        else if (vx.z == 1.0 || vx.z == -1.0)
-          {
-            rx = size.z/2.0;
-            rz = size.x/2.0;
-            transform = false;
-          }
-        if (transform == false)
-          {
-            rx *= ratio;
-            rz *= ratio;
-            ratio = 1.0/ratio;
-          }
-      }
-    height = size.y;
-    halfh = height/2.0;
-    if (transform)
+    {
+      if (vx.x == 1.0 || vx.x == -1.0)
       {
         rx = size.x/2.0;
         rz = size.z/2.0;
-        if (ratio == 0.0)
-          cone = true;
-        this.fromLocal = fromLocal;
+        transform = false;
       }
+      else if (vx.z == 1.0 || vx.z == -1.0)
+      {
+        rx = size.z/2.0;
+        rz = size.x/2.0;
+        transform = false;
+      }
+      if (transform == false && ratio == 0.0)
+        cone = true;
+    }
+    else if (vy.y == -1.0 && ratio != 0.0)
+    {
+      if (vx.x == 1.0 || vx.x == -1.0)
+      {
+        rx = size.x/2.0;
+        rz = size.z/2.0;
+        transform = false;
+      }
+      else if (vx.z == 1.0 || vx.z == -1.0)
+      {
+        rx = size.z/2.0;
+        rz = size.x/2.0;
+        transform = false;
+      }
+      if (transform == false)
+      {
+        rx *= ratio;
+        rz *= ratio;
+        ratio = 1.0/ratio;
+      }
+    }
+    height = size.y;
+    halfh = height/2.0;
+    if (transform)
+    {
+      rx = size.x/2.0;
+      rz = size.z/2.0;
+      if (ratio == 0.0)
+        cone = true;
+      this.fromLocal = fromLocal;
+    }
     cx = fromLocal.m14/fromLocal.m44;
     cy = fromLocal.m24/fromLocal.m44;
     cz = fromLocal.m34/fromLocal.m44;
@@ -144,76 +144,76 @@ public class RTCylinder extends RTObject
     int intersections, hit = -1;
 
     if (transform)
-      {
-        v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
-        toLocal.transformDirection(v1);
-        v1.y -= halfh;
-        dir.set(rdir);
-        toLocal.transformDirection(dir);
-      }
+    {
+      v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
+      toLocal.transformDirection(v1);
+      v1.y -= halfh;
+      dir.set(rdir);
+      toLocal.transformDirection(dir);
+    }
     else
-      {
-        v1.set(cx-orig.x, cy-orig.y-halfh, cz-orig.z);
-        if (uniform)
-          dir = rdir;
-        else
-          dir.set(rdir);
-      }
+    {
+      v1.set(cx-orig.x, cy-orig.y-halfh, cz-orig.z);
+      if (uniform)
+        dir = rdir;
+      else
+        dir.set(rdir);
+    }
     mint = Double.MAX_VALUE;
     if (dir.y != 0.0)
+    {
+      // See if the ray hits the top or bottom face of the cylinder.
+
+      temp1 = v1.y/dir.y;
+      if (temp1 > intTolLinear)
       {
-        // See if the ray hits the top or bottom face of the cylinder.
-
-        temp1 = v1.y/dir.y;
-        if (temp1 > intTolLinear)
-          {
-            a = temp1*dir.x - v1.x;
-            b = temp1*dir.z - v1.z;
-            if (a*a+sz*b*b < rx2)
-              {
-                hit = BOTTOM;
-                mint = temp1;
-              }
-          }
-        if (!cone)
-          {
-            temp1 = (v1.y+height)/dir.y;
-            if (temp1 > intTolLinear)
-              {
-                a = temp1*dir.x - v1.x;
-                b = temp1*dir.z - v1.z;
-                if (a*a+sz*b*b < toprx2)
-                  {
-                    if (mint < Double.MAX_VALUE)
-                      {
-                        // The ray hit both the top and bottom faces, so we know it
-                        // didn't hit the sides.
-
-                        intersections = 2;
-                        if (temp1 < mint)
-                          {
-                            hit = TOP;
-                            dist1 = temp1;
-                            dist2 = mint;
-                          }
-                        else
-                          {
-                            dist1 = mint;
-                            dist2 = temp1;
-                          }
-                        v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
-                        v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
-                        return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
-                      }
-                    else
-                      {
-                        hit = TOP;
-                        mint = temp1;
-                      }
-                  }
-              }
-          }
+        a = temp1*dir.x - v1.x;
+        b = temp1*dir.z - v1.z;
+        if (a*a+sz*b*b < rx2)
+        {
+          hit = BOTTOM;
+          mint = temp1;
+        }
       }
+      if (!cone)
+      {
+        temp1 = (v1.y+height)/dir.y;
+        if (temp1 > intTolLinear)
+        {
+          a = temp1*dir.x - v1.x;
+          b = temp1*dir.z - v1.z;
+          if (a*a+sz*b*b < toprx2)
+          {
+            if (mint < Double.MAX_VALUE)
+            {
+              // The ray hit both the top and bottom faces, so we know it
+              // didn't hit the sides.
+
+              intersections = 2;
+              if (temp1 < mint)
+              {
+                hit = TOP;
+                dist1 = temp1;
+                dist2 = mint;
+              }
+              else
+              {
+                dist1 = mint;
+                dist2 = temp1;
+              }
+              v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
+              v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
+              return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
+            }
+            else
+            {
+              hit = TOP;
+              mint = temp1;
+            }
+          }
+        }
+      }
+    }
 
     // Now see if it hits the sides of the cylinder.
 
@@ -238,46 +238,46 @@ public class RTCylinder extends RTObject
     dist1 = Double.MAX_VALUE;
     dist2 = mint;
     if (c > intTolRadial)  // Ray origin is outside cylinder.
-      {
-        if (b > 0.0)  // Ray points toward cylinder.
+    {
+      if (b > 0.0)  // Ray points toward cylinder.
+        {
+          a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
+          e = b*b - a*c;
+          if (e >= 0.0)
           {
-            a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
-            e = b*b - a*c;
-            if (e >= 0.0)
-              {
-                temp1 = Math.sqrt(e);
-                dist1 = (b - temp1)/a;
-                if (dist2 == Double.MAX_VALUE)
-                  dist2 = (b + temp1)/a;
-              }
+            temp1 = Math.sqrt(e);
+            dist1 = (b - temp1)/a;
+            if (dist2 == Double.MAX_VALUE)
+              dist2 = (b + temp1)/a;
           }
-      }
+        }
+    }
     else if (c < -intTolRadial)  // Ray origin is inside cylinder.
+    {
+      a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
+      e = b*b - a*c;
+      if (e >= 0.0)
+        dist1 = (b + Math.sqrt(e))/a;
+    }
+    else  // Ray origin is on the surface of the cylinder.
+    {
+      if (b > 0.0)  // Ray points into cylinder.
       {
         a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
         e = b*b - a*c;
         if (e >= 0.0)
           dist1 = (b + Math.sqrt(e))/a;
       }
-    else  // Ray origin is on the surface of the cylinder.
-      {
-        if (b > 0.0)  // Ray points into cylinder.
-          {
-            a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
-            e = b*b - a*c;
-            if (e >= 0.0)
-              dist1 = (b + Math.sqrt(e))/a;
-          }
-      }
+    }
     if (dist1 < mint)
+    {
+      a = dist1*dir.y-v1.y;
+      if (a > 0.0 && a < height)
       {
-        a = dist1*dir.y-v1.y;
-        if (a > 0.0 && a < height)
-          {
-            hit = SIDE;
-            mint = dist1;
-          }
+        hit = SIDE;
+        mint = dist1;
       }
+    }
     if (mint == Double.MAX_VALUE)
       return SurfaceIntersection.NO_INTERSECTION;
     if (dist2 < mint)
@@ -293,10 +293,10 @@ public class RTCylinder extends RTObject
     if (dist2 == Double.MAX_VALUE)
       intersections = 1;
     else
-      {
-        intersections = 2;
-        v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
-      }
+    {
+      intersections = 2;
+      v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
+    }
     return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
   }
 
@@ -330,10 +330,10 @@ public class RTCylinder extends RTObject
     if (transform)
       return (new BoundingBox(-rx, rx, -halfh, halfh, -rz, rz)).transformAndOutset(fromLocal);
     else if (toprx2 > rx2)
-      {
-        double xrad = Math.sqrt(toprx2), zrad = Math.sqrt(rz2*toprx2/rx2);
-        return new BoundingBox(cx-xrad, cx+xrad, cy-halfh, cy+halfh, cz-zrad, cz+zrad);
-      }
+    {
+      double xrad = Math.sqrt(toprx2), zrad = Math.sqrt(rz2*toprx2/rx2);
+      return new BoundingBox(cx-xrad, cx+xrad, cy-halfh, cy+halfh, cz-zrad, cz+zrad);
+    }
     else
       return new BoundingBox(cx-rx, cx+rx, cy-halfh, cy+halfh, cz-rz, cz+rz);
   }
@@ -347,24 +347,24 @@ public class RTCylinder extends RTObject
 
     BoundingBox bb = node.getBounds();
     if (transform)
-      {
-        bb = bb.transformAndOutset(toLocal);
-        if (bb.miny > halfh || bb.maxy < -halfh)
-          return false;
-        x = 0.0;
-        z = 0.0;
-        if (bb.minx > 0.0)
-          x = bb.minx;
-        else if (bb.maxx < 0.0)
-          x = bb.maxx;
-        if (bb.minz > 0.0)
-          z = bb.minz;
-        else if (bb.maxz < 0.0)
-          z = bb.maxz;
-        if (x*x + sz*z*z > rx2)
-          return false;
-        return true;
-      }
+    {
+      bb = bb.transformAndOutset(toLocal);
+      if (bb.miny > halfh || bb.maxy < -halfh)
+        return false;
+      x = 0.0;
+      z = 0.0;
+      if (bb.minx > 0.0)
+        x = bb.minx;
+      else if (bb.maxx < 0.0)
+        x = bb.maxx;
+      if (bb.minz > 0.0)
+        z = bb.minz;
+      else if (bb.maxz < 0.0)
+        z = bb.maxz;
+      if (x*x + sz*z*z > rx2)
+        return false;
+      return true;
+    }
     if (bb.miny > cy+halfh || bb.maxy < cy-halfh)
       return false;
     x = cx;
@@ -485,10 +485,10 @@ public class RTCylinder extends RTObject
       if (cylinder.uniform)
         map.getTransparency(pos, trans, angle, size, time, cylinder.param);
       else
-        {
-          cylinder.toLocal.transform(pos);
-          map.getTransparency(pos, trans, angle, size, time, cylinder.param);
-        }
+      {
+        cylinder.toLocal.transform(pos);
+        map.getTransparency(pos, trans, angle, size, time, cylinder.param);
+      }
     }
 
     @Override

--- a/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
+++ b/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
@@ -38,63 +38,63 @@ public class RTEllipsoid extends RTObject
     uniform = sphere.getTextureMapping() instanceof UniformMapping;
     transform = true;
     if (vx.x == 1.0 || vx.x == -1.0)
-      {
-        if (vy.y == 1.0 || vy.y == -1.0)
-          {
-            rx = radii.x;
-            ry = radii.y;
-            rz = radii.z;
-            transform = false;
-          }
-        else if (vy.z == 1.0 || vy.z == -1.0)
-          {
-            rx = radii.x;
-            ry = radii.z;
-            rz = radii.y;
-            transform = false;
-          }
-      }
-    else if (vx.y == 1.0 || vx.y == -1.0)
-      {
-        if (vy.x == 1.0 || vy.x == -1.0)
-          {
-            rx = radii.y;
-            ry = radii.x;
-            rz = radii.z;
-            transform = false;
-          }
-        else if (vy.z == 1.0 || vy.z == -1.0)
-          {
-            rx = radii.y;
-            ry = radii.z;
-            rz = radii.x;
-            transform = false;
-          }
-      }
-    else if (vx.z == 1.0 || vx.z == -1.0)
-      {
-        if (vy.x == 1.0 || vy.x == -1.0)
-          {
-            rx = radii.z;
-            ry = radii.x;
-            rz = radii.y;
-            transform = false;
-          }
-        else if (vy.y == 1.0 || vy.y == -1.0)
-          {
-            rx = radii.z;
-            ry = radii.y;
-            rz = radii.x;
-            transform = false;
-          }
-      }
-    if (transform)
+    {
+      if (vy.y == 1.0 || vy.y == -1.0)
       {
         rx = radii.x;
         ry = radii.y;
         rz = radii.z;
-        this.fromLocal = fromLocal;
+        transform = false;
       }
+      else if (vy.z == 1.0 || vy.z == -1.0)
+      {
+        rx = radii.x;
+        ry = radii.z;
+        rz = radii.y;
+        transform = false;
+      }
+    }
+    else if (vx.y == 1.0 || vx.y == -1.0)
+    {
+      if (vy.x == 1.0 || vy.x == -1.0)
+      {
+        rx = radii.y;
+        ry = radii.x;
+        rz = radii.z;
+        transform = false;
+      }
+      else if (vy.z == 1.0 || vy.z == -1.0)
+      {
+        rx = radii.y;
+        ry = radii.z;
+        rz = radii.x;
+        transform = false;
+      }
+    }
+    else if (vx.z == 1.0 || vx.z == -1.0)
+    {
+      if (vy.x == 1.0 || vy.x == -1.0)
+      {
+        rx = radii.z;
+        ry = radii.x;
+        rz = radii.y;
+        transform = false;
+      }
+      else if (vy.y == 1.0 || vy.y == -1.0)
+      {
+        rx = radii.z;
+        ry = radii.y;
+        rz = radii.x;
+        transform = false;
+      }
+    }
+    if (transform)
+    {
+      rx = radii.x;
+      ry = radii.y;
+      rz = radii.z;
+      this.fromLocal = fromLocal;
+    }
     cx = fromLocal.m14/fromLocal.m44;
     cy = fromLocal.m24/fromLocal.m44;
     cz = fromLocal.m34/fromLocal.m44;
@@ -146,11 +146,11 @@ public class RTEllipsoid extends RTObject
 
     v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
     if (transform)
-      {
-        toLocal.transformDirection(v1);
-        dir.set(rdir);
-        toLocal.transformDirection(dir);
-      }
+    {
+      toLocal.transformDirection(v1);
+      dir.set(rdir);
+      toLocal.transformDirection(dir);
+    }
     else if (uniform)
       dir = rdir;
     else
@@ -162,47 +162,47 @@ public class RTEllipsoid extends RTObject
     int numIntersections;
 
     if (c > intTol*b)
-      {
-        // Ray origin is outside ellipsoid.
+    {
+      // Ray origin is outside ellipsoid.
 
-        if (b <= intTol)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
+      if (b <= intTol)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
 
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 2;
-        temp1 = Math.sqrt(d);
-        dist1 = (b - temp1)/a;
-        dist2 = (b + temp1)/a;
-        v2.set(orig.x+dist2*dir.x, orig.y+dist2*dir.y, orig.z+dist2*dir.z);
-        projectPoint(v2);
-      }
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 2;
+      temp1 = Math.sqrt(d);
+      dist1 = (b - temp1)/a;
+      dist2 = (b + temp1)/a;
+      v2.set(orig.x+dist2*dir.x, orig.y+dist2*dir.y, orig.z+dist2*dir.z);
+      projectPoint(v2);
+    }
     else if (c < -intTol*b)
-      {
-        // Ray origin is inside ellipsoid.
+    {
+      // Ray origin is inside ellipsoid.
 
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        dist1 = (b + Math.sqrt(d))/a;
-      }
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      dist1 = (b + Math.sqrt(d))/a;
+    }
     else
-      {
-        // Ray origin is on the surface of the ellipsoid.
+    {
+      // Ray origin is on the surface of the ellipsoid.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        dist1 = (b + Math.sqrt(d))/a;
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      dist1 = (b + Math.sqrt(d))/a;
+    }
     v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
     projectPoint(v1);
     return new EllipsoidIntersection(this, numIntersections, v1, v2, dist1, dist2);
@@ -248,16 +248,16 @@ public class RTEllipsoid extends RTObject
 
     BoundingBox bb = node.getBounds();
     if (transform)
-      {
-        bb = bb.transformAndOutset(toLocal);
-        centerx = centery = centerz = 0.0;
-      }
+    {
+      bb = bb.transformAndOutset(toLocal);
+      centerx = centery = centerz = 0.0;
+    }
     else
-      {
-        centerx = cx;
-        centery = cy;
-        centerz = cz;
-      }
+    {
+      centerx = cx;
+      centery = cy;
+      centerz = cz;
+    }
     Vec3 c = new Vec3(centerx, centery, centerz);
 
     // Find the nearest point of the box to the ellipsoid.

--- a/Renderers/src/artofillusion/raytracer/RTSphere.java
+++ b/Renderers/src/artofillusion/raytracer/RTSphere.java
@@ -78,43 +78,43 @@ public class RTSphere extends RTObject
     b = dir.x*v1.x + dir.y*v1.y + dir.z*v1.z;
     c = v1.x*v1.x + v1.y*v1.y + v1.z*v1.z - r2;
     if (c > intTol)
-      {
-        // Ray origin is outside sphere.
+    {
+      // Ray origin is outside sphere.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 2;
-        root = Math.sqrt(d);
-        t = b - root;
-        t2 = b + root;
-        v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
-        projectPoint(v2);
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 2;
+      root = Math.sqrt(d);
+      t = b - root;
+      t2 = b + root;
+      v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
+      projectPoint(v2);
+    }
     else if (c < -intTol)
-      {
-        // Ray origin is inside sphere.
+    {
+      // Ray origin is inside sphere.
 
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        t = b + Math.sqrt(d);
-      }
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      t = b + Math.sqrt(d);
+    }
     else
-      {
-        // Ray origin is on the surface of the sphere.
+    {
+      // Ray origin is on the surface of the sphere.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        t = b + Math.sqrt(d);
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      t = b + Math.sqrt(d);
+    }
     v1.set(orig.x+t*dir.x, orig.y+t*dir.y, orig.z+t*dir.z);
     projectPoint(v1);
     return new SphereIntersection(this, numIntersections, v1, v2, t, t2);

--- a/Renderers/src/artofillusion/raytracer/RTSphere.java
+++ b/Renderers/src/artofillusion/raytracer/RTSphere.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Modification copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -25,6 +26,7 @@ public class RTSphere extends RTObject
   double r, r2, cx, cy, cz, param[];
   boolean bumpMapped;
   Mat4 toLocal, fromLocal;
+  private double objectTol;
 
   public static final double TOL = 1e-12;
 
@@ -41,6 +43,7 @@ public class RTSphere extends RTObject
     if (bumpMapped)
       this.fromLocal = fromLocal;
     this.toLocal = toLocal;
+    objectTol = r2*TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -67,12 +70,14 @@ public class RTSphere extends RTObject
     Vec3 orig = r.getOrigin(), dir = r.getDirection();
     Vec3 v1 = r.tempVec1, v2 = r.tempVec2;
     double b, c, d, root, t, t2 = 0.0;
+    double rayTol = orig.length()*Raytracer.TOL*0.01;
+    double intTol = objectTol > rayTol ? objectTol : rayTol;
     int numIntersections;
 
     v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
     b = dir.x*v1.x + dir.y*v1.y + dir.z*v1.z;
     c = v1.x*v1.x + v1.y*v1.y + v1.z*v1.z - r2;
-    if (c > TOL)
+    if (c > intTol)
       {
         // Ray origin is outside sphere.
 
@@ -88,7 +93,7 @@ public class RTSphere extends RTObject
         v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
         projectPoint(v2);
       }
-    else if (c < -TOL)
+    else if (c < -intTol)
       {
         // Ray origin is inside sphere.
 

--- a/Renderers/src/artofillusion/raytracer/RTTriangle.java
+++ b/Renderers/src/artofillusion/raytracer/RTTriangle.java
@@ -284,83 +284,83 @@ public class RTTriangle extends RTObject
     double dirx = p2.x-p1.x, diry = p2.y-p1.y, dirz = p2.z-p1.z;
     double len = Math.sqrt(dirx*dirx + diry*diry + dirz*dirz);
     if (dirx == 0.0)
-      {
-        if (p1.x < node.minx || p1.x > node.maxx)
-          return false;
-      }
+    {
+      if (p1.x < node.minx || p1.x > node.maxx)
+        return false;
+    }
     else
+    {
+      t1 = (node.minx-p1.x)*len/dirx;
+      t2 = (node.maxx-p1.x)*len/dirx;
+      if (t1 < t2)
       {
-        t1 = (node.minx-p1.x)*len/dirx;
-        t2 = (node.maxx-p1.x)*len/dirx;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (diry == 0.0)
-      {
-        if (p1.y < node.miny || p1.y > node.maxy)
-          return false;
-      }
+    {
+      if (p1.y < node.miny || p1.y > node.maxy)
+        return false;
+    }
     else
+    {
+      t1 = (node.miny-p1.y)*len/diry;
+      t2 = (node.maxy-p1.y)*len/diry;
+      if (t1 < t2)
       {
-        t1 = (node.miny-p1.y)*len/diry;
-        t2 = (node.maxy-p1.y)*len/diry;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (dirz == 0.0)
-      {
-        if (p1.z < node.minz || p1.z > node.maxz)
-          return false;
-      }
+    {
+      if (p1.z < node.minz || p1.z > node.maxz)
+        return false;
+    }
     else
+    {
+      t1 = (node.minz-p1.z)*len/dirz;
+      t2 = (node.maxz-p1.z)*len/dirz;
+      if (t1 < t2)
       {
-        t1 = (node.minz-p1.z)*len/dirz;
-        t2 = (node.maxz-p1.z)*len/dirz;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     return true;
   }
 

--- a/Renderers/src/artofillusion/raytracer/RTTriangleLowMemory.java
+++ b/Renderers/src/artofillusion/raytracer/RTTriangleLowMemory.java
@@ -275,83 +275,83 @@ public class RTTriangleLowMemory extends RTObject
     double dirx = p2.x-p1.x, diry = p2.y-p1.y, dirz = p2.z-p1.z;
     double len = Math.sqrt(dirx*dirx + diry*diry + dirz*dirz);
     if (dirx == 0.0)
-      {
-        if (p1.x < node.minx || p1.x > node.maxx)
-          return false;
-      }
+    {
+      if (p1.x < node.minx || p1.x > node.maxx)
+        return false;
+    }
     else
+    {
+      t1 = (node.minx-p1.x)*len/dirx;
+      t2 = (node.maxx-p1.x)*len/dirx;
+      if (t1 < t2)
       {
-        t1 = (node.minx-p1.x)*len/dirx;
-        t2 = (node.maxx-p1.x)*len/dirx;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (diry == 0.0)
-      {
-        if (p1.y < node.miny || p1.y > node.maxy)
-          return false;
-      }
+    {
+      if (p1.y < node.miny || p1.y > node.maxy)
+        return false;
+    }
     else
+    {
+      t1 = (node.miny-p1.y)*len/diry;
+      t2 = (node.maxy-p1.y)*len/diry;
+      if (t1 < t2)
       {
-        t1 = (node.miny-p1.y)*len/diry;
-        t2 = (node.maxy-p1.y)*len/diry;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (dirz == 0.0)
-      {
-        if (p1.z < node.minz || p1.z > node.maxz)
-          return false;
-      }
+    {
+      if (p1.z < node.minz || p1.z > node.maxz)
+        return false;
+    }
     else
+    {
+      t1 = (node.minz-p1.z)*len/dirz;
+      t2 = (node.maxz-p1.z)*len/dirz;
+      if (t1 < t2)
       {
-        t1 = (node.minz-p1.z)*len/dirz;
-        t2 = (node.maxz-p1.z)*len/dirz;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     return true;
   }
 
@@ -426,24 +426,24 @@ public class RTTriangleLowMemory extends RTObject
       if ((rtTri.flags&INTERP_NORMALS) == 0)
         n.set(rtTri.tri.theMesh.faceNorm[rtTri.tri.index]);
       else
-        {
-          Vec3 normals[] = rtTri.tri.theMesh.norm;
-          Vec3 norm1 = normals[rtTri.tri.n1];
-          Vec3 norm2 = normals[rtTri.tri.n2];
-          Vec3 norm3 = normals[rtTri.tri.n3];
-          n.x = u*norm1.x + v*norm2.x + w*norm3.x;
-          n.y = u*norm1.y + v*norm2.y + w*norm3.y;
-          n.z = u*norm1.z + v*norm2.z + w*norm3.z;
-          n.normalize();
-        }
+      {
+        Vec3 normals[] = rtTri.tri.theMesh.norm;
+        Vec3 norm1 = normals[rtTri.tri.n1];
+        Vec3 norm2 = normals[rtTri.tri.n2];
+        Vec3 norm3 = normals[rtTri.tri.n3];
+        n.x = u*norm1.x + v*norm2.x + w*norm3.x;
+        n.y = u*norm1.y + v*norm2.y + w*norm3.y;
+        n.z = u*norm1.z + v*norm2.z + w*norm3.z;
+        n.normalize();
+      }
       rtTri.tri.getTextureSpec(spec, -n.dot(viewDir), u, v, w, size, time);
       if ((rtTri.flags&BUMP_MAPPED) != 0)
-        {
-          rtTri.fromLocal.transformDirection(spec.bumpGrad);
-          n.scale(spec.bumpGrad.dot(n)+1.0);
-          n.subtract(spec.bumpGrad);
-          n.normalize();
-        }
+      {
+        rtTri.fromLocal.transformDirection(spec.bumpGrad);
+        n.scale(spec.bumpGrad.dot(n)+1.0);
+        n.subtract(spec.bumpGrad);
+        n.normalize();
+      }
     }
 
     @Override

--- a/Renderers/src/artofillusion/raytracer/Raytracer.java
+++ b/Renderers/src/artofillusion/raytracer/Raytracer.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
    Changes copyright (C) 2018 by Maksim Khramov
+   Changes copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -517,12 +518,18 @@ public class Raytracer
         if (objBounds[i].maxz > maxz)
           maxz = objBounds[i].maxz;
       }
-    minx -= TOL;
-    miny -= TOL;
-    minz -= TOL;
-    maxx += TOL;
-    maxy += TOL;
-    maxz += TOL;
+
+    double extTol = maxx-minx;
+    if (maxy-miny > extTol) extTol = maxy-miny;
+    if (maxz-minz > extTol) extTol = maxz-minz;
+    extTol *= Raytracer.TOL;
+
+    minx -= extTol;
+    miny -= extTol;
+    minz -= extTol;
+    maxx += extTol;
+    maxy += extTol;
+    maxz += extTol;;
 
     // Create the octree.
 

--- a/Renderers/src/artofillusion/raytracer/Raytracer.java
+++ b/Renderers/src/artofillusion/raytracer/Raytracer.java
@@ -503,21 +503,21 @@ public class Raytracer
     minx = miny = minz = Double.MAX_VALUE;
     maxx = maxy = maxz = -Double.MAX_VALUE;
     for (i = 0; i < sceneObject.length; i++)
-      {
-        objBounds[i] = sceneObject[i].getBounds();
-        if (objBounds[i].minx < minx)
-          minx = objBounds[i].minx;
-        if (objBounds[i].maxx > maxx)
-          maxx = objBounds[i].maxx;
-        if (objBounds[i].miny < miny)
-          miny = objBounds[i].miny;
-        if (objBounds[i].maxy > maxy)
-          maxy = objBounds[i].maxy;
-        if (objBounds[i].minz < minz)
-          minz = objBounds[i].minz;
-        if (objBounds[i].maxz > maxz)
-          maxz = objBounds[i].maxz;
-      }
+    {
+      objBounds[i] = sceneObject[i].getBounds();
+      if (objBounds[i].minx < minx)
+        minx = objBounds[i].minx;
+      if (objBounds[i].maxx > maxx)
+        maxx = objBounds[i].maxx;
+      if (objBounds[i].miny < miny)
+        miny = objBounds[i].miny;
+      if (objBounds[i].maxy > maxy)
+        maxy = objBounds[i].maxy;
+      if (objBounds[i].minz < minz)
+        minz = objBounds[i].minz;
+      if (objBounds[i].maxz > maxz)
+        maxz = objBounds[i].maxz;
+    }
 
     double extTol = maxx-minx;
     if (maxy-miny > extTol) extTol = maxy-miny;
@@ -534,8 +534,9 @@ public class Raytracer
     // Create the octree.
 
     rootNode = new OctreeNode(Math.nextAfter((float) minx, Double.NEGATIVE_INFINITY), Math.nextAfter((float) maxx, Double.POSITIVE_INFINITY),
-        Math.nextAfter((float) miny, Double.NEGATIVE_INFINITY), Math.nextAfter((float) maxy, Double.POSITIVE_INFINITY),
-        Math.nextAfter((float) minz, Double.NEGATIVE_INFINITY), Math.nextAfter((float) maxz, Double.POSITIVE_INFINITY), sceneObject, objBounds, null);
+                              Math.nextAfter((float) miny, Double.NEGATIVE_INFINITY), Math.nextAfter((float) maxy, Double.POSITIVE_INFINITY),
+                              Math.nextAfter((float) minz, Double.NEGATIVE_INFINITY), Math.nextAfter((float) maxz, Double.POSITIVE_INFINITY), 
+                              sceneObject, objBounds, null);
 
     // Find the nodes which contain the camera and the lights.
 

--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2014 by Peter Eastman
+   Modification copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -166,10 +167,11 @@ public class RaytracerRenderer implements Renderer, Runnable
   @Override
   public synchronized void cancelRendering(Scene sc)
   {
-    Thread t = renderThread;
-
     if (theScene != sc)
       return;
+
+    Thread t = renderThread;
+
     renderThread = null;
     if (t == null)
       return;
@@ -1869,6 +1871,7 @@ public class RaytracerRenderer implements Renderer, Runnable
     MaterialIntersection matChange[] = workspace.matChange;
     int i, j, matCount = 0;
 
+    OctreeNode theSame = null;
     do
     {
       RTObject obj[] = node.getObjects();
@@ -1911,10 +1914,12 @@ public class RaytracerRenderer implements Renderer, Runnable
               break;
           }
       }
-      if (node == endNode)
+      if (node == endNode || node == theSame)
         break;
+      theSame = node;
       node = node.findNextNode(r);
     } while (node != null);
+
     if (currentMaterial == null && matCount == 0)
       return true;
 


### PR DESCRIPTION
Partial solution to things discussed in #193.

These at least push the boundaries, where the problems start, a bit farther. 

Unfortunately, a completely flat object on the scene may still drive the rendering into a loop, when the general size of the scene is somewhere between 25000 and 50000 units. Before that there already are serious quality issues on smaller sizes.  I have not been able to figure out, where _that_ loop happens but it is instant, when you launch the rendering.

The loop catcher in the commit does work for that particular case. You can see the result in the image, when it happens: Instead of transparent pixels you get pixels with the wrong color spread around the problem area.

<b>EDIT:</b> I have tested so many things that I got confused with what I had where: <b>&rarr;</b>

I have tested relative tolerance on  _a few more things_. With that modification I managed to render a somewhat demanding case without very serious problems or _(this is noteworthy! **\***_) looping treads: The case took over 5 hours with an 8-thread 4,0 GHz engine. Millions of triangles in the scene, a reflective water texture, 8/16 (or maybe 16/32) anti aliasing and 16 ray ambient occlusion, the largest object was with 20000 unit diameter _(= sea 10 km to the horizon)_. If the process had been bound to crash or loop, the probability is rather high, that it would have. 

Those changes were mostly in `Raytracer`. Then there is still the `OctreeNode`. Among other issues, its `contains` can not seem to work with the same rules to rays and nodes.... <b>&larr; edit</b>.

Until the next update. :)

_**\***) It is really hard to think of anything worse in that moment, when you have about 90% of a movie rendered and then CPU usage drops to show activity of one thread and never gets forward. You know that the image and therefore the entire movie will never be finished because the renderer can't get over just one damn ray in one damn pixel!_