### PR TITLE
No need to calculate ports count for Output module.

### DIFF
--- a/ArtOfIllusion/src/artofillusion/procedural/OutputModule.java
+++ b/ArtOfIllusion/src/artofillusion/procedural/OutputModule.java
@@ -40,7 +40,9 @@ public class OutputModule extends ProceduralModule
   @Override
   public void calcSize()
   {
-    super.calcSize();
+    bounds.width = defaultMetrics.stringWidth(name) + IOPort.SIZE * 4;
+    bounds.height = defaultMetrics.getMaxAscent() + defaultMetrics.getMaxDescent() + IOPort.SIZE * 4;
+    
     if (width > 0)
       bounds.width = width;
   }


### PR DESCRIPTION
No need to calculate ports count as Output module always has only single input port.Simple evaluate width anf height from name string