### PR TITLE
Illumination tab initial enabled-status

### DIFF
--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -394,6 +394,7 @@ public class RaytracerRenderer implements Renderer, Runnable
       giModeChoice.addEventLink(ValueChangedEvent.class, illumListener);
       causticsBox.addEventLink(ValueChangedEvent.class, illumListener);
       scatterModeChoice.addEventLink(ValueChangedEvent.class, illumListener);
+      giModeChoice.dispatchEvent(new ValueChangedEvent(giModeChoice));
     }
     if (needCopyToUI)
       copyConfigurationToUI();
@@ -440,6 +441,7 @@ public class RaytracerRenderer implements Renderer, Runnable
     // Generate events to force appropriate components to be enabled or disabled.
 
     aliasChoice.dispatchEvent(new ValueChangedEvent(aliasChoice));
+    giModeChoice.dispatchEvent(new ValueChangedEvent(giModeChoice));
   }
 
   @Override


### PR DESCRIPTION
The Illumination tab had all input fields enabled at start-up. Also after re-opening a file the enabled-states were not necessarily up to date. Added `dipatchEvent`s just like to the General tab, to update it at launch.
