### PR TITLE
Handling of editing by ScriptedObject

### DIFF
--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -1249,6 +1249,8 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
   public void setTime(double time)
   {
     theScene.setTime(time);
+    if (theScene.itemListChanged)
+      rebuildItemList(); // The user sees the change. The problem has been pointed out before, so let's just show the effect.
     theScore.setTime(time);
     theScore.repaint();
     itemTree.repaint();

--- a/ArtOfIllusion/src/artofillusion/animation/AnimationPreviewer.java
+++ b/ArtOfIllusion/src/artofillusion/animation/AnimationPreviewer.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2001-2012 by Peter Eastman
    Changes copyright (C) 2016 by Maksim Khramov
+   Changes copyright (C) 2020 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -154,6 +155,8 @@ public class AnimationPreviewer implements Runnable
       {
         final double time = startTime+i/(double) fps;
         theScene.setTime(time);
+        if (theScene.itemListChanged)
+          window.rebuildItemList();
         SceneCamera sc = (SceneCamera) sceneCamera.getObject();
         cam.setCameraCoordinates(sceneCamera.getCoords().duplicate());
         cam.setScreenTransform(sc.getScreenTransform(width, height), width, height);
@@ -161,7 +164,7 @@ public class AnimationPreviewer implements Runnable
         try
         {
           EventQueue.invokeAndWait(new Runnable() {
-                      @Override
+            @Override
             public void run()
             {
               setLabels(time, frame);
@@ -255,6 +258,8 @@ public class AnimationPreviewer implements Runnable
     {
     }
     theScene.setTime(originalTime);
+      if (theScene.itemListChanged)
+        window.rebuildItemList();
     display.dispose();
   }
 

--- a/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2002-2013 by Peter Eastman
-
+   Modifications Copyright (C) 2020 by Petri Ihalainen
+ 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
    Foundation; either version 2 of the License, or (at your option) any later version.
@@ -17,6 +18,7 @@ import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
 import java.io.*;
+import java.util.ArrayList;
 
 /** This class presents a user interface for entering object scripts. */
 
@@ -157,6 +159,10 @@ public class ScriptedObjectEditorWindow extends BFrame
 
   private void commitChanges()
   {
+    // Let's take a snapshot od the scene before we run the ScriptedObject
+
+    ArrayList<ObjectInfo> objectsBeforeRun = new ArrayList(window.getScene().getAllObjects());
+
     ScriptedObject so = (ScriptedObject) info.getObject();
     setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
     so.setScript(scriptText.getText());
@@ -167,6 +173,14 @@ public class ScriptedObjectEditorWindow extends BFrame
     window.updateImage();
     setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
     dispose();
+
+    // Compare the snapshot to the current scene and inform the user if necessary.
+
+    if (! objectsBeforeRun.equals(window.getScene().getAllObjects()))
+    {
+      ((LayoutWindow)window).rebuildItemList();
+      new BStandardDialog("Warning", "This ScriptedObject edits the Scene.",  BStandardDialog.WARNING).showMessageDialog(null);
+    }
   }
 
   /** This is an inner class for editing the list of parameters on the object. */


### PR DESCRIPTION
Resolves #241.

It notifies the user when the information is most likely to be understood and otherwise (it is supposed to) just tolerate the case.

There are still  a lot of calls to `Scene.setTime()` in the code that don't check if the scene content changed or update the ItemList accordingly. Though, when those calls happen, the user should already be aware of what is happening.

EDIT: I did not translate the notifications either. If you think, this is approach is OK, I may check the rest of the code and translate if you feel it's worth it.

