### PR TITLE
More Named interface usages

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -12,13 +12,11 @@
 
 package artofillusion;
 
-import artofillusion.animation.*;
 import artofillusion.image.*;
 import artofillusion.image.filter.*;
 import artofillusion.material.*;
 import artofillusion.math.*;
 import artofillusion.object.*;
-import artofillusion.procedural.*;
 import artofillusion.script.*;
 import artofillusion.texture.*;
 import artofillusion.ui.*;
@@ -27,12 +25,11 @@ import artofillusion.view.*;
 import buoy.widget.*;
 import buoy.xml.*;
 
-import java.awt.*;
 import java.io.*;
 import java.net.*;
 import java.util.*;
 import java.util.List;
-import java.lang.reflect.*;
+
 import java.util.prefs.Preferences;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -515,25 +512,30 @@ public class ArtOfIllusion
   /** Load a scene from a file, and open a new window containing it.  The BFrame is used for
       displaying dialogs. */
 
-  public static void openScene(File f, BFrame fr)
+  public static void openScene(File file, BFrame frame)
   {
     // Open the file and read the scene.
 
     try
     {
-      Scene sc = new Scene(f, true);
-      if (sc.errorsOccurredInLoading())
-        new BStandardDialog("", new Object[] {UIUtilities.breakString(Translate.text("errorLoadingScenePart")), new BScrollPane(new BTextArea(sc.getLoadingErrors()))}, BStandardDialog.ERROR).showMessageDialog(fr);
-      newWindow(sc);
-      RecentFiles.addRecentFile(f);
+      Scene scene = new Scene(file, true);
+      List<String> errors = scene.getErrors();
+      if (!errors.isEmpty())
+      {
+        String allErrors = String.join("\n", errors);
+        new BStandardDialog("", new Object[] {UIUtilities.breakString(Translate.text("errorLoadingScenePart")), new BScrollPane(new BTextArea(allErrors))}, BStandardDialog.ERROR).showMessageDialog(frame);
+    }
+
+      newWindow(scene);
+      RecentFiles.addRecentFile(file);
     }
     catch (InvalidObjectException ex)
     {
-      new BStandardDialog("", UIUtilities.breakString(Translate.text("errorLoadingWholeScene")), BStandardDialog.ERROR).showMessageDialog(fr);
+      new BStandardDialog("", UIUtilities.breakString(Translate.text("errorLoadingWholeScene")), BStandardDialog.ERROR).showMessageDialog(frame);
     }
     catch (IOException ex)
     {
-      new BStandardDialog("", new String [] {Translate.text("errorLoadingFile"), ex.getMessage() == null ? "" : ex.getMessage()}, BStandardDialog.ERROR).showMessageDialog(fr);
+      new BStandardDialog("", new String [] {Translate.text("errorLoadingFile"), ex.getMessage() == null ? "" : ex.getMessage()}, BStandardDialog.ERROR).showMessageDialog(frame);
     }
   }
 

--- a/ArtOfIllusion/src/artofillusion/Named.java
+++ b/ArtOfIllusion/src/artofillusion/Named.java
@@ -1,0 +1,27 @@
+/* Copyright (C) 2020 by Maksim Khramov
+
+   This program is free software; you can redistribute it and/or modify it under the
+   terms of the GNU General Public License as published by the Free Software
+   Foundation; either version 2 of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
+
+package artofillusion;
+
+/**
+ *
+ * @author MaksK
+ */
+public interface Named<T> {
+
+    public String getName();
+    public void setName(String name);
+
+    default T setNameFluent(String name)
+    {
+      setName(name);
+      return (T)this;
+    }
+}

--- a/ArtOfIllusion/src/artofillusion/Named.java
+++ b/ArtOfIllusion/src/artofillusion/Named.java
@@ -17,11 +17,6 @@ package artofillusion;
 public interface Named<T> {
 
     public String getName();
-    public void setName(String name);
+    public T setName(String name);
 
-    default T setNameFluent(String name)
-    {
-      setName(name);
-      return (T)this;
-    }
 }

--- a/ArtOfIllusion/src/artofillusion/ObjectSet.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectSet.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2008 by Peter Eastman
    Updates copyright (C) 2020 by Petri Ihalainen
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -21,7 +22,7 @@ import java.beans.*;
  * saved selections.
  */
 
-public class ObjectSet
+public class ObjectSet implements Named<ObjectSet>
 {
   private String name;
   private int objectIDs[];
@@ -83,9 +84,10 @@ public class ObjectSet
    * Set the name of this ObjectSet.
    */
 
-  public void setName(String name)
+  public ObjectSet setName(String name)
   {
     this.name = name;
+    return this;
   }
 
   /**

--- a/ArtOfIllusion/src/artofillusion/Scene.java
+++ b/ArtOfIllusion/src/artofillusion/Scene.java
@@ -1209,7 +1209,6 @@ public class Scene
     initFromStream(in, fullScene);
   }
 
-  @SuppressWarnings("UseOfObsoleteCollectionType")
   private static Vector<Named> loadSceneAsset(DataInputStream source, Scene scene, Supplier<Named> stub) throws IOException
   {
       int counter = source.readInt();

--- a/ArtOfIllusion/src/artofillusion/Scene.java
+++ b/ArtOfIllusion/src/artofillusion/Scene.java
@@ -45,11 +45,17 @@ public class Scene
   private TextureMapping environMapping;
   private int gridSubdivisions, environMode, framesPerSecond, nextID;
   private double fogDist, gridSpacing, time;
-  private boolean fog, showGrid, snapToGrid, errorsLoading;
+  private boolean fog, showGrid, snapToGrid;
   private String name, directory;
 
   private ParameterValue environParamValue[];
-  private StringBuffer loadingErrors;
+
+  private final List<String> errors = new ArrayList<>();
+
+  public List<String> getErrors()
+  {
+    return Collections.unmodifiableList(errors);
+  }
 
   public static final int HANDLE_SIZE = 4;
   public static final int ENVIRON_SOLID = 0;
@@ -1159,21 +1165,6 @@ public class Scene
     return sel;
   }
 
-  /** Return true if any errors occurred while loading the scene.  The scene is still valid
-      and usable, but some objects in it were not loaded correctly. */
-
-  public boolean errorsOccurredInLoading()
-  {
-    return errorsLoading;
-  }
-
-  /** Get a description of any errors which occurred while loading the scene. */
-
-  public String getLoadingErrors()
-  {
-    return (loadingErrors == null ? "" : loadingErrors.toString());
-  }
-
   /** The following constructor is used for reading files.  If fullScene is false, only the
       Textures and Materials are read. */
 
@@ -1229,7 +1220,7 @@ public class Scene
 
     if (version < 0 || version > 5)
       throw new InvalidObjectException("");
-    loadingErrors = new StringBuffer();
+
     ambientColor = new RGBColor(in);
     fogColor = new RGBColor(in);
     fog = in.readBoolean();
@@ -1291,13 +1282,12 @@ public class Scene
               {
                 ex.printStackTrace();
                 if (ex instanceof ClassNotFoundException)
-                  loadingErrors.append(Translate.text("errorFindingClass", classname)).append('\n');
+                  errors.add(Translate.text("errorFindingClass", classname));
                 else
-                  loadingErrors.append(Translate.text("errorInstantiatingClass", classname)).append('\n');
+                  errors.add(Translate.text("errorInstantiatingClass", classname));
                 UniformMaterial m = new UniformMaterial();
                 m.setName("<unreadable>");
                 materials.addElement(m);
-                errorsLoading = true;
               }
           }
         catch (Exception ex)
@@ -1331,13 +1321,12 @@ public class Scene
               {
                 ex.printStackTrace();
                 if (ex instanceof ClassNotFoundException)
-                  loadingErrors.append(Translate.text("errorFindingClass", classname)).append('\n');
+                  errors.add(Translate.text("errorFindingClass", classname));
                 else
-                  loadingErrors.append(Translate.text("errorInstantiatingClass", classname)).append('\n');
+                  errors.add(Translate.text("errorInstantiatingClass", classname));
                 UniformTexture t = new UniformTexture();
                 t.setName("<unreadable>");
                 textures.addElement(t);
-                errorsLoading = true;
               }
           }
         catch (Exception ex)
@@ -1483,12 +1472,12 @@ public class Scene
                 else
                   ex.printStackTrace();
                 if (ex instanceof ClassNotFoundException)
-                  loadingErrors.append(info.getName()).append(": ").append(Translate.text("errorFindingClass", classname)).append('\n');
+                  errors.add(info.getName() + ": " + Translate.text("errorFindingClass", classname));
                 else
-                  loadingErrors.append(info.getName()).append(": ").append(Translate.text("errorInstantiatingClass", classname)).append('\n');
+                  errors.add(info.getName() + ": " + Translate.text("errorInstantiatingClass", classname));
                 obj = new NullObject();
                 info.setName("<unreadable> "+ info.getName());
-                errorsLoading = true;
+
               }
             table.put(key, obj);
           }

--- a/ArtOfIllusion/src/artofillusion/Scene.java
+++ b/ArtOfIllusion/src/artofillusion/Scene.java
@@ -1261,7 +1261,6 @@ public class Scene
 
   /** Initialize the scene based on information read from an input stream. */
 
-  @SuppressWarnings("UseOfObsoleteCollectionType")
   private void initFromStream(DataInputStream in, boolean fullScene) throws IOException, InvalidObjectException
   {
     int count;

--- a/ArtOfIllusion/src/artofillusion/Scene.java
+++ b/ArtOfIllusion/src/artofillusion/Scene.java
@@ -67,7 +67,7 @@ public class Scene
 
   public Scene()
   {
-    Texture defTex = new UniformTexture().setNameFluent("Default Texture");
+    Texture defTex = new UniformTexture().setName("Default Texture");
 
     objects = new Vector<ObjectInfo>();
     materials = new Vector<Material>();
@@ -1233,13 +1233,13 @@ public class Scene
         }
         catch(ClassNotFoundException cnfe) //Exception thrown once class not found across loaded plugins...
         {
-          result.add((Named)stub.get().setNameFluent("<unreadable>"));
+          result.add((Named)stub.get().setName("<unreadable>"));
           scene.errors.add(Translate.text("errorFindingClass", className));
           continue;
         }
         if(clazz == null) // Null class returns from ArtofIllusion.getClass when no loaded plugins at all
         {
-          result.add((Named)stub.get().setNameFluent("<unreadable>"));
+          result.add((Named)stub.get().setName("<unreadable>"));
           scene.errors.add(Translate.text("errorFindingClass", className));
           continue;
         }
@@ -1251,7 +1251,7 @@ public class Scene
         }
         catch(IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex)
         {
-          result.add((Named)stub.get().setNameFluent("<unreadable>"));
+          result.add((Named)stub.get().setName("<unreadable>"));
           scene.errors.add(Translate.text("errorInstantiatingClass", className));
         }
       }

--- a/ArtOfIllusion/src/artofillusion/animation/ProceduralPositionTrack.java
+++ b/ArtOfIllusion/src/artofillusion/animation/ProceduralPositionTrack.java
@@ -622,14 +622,6 @@ public class ProceduralPositionTrack extends Track implements ProcedureOwner
     return true;
   }
 
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
-  {
-    return true;
-  }
-
   /** This is called when the user clicks OK in the procedure editor. */
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/animation/ProceduralRotationTrack.java
+++ b/ArtOfIllusion/src/artofillusion/animation/ProceduralRotationTrack.java
@@ -607,14 +607,6 @@ public class ProceduralRotationTrack extends Track implements ProcedureOwner
     return true;
   }
 
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
-  {
-    return true;
-  }
-
   /** This is called when the user clicks OK in the procedure editor. */
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/animation/Track.java
+++ b/ArtOfIllusion/src/artofillusion/animation/Track.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2001-2013 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -18,7 +19,7 @@ import java.util.*;
 /** This is an abstract class representing an aspect of the scene which changes with time.
     Tracks are typically defined either by a Timecourse or a Procedure. */
 
-public abstract class Track
+public abstract class Track implements Named<Track>
 {
   protected String name;
   protected boolean enabled = true, quantized = true;
@@ -41,9 +42,10 @@ public abstract class Track
   
   /** Set the name of the track. */
   
-  public void setName(String name)
+  public Track setName(String name)
   {
     this.name = name;
+    return this;
   }
   
   /** Returns whether the track is currently enabled. */

--- a/ArtOfIllusion/src/artofillusion/animation/distortion/CustomDistortionTrack.java
+++ b/ArtOfIllusion/src/artofillusion/animation/distortion/CustomDistortionTrack.java
@@ -455,14 +455,6 @@ public class CustomDistortionTrack extends Track implements ProcedureOwner
     return true;
   }
 
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
-  {
-    return true;
-  }
-
   /** This is called when the user clicks OK in the procedure editor. */
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/material/Material.java
+++ b/ArtOfIllusion/src/artofillusion/material/Material.java
@@ -20,7 +20,7 @@ import java.io.*;
     internal color and transparency, index of refraction, etc.  This is distinct from the
     surface properties, which are described by a Texture object. */
 
-public abstract class Material
+public abstract class Material implements Named<Material>
 {
   protected String name;
   protected double refraction = 1.0;
@@ -38,6 +38,7 @@ public abstract class Material
 
   /** Get the name of the material. */
 
+  @Override
   public String getName()
   {
     return name;
@@ -45,6 +46,7 @@ public abstract class Material
 
   /** Change the name of the material. */
 
+  @Override
   public void setName(String name)
   {
     this.name = name;

--- a/ArtOfIllusion/src/artofillusion/material/Material.java
+++ b/ArtOfIllusion/src/artofillusion/material/Material.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2007 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -47,9 +48,10 @@ public abstract class Material implements Named<Material>
   /** Change the name of the material. */
 
   @Override
-  public void setName(String name)
+  public Material setName(String name)
   {
     this.name = name;
+    return this;
   }
 
   /** Get the index of refraction. */  
@@ -118,7 +120,7 @@ public abstract class Material implements Named<Material>
   
   public abstract Material duplicate();
 
-  /** Allow the user to interactively edit the naterial.  parent is a WindowWidget which can be used as a
+  /** Allow the user to interactively edit the material.  parent is a WindowWidget which can be used as a
    parent for Dialogs, and sc is the Scene which this Material is part of.  Subclasses should override
    this to implement editing. */
 

--- a/ArtOfIllusion/src/artofillusion/material/ProceduralMaterial3D.java
+++ b/ArtOfIllusion/src/artofillusion/material/ProceduralMaterial3D.java
@@ -346,14 +346,6 @@ public class ProceduralMaterial3D extends Material3D implements ProcedureOwner
     return false;
   }
 
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
-  {
-    return true;
-  }
-
   /** This is called when the user clicks OK in the procedure editor. */
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/object/ObjectInfo.java
+++ b/ArtOfIllusion/src/artofillusion/object/ObjectInfo.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -27,7 +28,7 @@ import java.util.*;
     There may be several ObjectInfos in a scene which all reference
     the same Object3D.  In that case, they are live duplicates of each other. */
 
-public class ObjectInfo
+public class ObjectInfo implements Named<ObjectInfo>
 {
   public Object3D object;
   public CoordinateSystem coords;
@@ -452,9 +453,10 @@ public class ObjectInfo
 
   /** Set the name of this object. */
 
-  public void setName(String name)
+  public ObjectInfo setName(String name)
   {
     this.name = name;
+    return this;
   }
 
   /** Get whether this object is visible. */

--- a/ArtOfIllusion/src/artofillusion/object/ProceduralDirectionalLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/ProceduralDirectionalLight.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2008 by Peter Eastman
-   Changes copyright (C) 2017 by Maksim Khramov
+   Changes copyright (C) 2017-2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -538,23 +538,6 @@ public class ProceduralDirectionalLight extends DirectionalLight
     public boolean allowViewAngle()
     {
       return false;
-    }
-
-    @Override
-    public boolean canEditName()
-    {
-      return false;
-    }
-
-    @Override
-    public String getName()
-    {
-      return info.getName();
-    }
-
-    @Override
-    public void setName(String name)
-    {
     }
 
     @Override

--- a/ArtOfIllusion/src/artofillusion/object/ProceduralPointLight.java
+++ b/ArtOfIllusion/src/artofillusion/object/ProceduralPointLight.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2008 by Peter Eastman
-   Changes copyright (C) 2017 by Maksim Khramov
+   Changes copyright (C) 2017-2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -546,23 +546,6 @@ public class ProceduralPointLight extends PointLight
     public boolean allowViewAngle()
     {
       return false;
-    }
-
-    @Override
-    public boolean canEditName()
-    {
-      return false;
-    }
-
-    @Override
-    public String getName()
-    {
-      return info.getName();
-    }
-
-    @Override
-    public void setName(String name)
-    {
     }
 
     @Override

--- a/ArtOfIllusion/src/artofillusion/procedural/ProcedureEditor.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ProcedureEditor.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2000-2012 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -99,10 +100,10 @@ public class ProcedureEditor extends CustomWidget
     FormContainer top = new FormContainer(new double [] {0.0, 0.0, 1.0, 0.0, 0.0}, new double [] {1.0});
     top.setDefaultLayout(new LayoutInfo(LayoutInfo.CENTER, LayoutInfo.HORIZONTAL, new Insets(0, 0, 0, 5), null));
     top.add(Translate.button("properties", this, "actionPerformed"), 0, 0);
-    if (owner.canEditName())
+    if (owner instanceof Named)
     {
       top.add(new BLabel(Translate.text("Name")+':'), 1, 0);
-      top.add(nameField = new BTextField(owner.getName()), 2, 0);
+      top.add(nameField = new BTextField(((Named)owner).getName()), 2, 0);
     }
     top.add(Translate.button("ok", this, "doOk"), 3, 0);
     top.add(Translate.button("cancel", this, "actionPerformed"), 4, 0);
@@ -421,8 +422,8 @@ public class ProcedureEditor extends CustomWidget
 
   private void doOk()
   {
-    if (owner.canEditName())
-      owner.setName(nameField.getText());
+    if (owner instanceof Named)
+    ((Named)owner).setName(nameField.getText());
     owner.acceptEdits(this);
     owner.disposePreview(preview);
     parent.dispose();

--- a/ArtOfIllusion/src/artofillusion/procedural/ProcedureOwner.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/ProcedureOwner.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2002 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -38,18 +39,6 @@ public interface ProcedureOwner
   /** Determine whether the procedure may contain View Angle modules. */
   
   public boolean allowViewAngle();
-  
-  /** Determine whether the procedure may be renamed. */
-  
-  public boolean canEditName();
-  
-  /** Get the name of the procedure. */
-  
-  public String getName();
-  
-  /** Set the name of the procedure. */
-  
-  public void setName(String name);
   
   /** This is called when the user clicks OK in the procedure editor. */
   

--- a/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture2D.java
+++ b/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture2D.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2000-2008 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -397,14 +398,6 @@ public class ProceduralTexture2D extends Texture2D implements ProcedureOwner
 
   @Override
   public boolean allowViewAngle()
-  {
-    return true;
-  }
-
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
   {
     return true;
   }

--- a/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture3D.java
+++ b/ArtOfIllusion/src/artofillusion/texture/ProceduralTexture3D.java
@@ -402,14 +402,6 @@ public class ProceduralTexture3D extends Texture3D implements ProcedureOwner
     return true;
   }
 
-  /** Determine whether the procedure may be renamed. */
-
-  @Override
-  public boolean canEditName()
-  {
-    return true;
-  }
-
   /** This is called when the user clicks OK in the procedure editor. */
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/texture/Texture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/Texture.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2004 by Peter Eastman
+   Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -54,9 +55,10 @@ public abstract class Texture implements Named<Texture>
   /** Change the name of the texture. */
 
   @Override
-  public void  setName(String name)
+  public Texture setName(String name)
   {
     this.name = name;
+    return this;
   }
   
   /** Determine whether this texture has a non-zero value anywhere for a particular component.

--- a/ArtOfIllusion/src/artofillusion/texture/Texture.java
+++ b/ArtOfIllusion/src/artofillusion/texture/Texture.java
@@ -20,7 +20,7 @@ import java.io.*;
     transparency, displacement, etc.  This is distinct from the interior bulk properties,
     which are described by a Material object. */
 
-public abstract class Texture
+public abstract class Texture implements Named<Texture>
 {
   protected String name;
   protected int id = nextID++;
@@ -45,6 +45,7 @@ public abstract class Texture
 
   /** Get the name of the texture. */
 
+  @Override
   public String getName()
   {
     return name;
@@ -52,7 +53,8 @@ public abstract class Texture
 
   /** Change the name of the texture. */
 
-  public void setName(String name)
+  @Override
+  public void  setName(String name)
   {
     this.name = name;
   }


### PR DESCRIPTION
More Named interface usages
Remove fluent suffix from Named intrface
Remove name getter/setter and canEditName methods from ProcedureOwner interface
Replace usage of canEditName with instanceof Named  idiom