### PR TITLE
twist angle optimization recoded

### DIFF
--- a/ArtOfIllusion/src/artofillusion/animation/Joint.java
+++ b/ArtOfIllusion/src/artofillusion/animation/Joint.java
@@ -42,8 +42,11 @@ public class Joint
       length = new DOF(0.0, Double.MAX_VALUE, d);
       calcAnglesFromCoords(false);
     }
-    if (twist.pos >  90) twist.pos -= 180;
-    if (twist.pos < -90) twist.pos += 180;
+    if (twist.pos < -90 || twist.pos >  90)
+    {
+      twist.pos -= (180*Math.signum(twist.pos));
+      recalcCoords(false); // A new bone does not have children
+    }
     length.fixed = true;
     angle1.loop = angle2.loop = twist.loop = true;
     id = -1;


### PR DESCRIPTION
The problem is demonstrated in the zipped .mp4 below. 

[twisanglefixbug.zip](https://github.com/ArtOfIllusion/ArtOfIllusion/files/5286776/twisanglefixbug.zip)

I should have realized that after modifying the angle the CoordinateSystem system needs to be recalculated. Otherwise the outdated CoordinateSystem takes over the next time the bones move.

