### PR TITLE
Harden test implicit resolves #67

### DIFF
--- a/Tests/src/artofillusion/object/ImplicitSphereTest.java
+++ b/Tests/src/artofillusion/object/ImplicitSphereTest.java
@@ -103,16 +103,22 @@ public class ImplicitSphereTest
         double radius = sphere.getRadius();
         double value = sphere.getFieldValue(point.x, point.y, point.z, 0, 0);
         sphere.getFieldGradient(point.x, point.y, point.z, 0, 0, grad);
-        double step = radius*1e-3;
+        double step = radius*1e-4;
         double vx1 = sphere.getFieldValue(point.x-step, point.y, point.z, 0, 0);
         double vx2 = sphere.getFieldValue(point.x+step, point.y, point.z, 0, 0);
         double vy1 = sphere.getFieldValue(point.x, point.y-step, point.z, 0, 0);
         double vy2 = sphere.getFieldValue(point.x, point.y+step, point.z, 0, 0);
         double vz1 = sphere.getFieldValue(point.x, point.y, point.z-step, 0, 0);
         double vz2 = sphere.getFieldValue(point.x, point.y, point.z+step, 0, 0);
-        assertEquals(0.5*(vx2-vx1)/step, grad.x, 1e-2*value);
-        assertEquals(0.5*(vy2-vy1)/step, grad.y, 1e-2*value);
-        assertEquals(0.5*(vz2-vz1)/step, grad.z, 1e-2*value);
+        double gradient = (vx2-vx1)/step;
+	assertEquals("X-grad" + representTestPair(point, sphere),
+                     0.5*gradient, grad.x, 1e-5*Math.abs(grad.x));
+        gradient = (vy2-vy1)/step;
+	assertEquals("Y-grad" + representTestPair(point, sphere),
+                     0.5*gradient, grad.y, 1e-5*Math.abs(grad.y));
+        gradient = (vz2-vz1)/step;
+	assertEquals("Z-grad" + representTestPair(point, sphere),
+                     0.5*gradient, grad.z, 1e-5*Math.abs(grad.z));
       }
     }
   }

--- a/Tests/src/artofillusion/object/ImplicitSphereTest.java
+++ b/Tests/src/artofillusion/object/ImplicitSphereTest.java
@@ -15,123 +15,126 @@ import org.junit.*;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 public class ImplicitSphereTest
 { 
 
-  private static ImplicitSphere[] testSpheres = new ImplicitSphere[20];
-  private static Vec3[] samplePoints = new Vec3[100];
+  private static int testSpheres = 20;
+  private static int samplePoints = 100;
+  private static List<TestPair> pairs = new ArrayList<TestPair>();
+
+  private static class TestPair  //It was this, or abuse AbstractMap.SimpleEntry
+  {
+    public final ImplicitSphere sphere;
+    public final Vec3 point;
+
+    public TestPair(ImplicitSphere sp, Vec3 pnt)
+    {
+      sphere = sp;
+      point = pnt;
+    }
+  }
 
   @BeforeClass
   public static void setup_spheres_and_test_points()
   {
-    for (int sphere = 0; sphere < testSpheres.length; sphere++)
+    for (int sphere = 0; sphere < testSpheres; sphere++)
     {
       double r1 = 0.1 + Math.random();
       double r2 = 0.1 + Math.random();
-      testSpheres[sphere] = new ImplicitSphere(Math.min(r1, r2),
-                                               Math.max(r1, r2));
-    }
+      ImplicitSphere currentSphere = new ImplicitSphere(Math.min(r1, r2),
+                                                        Math.max(r1, r2));
 
-    for (int point = 0; point < samplePoints.length; point++)
-    {
-      /* Factor 2.05 is to cover the entire possible size range of
-       * test spheres (-1.1 to 1.1) Unlike original code, we're not
-       * scaling the test points to a specific sphere.
-       */
-      samplePoints[point] = new Vec3(2.05*(Math.random() - 0.5),
-                                     2.05*(Math.random() - 0.5),
-                                     2.05*(Math.random() - 0.5));
+      for (int point = 0; point < samplePoints; point++)
+      {
+        /* Factor 2.05 is to cover the entire possible size range of
+         * test spheres (-1.1 to 1.1) Unlike original code, we're not
+         * scaling the test points to a specific sphere.
+         */
+        Vec3 currentPoint = new Vec3(2.05*(Math.random() - 0.5),
+                                       2.05*(Math.random() - 0.5),
+				       2.05*(Math.random() - 0.5));
+
+	pairs.add(new TestPair(currentSphere, currentPoint));
+      }
     }
   }
 
   @Test
   public void point_inside_radius_is_greater_than_1()
   {
-    for (ImplicitSphere sphere: testSpheres)
-    {
-      for (Vec3 point: samplePoints)
-      {
-        if (point.length() < sphere.getRadius())
-           assertTrue(representTestPair(point, sphere),
-                      sphere.getFieldValue(point.x, point.y, point.z, 0, 0) > 1);
-      }
-    }
+    pairs.stream()
+         .filter(p -> p.point.length() < p.sphere.getRadius())
+         .forEach(p ->
+           assertTrue(printPair(p),
+                      p.sphere.getFieldValue(p.point.x, p.point.y,
+                                             p.point.z, 0, 0) > 1));
   }
 
   @Test
   public void point_outside_influence_radius_is_0()
   {
-    for (ImplicitSphere sphere: testSpheres)
-    {
-      for (Vec3 point: samplePoints)
-      {
-        if (point.length() > sphere.getInfluenceRadius())
-        {
-          assertTrue(representTestPair(point, sphere),
-                     sphere.getFieldValue(point.x, point.y, point.z, 0, 0) == 0);
-        }
-      }
-    }
+    pairs.stream()
+         .filter(p -> p.point.length() > p.sphere.getInfluenceRadius())
+         .forEach(p ->
+           assertTrue(printPair(p),
+                      p.sphere.getFieldValue(p.point.x, p.point.y,
+                                             p.point.z, 0, 0) == 0));
   }
 
   @Test
   public void point_between_radius_and_influence_is_between_0_and_1()
   {
-    for (ImplicitSphere sphere: testSpheres)
-    {
-      for (Vec3 point: samplePoints)
-      {
-        if (point.length() <= sphere.getInfluenceRadius()
-            && point.length() >= sphere.getRadius())
-        {
-           double value = sphere.getFieldValue(point.x, point.y, point.z, 0, 0);
-           assertTrue(representTestPair(point, sphere) + "\nValue:" + value,
-                     1 > value && value > 0);
-        }
-      }
-    }
+    pairs.stream()
+         .filter(p -> p.point.length() <= p.sphere.getInfluenceRadius()
+                      && p.point.length() >= p.sphere.getRadius())
+         .forEach(p ->	 
+           {
+             double value = p.sphere.getFieldValue(p.point.x, p.point.y,
+                                                   p.point.z, 0, 0);
+             assertTrue(printPair(p) + "\nValue:" + value, 1 > value && value > 0);
+           }); 
   }
 
   @Test
   public void gradient_estimate_within_delta()
   {
     Vec3 grad = new Vec3();
-    for (ImplicitSphere sphere: testSpheres)
-    {
-      for (Vec3 point: samplePoints)
+    pairs.stream()
+         .forEach(p ->
       {
-        double radius = sphere.getRadius();
-        double value = sphere.getFieldValue(point.x, point.y, point.z, 0, 0);
-        sphere.getFieldGradient(point.x, point.y, point.z, 0, 0, grad);
+        double radius = p.sphere.getRadius();
+        double value = p.sphere.getFieldValue(p.point.x, p.point.y, p.point.z, 0, 0);
+        p.sphere.getFieldGradient(p.point.x, p.point.y, p.point.z, 0, 0, grad);
         double step = radius*1e-4;
-        double vx1 = sphere.getFieldValue(point.x-step, point.y, point.z, 0, 0);
-        double vx2 = sphere.getFieldValue(point.x+step, point.y, point.z, 0, 0);
-        double vy1 = sphere.getFieldValue(point.x, point.y-step, point.z, 0, 0);
-        double vy2 = sphere.getFieldValue(point.x, point.y+step, point.z, 0, 0);
-        double vz1 = sphere.getFieldValue(point.x, point.y, point.z-step, 0, 0);
-        double vz2 = sphere.getFieldValue(point.x, point.y, point.z+step, 0, 0);
+        double vx1 = p.sphere.getFieldValue(p.point.x-step, p.point.y, p.point.z, 0, 0);
+        double vx2 = p.sphere.getFieldValue(p.point.x+step, p.point.y, p.point.z, 0, 0);
+        double vy1 = p.sphere.getFieldValue(p.point.x, p.point.y-step, p.point.z, 0, 0);
+        double vy2 = p.sphere.getFieldValue(p.point.x, p.point.y+step, p.point.z, 0, 0);
+        double vz1 = p.sphere.getFieldValue(p.point.x, p.point.y, p.point.z-step, 0, 0);
+        double vz2 = p.sphere.getFieldValue(p.point.x, p.point.y, p.point.z+step, 0, 0);
         double gradient = (vx2-vx1)/step;
-	assertEquals("X-grad" + representTestPair(point, sphere),
+	assertEquals("X-grad" + printPair(p),
                      0.5*gradient, grad.x, 1e-5*Math.abs(grad.x));
         gradient = (vy2-vy1)/step;
-	assertEquals("Y-grad" + representTestPair(point, sphere),
+	assertEquals("Y-grad" + printPair(p),
                      0.5*gradient, grad.y, 1e-5*Math.abs(grad.y));
         gradient = (vz2-vz1)/step;
-	assertEquals("Z-grad" + representTestPair(point, sphere),
+	assertEquals("Z-grad" + printPair(p),
                      0.5*gradient, grad.z, 1e-5*Math.abs(grad.z));
-      }
-    }
+      });
   }
 
-  private String representTestPair(Vec3 point, ImplicitSphere sphere)
+  private String printPair(TestPair pair)
   {
     return "\nTest Point:\n" +
-	   "\nX:" + point.x +
-	   "\nY:" + point.y +
-	   "\nZ:" + point.z +
-	   "\nLength:" + point.length() +
+	   "\nX:" + pair.point.x +
+	   "\nY:" + pair.point.y +
+	   "\nZ:" + pair.point.z +
+	   "\nLength:" + pair.point.length() +
            "\n\nImplicit Sphere:\n" +
-	   "\nRadius:" + sphere.getRadius() +
-	   "\nInfluence:" + sphere.getInfluenceRadius();
+	   "\nRadius:" + pair.sphere.getRadius() +
+	   "\nInfluence:" + pair.sphere.getInfluenceRadius();
   }
 }

--- a/Tests/src/artofillusion/object/ImplicitSphereTest.java
+++ b/Tests/src/artofillusion/object/ImplicitSphereTest.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2013 by Peter Eastman
    Changes copyright (C) 2017 by Maksim Khramov
+   Changes/refactor (C) 2020 by Lucas Stanek
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -16,6 +17,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import java.util.*;
+import static java.lang.Math.*;
 
 public class ImplicitSphereTest
 { 
@@ -41,20 +43,19 @@ public class ImplicitSphereTest
   {
     for (int sphere = 0; sphere < testSpheres; sphere++)
     {
-      double r1 = 0.1 + Math.random();
-      double r2 = 0.1 + Math.random();
-      ImplicitSphere currentSphere = new ImplicitSphere(Math.min(r1, r2),
-                                                        Math.max(r1, r2));
+      double r1 = 0.1 + random();
+      double r2 = 0.1 + random();
+      ImplicitSphere currentSphere = new ImplicitSphere(min(r1, r2),
+                                                        max(r1, r2));
 
       for (int point = 0; point < samplePoints; point++)
       {
         /* Factor 2.05 is to cover the entire possible size range of
-         * test spheres (-1.1 to 1.1) Unlike original code, we're not
-         * scaling the test points to a specific sphere.
+         * test spheres (-1.1 to 1.1) 
          */
-        Vec3 currentPoint = new Vec3(2.05*(Math.random() - 0.5),
-                                     2.05*(Math.random() - 0.5),
-                                     2.05*(Math.random() - 0.5));
+        Vec3 currentPoint = new Vec3(2.05*(random() - 0.5),
+                                     2.05*(random() - 0.5),
+                                     2.05*(random() - 0.5));
 
         pairs.add(new TestPair(currentSphere, currentPoint));
       }
@@ -93,7 +94,8 @@ public class ImplicitSphereTest
            {
              double value = p.sphere.getFieldValue(p.point.x, p.point.y,
                                                    p.point.z, 0, 0);
-             assertTrue(printPair(p) + "\nValue:" + value, 1 > value && value > 0);
+             assertTrue(printPair(p) + "\nValue:" + value,
+                        1 > value && value > 0);
            }); 
   }
 
@@ -101,7 +103,7 @@ public class ImplicitSphereTest
   public void gradient_estimate_within_delta()
   {
     pairs.stream()
-         .filter(p -> Math.abs(p.point.length() - p.sphere.getInfluenceRadius())
+         .filter(p -> abs(p.point.length() - p.sphere.getInfluenceRadius())
                       > p.sphere.getRadius() * 1e-4)
          .forEach(p ->
            {
@@ -110,14 +112,11 @@ public class ImplicitSphereTest
                                        0, 0, grad);
              Vec3 estGrad = estimateGradient(p);
              assertEquals("X-grad" + printPair(p),
-                          0.5 * estGrad.x, grad.x,
-                          1e-4*Math.abs(grad.x));
+                          0.5 * estGrad.x, grad.x, 1e-4 * abs(grad.x));
              assertEquals("Y-grad" + printPair(p),
-                          0.5 * estGrad.y, grad.y,
-                          1e-4*Math.abs(grad.y));
+                          0.5 * estGrad.y, grad.y, 1e-4 * abs(grad.y));
              assertEquals("Z-grad" + printPair(p),
-                          0.5 * estGrad.z, grad.z,
-                          1e-4*Math.abs(grad.z));
+                          0.5 * estGrad.z, grad.z, 1e-4 * abs(grad.z));
             });
   }
 
@@ -129,7 +128,7 @@ public class ImplicitSphereTest
   public void gradient_estimate_at_influence_edge()
   {
     pairs.stream()
-         .filter(p -> Math.abs(p.point.length() - p.sphere.getInfluenceRadius())
+         .filter(p -> abs(p.point.length() - p.sphere.getInfluenceRadius())
                       <= p.sphere.getRadius() * 1e-4)
          .forEach(p ->
            {
@@ -138,14 +137,11 @@ public class ImplicitSphereTest
                                        0, 0, grad);
              Vec3 estGrad = estimateGradient(p);
              assertEquals("X-grad" + printPair(p),
-                          Math.signum(0.5 * estGrad.x),
-                          Math.signum(grad.x), .01);
+                          signum(0.5 * estGrad.x), signum(grad.x), .01);
              assertEquals("Y-grad" + printPair(p),
-                          Math.signum(0.5 * estGrad.y),
-                          Math.signum(grad.y), .01);
+                          signum(0.5 * estGrad.y), signum(grad.y), .01);
              assertEquals("Z-grad" + printPair(p),
-                          Math.signum(0.5 * estGrad.z),
-                          Math.signum(grad.z), .01);
+                          signum(0.5 * estGrad.z), signum(grad.z), .01);
            });  
   }
 

--- a/Tests/src/artofillusion/object/ImplicitSphereTest.java
+++ b/Tests/src/artofillusion/object/ImplicitSphereTest.java
@@ -112,11 +112,11 @@ public class ImplicitSphereTest
                                        0, 0, grad);
              Vec3 estGrad = estimateGradient(p);
              assertEquals("X-grad" + printPair(p),
-                          0.5 * estGrad.x, grad.x, 1e-4 * abs(grad.x));
+                          estGrad.x, grad.x, 1e-4 * abs(grad.x));
              assertEquals("Y-grad" + printPair(p),
-                          0.5 * estGrad.y, grad.y, 1e-4 * abs(grad.y));
+                          estGrad.y, grad.y, 1e-4 * abs(grad.y));
              assertEquals("Z-grad" + printPair(p),
-                          0.5 * estGrad.z, grad.z, 1e-4 * abs(grad.z));
+                          estGrad.z, grad.z, 1e-4 * abs(grad.z));
             });
   }
 
@@ -137,11 +137,11 @@ public class ImplicitSphereTest
                                        0, 0, grad);
              Vec3 estGrad = estimateGradient(p);
              assertEquals("X-grad" + printPair(p),
-                          signum(0.5 * estGrad.x), signum(grad.x), .01);
+                          signum(estGrad.x), signum(grad.x), .01);
              assertEquals("Y-grad" + printPair(p),
-                          signum(0.5 * estGrad.y), signum(grad.y), .01);
+                          signum(estGrad.y), signum(grad.y), .01);
              assertEquals("Z-grad" + printPair(p),
-                          signum(0.5 * estGrad.z), signum(grad.z), .01);
+                          signum(estGrad.z), signum(grad.z), .01);
            });  
   }
 
@@ -156,7 +156,8 @@ public class ImplicitSphereTest
     double vy2 = sphere.getFieldValue(point.x, point.y+step, point.z, 0, 0);
     double vz1 = sphere.getFieldValue(point.x, point.y, point.z-step, 0, 0);
     double vz2 = sphere.getFieldValue(point.x, point.y, point.z+step, 0, 0);
-    return new Vec3((vx2-vx1)/step, (vy2-vy1)/step, (vz2-vz1)/step);
+    return new Vec3((vx2-vx1)/(2 * step),
+		    (vy2-vy1)/(2 * step), (vz2-vz1)/(2 * step));
   }
 
   private String printPair(TestPair pair)


### PR DESCRIPTION
As discussed in #67 
Well, this took me down a deeper rabbit hole than I was expecting. I've done the following:

- Restructured pretty much the entire test class.
  + I broke the various tests out into separate test methods, to improve localizing any failures. The test case name should tell exactly what kind of unexpected we've run into.
  + Added a readable printout of the <sphere, point> pair that failed the test
  + This would be much easier if we had a property testing framework (plugin to junit 5, but I'm not going there right now)
- Fixed two separate false failure modes, both as expected from the issue discussion
  + Scaled the allowable delta between the estimated and returned gradients proportional to the returned gradient
  + At the edge of the influence radius, some of the samples for the estimated gradient might be inside the influence, and some outside. This seriously skews the estimate. Instead of trying to do some really fussy bracketing, or trying to space the sample points tighter, I threw in the towel and just make sure that the estimate and the returned gradient are in the same octant of the sphere. (Make sure each of the components match in sign - pointing roughly in the right direction)

Was this overboard? Possibly. Unnecessary? Probably.

Learned a few things, and by the time I realized how much surgery I was doing, it was mostly done except for cleanup.