### PR TITLE
Math.round to Math.rint in artofillusion.ui -- bug fix

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
+++ b/ArtOfIllusion/src/artofillusion/ui/Compound3DManipulator.java
@@ -810,9 +810,9 @@ public class Compound3DManipulator extends EventSource implements Manipulator
         drag = view.getCamera().findDragVector(dragStartPosition, disp.x, disp.y);
       if (isShiftDown)
       {
-        drag.x = gridSize*Math.round(drag.x/gridSize);
-        drag.y = gridSize*Math.round(drag.y/gridSize);
-        drag.z = gridSize*Math.round(drag.z/gridSize);
+        drag.x = gridSize*roundValue(drag.x/gridSize);
+        drag.y = gridSize*roundValue(drag.y/gridSize);
+        drag.z = gridSize*roundValue(drag.z/gridSize);
       }
       Mat4 transform = Mat4.translation(drag.x, drag.y, drag.z);
       dispatchEvent(new HandleDraggedEvent(view, dragHandleType, dragAxis, bounds, selectionBounds, ev, transform));
@@ -868,7 +868,7 @@ public class Compound3DManipulator extends EventSource implements Manipulator
     if (isShiftDown)
     {
       dragDistance /= gridSize;
-      dragDistance = Math.round(dragDistance);
+      dragDistance = roundValue(dragDistance);
       dragDistance *= gridSize;
     }
     Vec3 drag3D = dragDir3D.times(dragDistance);
@@ -1016,6 +1016,11 @@ public class Compound3DManipulator extends EventSource implements Manipulator
   private Vec2 toVec2(Point start, Point end)
   {
      return new Vec2(end.x - start.x, end.y - start.y);
+  }
+
+  private double roundValue(double val)
+  {
+     return Math.abs(val) > 1.0e15 ? Math.rint(val) : Math.round(val);
   }
 
   /**

--- a/ArtOfIllusion/src/artofillusion/ui/ValueField.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ValueField.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2007 by Peter Eastman
+   Modification copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -193,7 +194,13 @@ public class ValueField extends BTextField
 
         int digits = (int) Math.floor(Math.log(Math.abs(val))/Math.log(10.0));
         double scale = Math.pow(10.0, digits < 0 ? decimalPlaces-1-digits : decimalPlaces);
-        return Double.toString(Math.round(val*scale)/scale);
+
+        // Math.round can only handle values up to Long.MAX_VALUE
+
+        if (Math.abs(val) > 1e15)
+          return Double.toString(Math.rint(val*scale)/scale);
+        else
+          return Double.toString(Math.round(val*scale)/scale);
       }
   }
 

--- a/ArtOfIllusion/src/artofillusion/ui/ValueSlider.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ValueSlider.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2005 by Peter Eastman
+   Modification copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -149,7 +150,13 @@ public class ValueSlider extends WidgetContainer
 
       int digits = (int) Math.floor(Math.log(Math.abs(value))/Math.log(10.0));
       double scale = Math.pow(10.0, digits < 0 ? 2-digits : 3);
-      text = Double.toString(Math.round(value*scale)/scale);
+
+      // Math.round can only handle values up to Long.MAX_VALUE
+
+      if (Math.abs(value) > 1e15)
+        text = Double.toString(Math.rint(value*scale)/scale);
+      else
+        text = Double.toString(Math.round(value*scale)/scale);
     }
     if (!text.equals(field.getText()))
       field.setText(text);


### PR DESCRIPTION
I discovered that `ValueField` changed anything larger than 9223372036854776.0 into 9.223372036854776E15, when reading values from objects.

The problem was that the process used `Math.round()`, which returns `long` and its  `MAX_VALUE` is 9223372036854776. `Math.rint()` returns the value as `double`.

This changes all the found rounds into rints in `artofilusion.ui`. In some cases it does not really make any difference, but in principle it is the correct operation. I checked, that the value is never handled as `long` after the rounding. It is either becomes `double` again in the next operation or is converted `(int)`.

Did not check the rest of the code, but I suspect that there is a large population of `Math.round` all over it, when the expected return value would still be be `double`....

