### PR TITLE
Include commit identifier when building

### DIFF
--- a/ArtOfIllusion.xml
+++ b/ArtOfIllusion.xml
@@ -53,6 +53,8 @@
       <manifest>
         <attribute name="Main-Class" value="artofillusion.ArtOfIllusion"/>
         <attribute name="Class-Path" value="${libraries}"/>
+        <attribute name="Implementation-Version" value="${git.revision}"/>
+        <attribute name="Build-Time" value="${TODAY} at ${TSTAMP}"/>
       </manifest>
     </jar>
   </target>

--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -233,6 +233,12 @@ public class ArtOfIllusion
     return "3.1";
   }
 
+
+  public static String getBuildInfo()
+  {
+    return java.util.Objects.toString(ArtOfIllusion.class.getPackage()
+	    .getImplementationVersion(), "Missing Build Data!");    
+  }
   /** Get the application preferences object. */
 
   public static ApplicationPreferences getPreferences()

--- a/ArtOfIllusion/src/artofillusion/TitleWindow.java
+++ b/ArtOfIllusion/src/artofillusion/TitleWindow.java
@@ -30,7 +30,8 @@ public class TitleWindow extends BWindow
     ImageIcon image = new ImageIcon(getClass().getResource("/artofillusion/titleImages/titleImage"+imageNumber+".jpg"));
     String text = "<html><div align=\"center\">"+
         "Art of Illusion v"+ArtOfIllusion.getVersion()+
-        "<br>Copyright 1999-2019 by Peter Eastman and others"+
+        "<br>Build: " + ArtOfIllusion.getBuildInfo() +
+        "<br>Copyright 1999-2020 by Peter Eastman and others"+
         "<br>(See the README file for details.)"+
         "<br>This program may be freely distributed under"+
         "<br>the terms of the accompanying license.</div></html>";

--- a/build.xml
+++ b/build.xml
@@ -11,15 +11,37 @@
   <property name="java.args" value="${java.args}" />
   <property name="java.encoding" value="${java.encoding}" />
 
+  <!--property name="git.tag" value="Unknown Version" />
+  <property name="git.revision" value="Unknown Source Revision" /-->
+
+
   <!-- set of all library jars -->
   <fileset id="libraries" dir="${srclib}" includes="*.jar" />
 
   <!-- set of all subproject build files -->
   <fileset id="subproject.files" dir="." includes="*.xml" excludes="build.xml" />
 
-  <target name="init">
+
+  <!-- Adapted from https://stackoverflow.com/a/4059546 -->
+  <available file=".git" type="dir" property="git.present"/>
+	
+  <!-- Get application version and source revision from SCM -->
+  <target name="set-versions" description="Store git revision data" if="git.present">
+    <exec executable="git" outputproperty="git.describe.long" failifexecutionfails="false" logerror="true">
+      <arg value="describe"/>
+      <arg value="--first-parent"/>
+      <arg value="--tags"/>
+      <arg value="--always"/>
+      <arg value="--dirty"/>
+    </exec>
+
+  </target>
+
+
+  <target name="init" depends="set-versions">
     <!-- Create the time stamp -->
     <tstamp/>
+
     <!-- Create the build directory structure used by build -->
     <mkdir dir="${dist}" />
     <mkdir dir="${dist}/Plugins"/>
@@ -28,9 +50,17 @@
     <mkdir dir="${dist}/Scripts/Tools"/>
     <mkdir dir="${dist}/Textures and Materials" />
 
-  </target>
 
-  <!-- Generate working application artifacts -->
+    <condition property="git.revision" value="${git.describe.long}" else="Unknown Source Revison">
+      <and>
+        <isset property="git.describe.long"/>
+ 	<length string="${git.describe.long}" trim="yes" length="0" when="greater"/>
+      </and>
+    </condition>
+    <echo message="${git.revision}"/>
+</target>
+
+<!-- Generate working application artifacts -->
   <target name="dist" depends="init" description="Generate a working full-project application">
     <copy todir="${dist}/lib">
       <fileset dir="${srclib}" includes="*"/>
@@ -43,6 +73,7 @@
       <property name="java.version" value="${java.version}" />
       <property name="java.args" value="${java.args}"/>
       <property name="java.encoding" value="${java.encoding}" />
+      <property name="git.revision" value="${git.revision}" />
       <fileset refid="subproject.files" />
     </subant>
   </target>


### PR DESCRIPTION
Automatically include Git commit data in `META-INF/MANIFEST.MF`
The intent is to make it possible to tell *Exactly* what version of AOI is being run, especially when troubleshooting for our users.
This takes the form of a string formatted as follows:

`<Latest Tag in the main branch>-<Commits since Tag>-<Current Commit Hash>-<Optional "dirty" flag if there are uncommitted changes>`

If built from a source-zip or in a non-standard way (not through the ANT script), a message about missing source version will be included instead.

I've displayed this data in the Title Window on startup, but it should be easily accessible from scripts, loggers, etc.