### PR TITLE
Rendering primitives, Light ray fix

### DIFF
--- a/Renderers/src/artofillusion/raytracer/RTCube.java
+++ b/Renderers/src/artofillusion/raytracer/RTCube.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2004-2013 by Peter Eastman
+   Editions copyright (C) by Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -27,6 +28,8 @@ public class RTCube extends RTObject
   protected Mat4 toLocal, fromLocal;
 
   public static final double TOL = 1e-12;
+
+  private double cubeTol;
 
   public RTCube(Cube cube, Mat4 fromLocal, Mat4 toLocal, double param[])
   {
@@ -103,6 +106,8 @@ public class RTCube extends RTObject
     }
     bumpMapped = cube.getTexture().hasComponent(Texture.BUMP_COMPONENT);
     this.toLocal = toLocal;
+    cubeTol = (Math.max(Math.max(Math.abs(fromLocal.m14), (Math.abs(fromLocal.m24))),(Math.abs(fromLocal.m34))) + 
+               Math.max(Math.max(xsize, ysize), zsize))*TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -128,6 +133,7 @@ public class RTCube extends RTObject
   {
     Vec3 rorig = r.getOrigin(), rdir = r.getDirection();
     Vec3 origin, direction;
+
     if (transform)
     {
       origin = r.tempVec1;
@@ -167,7 +173,7 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < cubeTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     if (direction.y == 0.0)
@@ -193,7 +199,7 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < cubeTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     if (direction.z == 0.0)
@@ -219,12 +225,12 @@ public class RTCube extends RTObject
         if (t1 < maxt)
           maxt = t1;
       }
-      if (mint > maxt || maxt < TOL)
+      if (mint > maxt || maxt < cubeTol)
         return SurfaceIntersection.NO_INTERSECTION;
     }
     int numIntersections;
     Vec3 v1 = r.tempVec1, v2 = r.tempVec2, trueNorm = r.tempVec3;
-    if (mint < TOL)
+    if (mint < cubeTol)
     {
       v1.set(rorig.x+maxt*rdir.x, rorig.y+maxt*rdir.y, rorig.z+maxt*rdir.z);
       mint = maxt;

--- a/Renderers/src/artofillusion/raytracer/RTCylinder.java
+++ b/Renderers/src/artofillusion/raytracer/RTCylinder.java
@@ -45,53 +45,53 @@ public class RTCylinder extends RTObject
     cone = false;
     transform = true;
     if (vy.y == 1.0)
-      {
-        if (vx.x == 1.0 || vx.x == -1.0)
-          {
-            rx = size.x/2.0;
-            rz = size.z/2.0;
-            transform = false;
-          }
-        else if (vx.z == 1.0 || vx.z == -1.0)
-          {
-            rx = size.z/2.0;
-            rz = size.x/2.0;
-            transform = false;
-          }
-        if (transform == false && ratio == 0.0)
-          cone = true;
-      }
-    else if (vy.y == -1.0 && ratio != 0.0)
-      {
-        if (vx.x == 1.0 || vx.x == -1.0)
-          {
-            rx = size.x/2.0;
-            rz = size.z/2.0;
-            transform = false;
-          }
-        else if (vx.z == 1.0 || vx.z == -1.0)
-          {
-            rx = size.z/2.0;
-            rz = size.x/2.0;
-            transform = false;
-          }
-        if (transform == false)
-          {
-            rx *= ratio;
-            rz *= ratio;
-            ratio = 1.0/ratio;
-          }
-      }
-    height = size.y;
-    halfh = height/2.0;
-    if (transform)
+    {
+      if (vx.x == 1.0 || vx.x == -1.0)
       {
         rx = size.x/2.0;
         rz = size.z/2.0;
-        if (ratio == 0.0)
-          cone = true;
-        this.fromLocal = fromLocal;
+        transform = false;
       }
+      else if (vx.z == 1.0 || vx.z == -1.0)
+      {
+        rx = size.z/2.0;
+        rz = size.x/2.0;
+        transform = false;
+      }
+      if (transform == false && ratio == 0.0)
+        cone = true;
+    }
+    else if (vy.y == -1.0 && ratio != 0.0)
+    {
+      if (vx.x == 1.0 || vx.x == -1.0)
+      {
+        rx = size.x/2.0;
+        rz = size.z/2.0;
+        transform = false;
+      }
+      else if (vx.z == 1.0 || vx.z == -1.0)
+      {
+        rx = size.z/2.0;
+        rz = size.x/2.0;
+        transform = false;
+      }
+      if (transform == false)
+      {
+        rx *= ratio;
+        rz *= ratio;
+        ratio = 1.0/ratio;
+      }
+    }
+    height = size.y;
+    halfh = height/2.0;
+    if (transform)
+    {
+      rx = size.x/2.0;
+      rz = size.z/2.0;
+      if (ratio == 0.0)
+        cone = true;
+      this.fromLocal = fromLocal;
+    }
     cx = fromLocal.m14/fromLocal.m44;
     cy = fromLocal.m24/fromLocal.m44;
     cz = fromLocal.m34/fromLocal.m44;
@@ -134,76 +134,76 @@ public class RTCylinder extends RTObject
     int intersections, hit = -1;
 
     if (transform)
-      {
-        v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
-        toLocal.transformDirection(v1);
-        v1.y -= halfh;
-        dir.set(rdir);
-        toLocal.transformDirection(dir);
-      }
+    {
+      v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
+      toLocal.transformDirection(v1);
+      v1.y -= halfh;
+      dir.set(rdir);
+      toLocal.transformDirection(dir);
+    }
     else
-      {
-        v1.set(cx-orig.x, cy-orig.y-halfh, cz-orig.z);
-        if (uniform)
-          dir = rdir;
-        else
-          dir.set(rdir);
-      }
+    {
+      v1.set(cx-orig.x, cy-orig.y-halfh, cz-orig.z);
+      if (uniform)
+        dir = rdir;
+      else
+        dir.set(rdir);
+    }
     mint = Double.MAX_VALUE;
     if (dir.y != 0.0)
+    {
+      // See if the ray hits the top or bottom face of the cylinder.
+
+      temp1 = v1.y/dir.y;
+      if (temp1 > TOL)
       {
-        // See if the ray hits the top or bottom face of the cylinder.
-
-        temp1 = v1.y/dir.y;
-        if (temp1 > TOL)
-          {
-            a = temp1*dir.x - v1.x;
-            b = temp1*dir.z - v1.z;
-            if (a*a+sz*b*b < rx2)
-              {
-                hit = BOTTOM;
-                mint = temp1;
-              }
-          }
-        if (!cone)
-          {
-            temp1 = (v1.y+height)/dir.y;
-            if (temp1 > TOL)
-              {
-                a = temp1*dir.x - v1.x;
-                b = temp1*dir.z - v1.z;
-                if (a*a+sz*b*b < toprx2)
-                  {
-                    if (mint < Double.MAX_VALUE)
-                      {
-                        // The ray hit both the top and bottom faces, so we know it
-                        // didn't hit the sides.
-
-                        intersections = 2;
-                        if (temp1 < mint)
-                          {
-                            hit = TOP;
-                            dist1 = temp1;
-                            dist2 = mint;
-                          }
-                        else
-                          {
-                            dist1 = mint;
-                            dist2 = temp1;
-                          }
-                        v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
-                        v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
-                        return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
-                      }
-                    else
-                      {
-                        hit = TOP;
-                        mint = temp1;
-                      }
-                  }
-              }
-          }
+        a = temp1*dir.x - v1.x;
+        b = temp1*dir.z - v1.z;
+        if (a*a+sz*b*b < rx2)
+        {
+          hit = BOTTOM;
+          mint = temp1;
+        }
       }
+      if (!cone)
+      {
+        temp1 = (v1.y+height)/dir.y;
+        if (temp1 > TOL)
+        {
+          a = temp1*dir.x - v1.x;
+          b = temp1*dir.z - v1.z;
+          if (a*a+sz*b*b < toprx2)
+          {
+            if (mint < Double.MAX_VALUE)
+            {
+              // The ray hit both the top and bottom faces, so we know it
+              // didn't hit the sides.
+
+              intersections = 2;
+              if (temp1 < mint)
+              {
+                hit = TOP;
+                dist1 = temp1;
+                dist2 = mint;
+              }
+              else
+              {
+                dist1 = mint;
+                dist2 = temp1;
+              }
+              v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
+              v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
+              return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
+            }
+            else
+            {
+              hit = TOP;
+              mint = temp1;
+            }
+          }
+        }
+      }
+    }
 
     // Now see if it hits the sides of the cylinder.
 
@@ -228,54 +228,54 @@ public class RTCylinder extends RTObject
     dist1 = Double.MAX_VALUE;
     dist2 = mint;
     if (c > TOL)  // Ray origin is outside cylinder.
+    {
+      if (b > 0.0)  // Ray points toward cylinder.
       {
-        if (b > 0.0)  // Ray points toward cylinder.
-          {
-            a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
-            e = b*b - a*c;
-            if (e >= 0.0)
-              {
-                temp1 = Math.sqrt(e);
-                dist1 = (b - temp1)/a;
-                if (dist2 == Double.MAX_VALUE)
-                  dist2 = (b + temp1)/a;
-              }
-          }
+        a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
+        e = b*b - a*c;
+        if (e >= 0.0)
+        {
+          temp1 = Math.sqrt(e);
+          dist1 = (b - temp1)/a;
+          if (dist2 == Double.MAX_VALUE)
+            dist2 = (b + temp1)/a;
+        }
       }
+    }
     else if (c < -TOL)  // Ray origin is inside cylinder.
+    {
+      a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
+      e = b*b - a*c;
+      if (e >= 0.0)
+        dist1 = (b + Math.sqrt(e))/a;
+    }
+    else  // Ray origin is on the surface of the cylinder.
+    {
+      if (b > 0.0)  // Ray points into cylinder.
       {
         a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
         e = b*b - a*c;
         if (e >= 0.0)
           dist1 = (b + Math.sqrt(e))/a;
       }
-    else  // Ray origin is on the surface of the cylinder.
-      {
-        if (b > 0.0)  // Ray points into cylinder.
-          {
-            a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
-            e = b*b - a*c;
-            if (e >= 0.0)
-              dist1 = (b + Math.sqrt(e))/a;
-          }
-      }
+    }
     if (dist1 < mint)
+    {
+      a = dist1*dir.y-v1.y;
+      if (a > 0.0 && a < height)
       {
-        a = dist1*dir.y-v1.y;
-        if (a > 0.0 && a < height)
-          {
-            hit = SIDE;
-            mint = dist1;
-          }
+        hit = SIDE;
+        mint = dist1;
       }
+    }
     if (mint == Double.MAX_VALUE)
       return SurfaceIntersection.NO_INTERSECTION;
     if (dist2 < mint)
-      {
-        temp1 = dist2;
-        dist2 = mint;
-        mint = temp1;
-      }
+    {
+      temp1 = dist2;
+      dist2 = mint;
+      mint = temp1;
+    }
     dist1 = mint;
     v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
     if (hit == SIDE)
@@ -283,10 +283,10 @@ public class RTCylinder extends RTObject
     if (dist2 == Double.MAX_VALUE)
       intersections = 1;
     else
-      {
-        intersections = 2;
-        v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
-      }
+    {
+      intersections = 2;
+      v2.set(orig.x+dist2*rdir.x, orig.y+dist2*rdir.y, orig.z+dist2*rdir.z);
+    }
     return new CylinderIntersection(this, intersections, hit, v1, v2, dist1, dist2);
   }
 
@@ -320,10 +320,10 @@ public class RTCylinder extends RTObject
     if (transform)
       return (new BoundingBox(-rx, rx, -halfh, halfh, -rz, rz)).transformAndOutset(fromLocal);
     else if (toprx2 > rx2)
-      {
-        double xrad = Math.sqrt(toprx2), zrad = Math.sqrt(rz2*toprx2/rx2);
-        return new BoundingBox(cx-xrad, cx+xrad, cy-halfh, cy+halfh, cz-zrad, cz+zrad);
-      }
+    {
+      double xrad = Math.sqrt(toprx2), zrad = Math.sqrt(rz2*toprx2/rx2);
+      return new BoundingBox(cx-xrad, cx+xrad, cy-halfh, cy+halfh, cz-zrad, cz+zrad);
+    }
     else
       return new BoundingBox(cx-rx, cx+rx, cy-halfh, cy+halfh, cz-rz, cz+rz);
   }
@@ -337,24 +337,24 @@ public class RTCylinder extends RTObject
 
     BoundingBox bb = node.getBounds();
     if (transform)
-      {
-        bb = bb.transformAndOutset(toLocal);
-        if (bb.miny > halfh || bb.maxy < -halfh)
-          return false;
-        x = 0.0;
-        z = 0.0;
-        if (bb.minx > 0.0)
-          x = bb.minx;
-        else if (bb.maxx < 0.0)
-          x = bb.maxx;
-        if (bb.minz > 0.0)
-          z = bb.minz;
-        else if (bb.maxz < 0.0)
-          z = bb.maxz;
-        if (x*x + sz*z*z > rx2)
-          return false;
-        return true;
-      }
+    {
+      bb = bb.transformAndOutset(toLocal);
+      if (bb.miny > halfh || bb.maxy < -halfh)
+        return false;
+      x = 0.0;
+      z = 0.0;
+      if (bb.minx > 0.0)
+        x = bb.minx;
+      else if (bb.maxx < 0.0)
+        x = bb.maxx;
+      if (bb.minz > 0.0)
+        z = bb.minz;
+      else if (bb.maxz < 0.0)
+        z = bb.maxz;
+      if (x*x + sz*z*z > rx2)
+        return false;
+      return true;
+    }
     if (bb.miny > cy+halfh || bb.maxy < cy-halfh)
       return false;
     x = cx;
@@ -475,10 +475,10 @@ public class RTCylinder extends RTObject
       if (cylinder.uniform)
         map.getTransparency(pos, trans, angle, size, time, cylinder.param);
       else
-        {
-          cylinder.toLocal.transform(pos);
-          map.getTransparency(pos, trans, angle, size, time, cylinder.param);
-        }
+      {
+        cylinder.toLocal.transform(pos);
+        map.getTransparency(pos, trans, angle, size, time, cylinder.param);
+      }
     }
 
     @Override

--- a/Renderers/src/artofillusion/raytracer/RTCylinder.java
+++ b/Renderers/src/artofillusion/raytracer/RTCylinder.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Editions copyright (C) by Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -31,6 +32,8 @@ public class RTCylinder extends RTObject
   public static final int TOP = 0;
   public static final int BOTTOM = 1;
   public static final int SIDE = 2;
+
+  private double linearTol, radialTol;
 
   public RTCylinder(Cylinder cylinder, Mat4 fromLocal, Mat4 toLocal, double param[])
   {
@@ -105,6 +108,11 @@ public class RTCylinder extends RTObject
       topNormal = bottomNormal.times(-1.0);
     bumpMapped = cylinder.getTexture().hasComponent(Texture.BUMP_COMPONENT);
     this.toLocal = toLocal;
+
+    linearTol = (Math.max(Math.max(Math.abs(fromLocal.m14), (Math.abs(fromLocal.m24))),(Math.abs(fromLocal.m34))) +
+                 Math.max(Math.max(rx, rz), height));
+    radialTol = Math.max(Math.max(rx2, rz2), linearTol)*TOL;
+    linearTol *= TOL;
   }
 
   /** Get the MaterialMapping for this object. */
@@ -155,7 +163,7 @@ public class RTCylinder extends RTObject
       // See if the ray hits the top or bottom face of the cylinder.
 
       temp1 = v1.y/dir.y;
-      if (temp1 > TOL)
+      if (temp1 > linearTol)
       {
         a = temp1*dir.x - v1.x;
         b = temp1*dir.z - v1.z;
@@ -168,7 +176,7 @@ public class RTCylinder extends RTObject
       if (!cone)
       {
         temp1 = (v1.y+height)/dir.y;
-        if (temp1 > TOL)
+        if (temp1 > linearTol)
         {
           a = temp1*dir.x - v1.x;
           b = temp1*dir.z - v1.z;
@@ -227,7 +235,7 @@ public class RTCylinder extends RTObject
     }
     dist1 = Double.MAX_VALUE;
     dist2 = mint;
-    if (c > TOL)  // Ray origin is outside cylinder.
+    if (c > radialTol)  // Ray origin is outside cylinder.
     {
       if (b > 0.0)  // Ray points toward cylinder.
       {
@@ -242,7 +250,7 @@ public class RTCylinder extends RTObject
         }
       }
     }
-    else if (c < -TOL)  // Ray origin is inside cylinder.
+    else if (c < -radialTol)  // Ray origin is inside cylinder.
     {
       a = dir.x*dir.x + temp1*dir.z - temp2*temp2;
       e = b*b - a*c;

--- a/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
+++ b/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
@@ -36,63 +36,63 @@ public class RTEllipsoid extends RTObject
     uniform = sphere.getTextureMapping() instanceof UniformMapping;
     transform = true;
     if (vx.x == 1.0 || vx.x == -1.0)
-      {
-        if (vy.y == 1.0 || vy.y == -1.0)
-          {
-            rx = radii.x;
-            ry = radii.y;
-            rz = radii.z;
-            transform = false;
-          }
-        else if (vy.z == 1.0 || vy.z == -1.0)
-          {
-            rx = radii.x;
-            ry = radii.z;
-            rz = radii.y;
-            transform = false;
-          }
-      }
-    else if (vx.y == 1.0 || vx.y == -1.0)
-      {
-        if (vy.x == 1.0 || vy.x == -1.0)
-          {
-            rx = radii.y;
-            ry = radii.x;
-            rz = radii.z;
-            transform = false;
-          }
-        else if (vy.z == 1.0 || vy.z == -1.0)
-          {
-            rx = radii.y;
-            ry = radii.z;
-            rz = radii.x;
-            transform = false;
-          }
-      }
-    else if (vx.z == 1.0 || vx.z == -1.0)
-      {
-        if (vy.x == 1.0 || vy.x == -1.0)
-          {
-            rx = radii.z;
-            ry = radii.x;
-            rz = radii.y;
-            transform = false;
-          }
-        else if (vy.y == 1.0 || vy.y == -1.0)
-          {
-            rx = radii.z;
-            ry = radii.y;
-            rz = radii.x;
-            transform = false;
-          }
-      }
-    if (transform)
+    {
+      if (vy.y == 1.0 || vy.y == -1.0)
       {
         rx = radii.x;
         ry = radii.y;
         rz = radii.z;
-        this.fromLocal = fromLocal;
+        transform = false;
       }
+      else if (vy.z == 1.0 || vy.z == -1.0)
+      {
+        rx = radii.x;
+        ry = radii.z;
+        rz = radii.y;
+        transform = false;
+      }
+    }
+    else if (vx.y == 1.0 || vx.y == -1.0)
+    {
+      if (vy.x == 1.0 || vy.x == -1.0)
+      {
+        rx = radii.y;
+        ry = radii.x;
+        rz = radii.z;
+        transform = false;
+      }
+      else if (vy.z == 1.0 || vy.z == -1.0)
+      {
+        rx = radii.y;
+        ry = radii.z;
+        rz = radii.x;
+        transform = false;
+      }
+    }
+    else if (vx.z == 1.0 || vx.z == -1.0)
+    {
+      if (vy.x == 1.0 || vy.x == -1.0)
+      {
+        rx = radii.z;
+        ry = radii.x;
+        rz = radii.y;
+        transform = false;
+      }
+      else if (vy.y == 1.0 || vy.y == -1.0)
+      {
+        rx = radii.z;
+        ry = radii.y;
+        rz = radii.x;
+        transform = false;
+      }
+    }
+    if (transform)
+    {
+      rx = radii.x;
+      ry = radii.y;
+      rz = radii.z;
+      this.fromLocal = fromLocal;
+    }
     cx = fromLocal.m14/fromLocal.m44;
     cy = fromLocal.m24/fromLocal.m44;
     cz = fromLocal.m34/fromLocal.m44;
@@ -133,11 +133,11 @@ public class RTEllipsoid extends RTObject
 
     v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
     if (transform)
-      {
-        toLocal.transformDirection(v1);
-        dir.set(rdir);
-        toLocal.transformDirection(dir);
-      }
+    {
+      toLocal.transformDirection(v1);
+      dir.set(rdir);
+      toLocal.transformDirection(dir);
+    }
     else if (uniform)
       dir = rdir;
     else
@@ -148,46 +148,46 @@ public class RTEllipsoid extends RTObject
     c = v1.x*v1.x + sy*v1.y*v1.y + sz*v1.z*v1.z - rx2;
     int numIntersections;
     if (c > TOL*b)
-      {
-        // Ray origin is outside ellipsoid.
+    {
+      // Ray origin is outside ellipsoid.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 2;
-        temp1 = Math.sqrt(d);
-        dist1 = (b - temp1)/a;
-        dist2 = (b + temp1)/a;
-        v2.set(orig.x+dist2*dir.x, orig.y+dist2*dir.y, orig.z+dist2*dir.z);
-        projectPoint(v2);
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 2;
+      temp1 = Math.sqrt(d);
+      dist1 = (b - temp1)/a;
+      dist2 = (b + temp1)/a;
+      v2.set(orig.x+dist2*dir.x, orig.y+dist2*dir.y, orig.z+dist2*dir.z);
+      projectPoint(v2);
+    }
     else if (c < -TOL*b)
-      {
-        // Ray origin is inside ellipsoid.
+    {
+      // Ray origin is inside ellipsoid.
 
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        dist1 = (b + Math.sqrt(d))/a;
-      }
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      dist1 = (b + Math.sqrt(d))/a;
+    }
     else
-      {
-        // Ray origin is on the surface of the ellipsoid.
+    {
+      // Ray origin is on the surface of the ellipsoid.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
-        a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
-        d = b*b - a*c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        dist1 = (b + Math.sqrt(d))/a;
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from the ellipsoid.
+      a = dir.x*dir.x + temp1*dir.y + temp2*dir.z;
+      d = b*b - a*c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      dist1 = (b + Math.sqrt(d))/a;
+    }
     v1.set(orig.x+dist1*rdir.x, orig.y+dist1*rdir.y, orig.z+dist1*rdir.z);
     projectPoint(v1);
     return new EllipsoidIntersection(this, numIntersections, v1, v2, dist1, dist2);
@@ -233,16 +233,16 @@ public class RTEllipsoid extends RTObject
 
     BoundingBox bb = node.getBounds();
     if (transform)
-      {
-        bb = bb.transformAndOutset(toLocal);
-        centerx = centery = centerz = 0.0;
-      }
+    {
+      bb = bb.transformAndOutset(toLocal);
+      centerx = centery = centerz = 0.0;
+    }
     else
-      {
-        centerx = cx;
-        centery = cy;
-        centerz = cz;
-      }
+    {
+      centerx = cx;
+      centery = cy;
+      centerz = cz;
+    }
     Vec3 c = new Vec3(centerx, centery, centerz);
 
     // Find the nearest point of the box to the ellipsoid.

--- a/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
+++ b/Renderers/src/artofillusion/raytracer/RTEllipsoid.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Editions copyright (C) by Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -26,6 +27,8 @@ public class RTEllipsoid extends RTObject
   Mat4 toLocal, fromLocal;
 
   public static final double TOL = 1e-12;
+
+  double ellipsoidTol;
 
   public RTEllipsoid(Sphere sphere, Mat4 fromLocal, Mat4 toLocal, double param[])
   {
@@ -103,6 +106,8 @@ public class RTEllipsoid extends RTObject
     sz = rx2/rz2;
     bumpMapped = sphere.getTexture().hasComponent(Texture.BUMP_COMPONENT);
     this.toLocal = toLocal;
+    ellipsoidTol = (Math.max(Math.max(Math.abs(fromLocal.m14), (Math.abs(fromLocal.m24))),(Math.abs(fromLocal.m34))) +
+                    Math.max(Math.max(rx, ry), rz))*TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -147,7 +152,8 @@ public class RTEllipsoid extends RTObject
     b = dir.x*v1.x + temp1*v1.y + temp2*v1.z;
     c = v1.x*v1.x + sy*v1.y*v1.y + sz*v1.z*v1.z - rx2;
     int numIntersections;
-    if (c > TOL*b)
+
+    if (c > ellipsoidTol*b)
     {
       // Ray origin is outside ellipsoid.
 
@@ -164,7 +170,7 @@ public class RTEllipsoid extends RTObject
       v2.set(orig.x+dist2*dir.x, orig.y+dist2*dir.y, orig.z+dist2*dir.z);
       projectPoint(v2);
     }
-    else if (c < -TOL*b)
+    else if (c < -ellipsoidTol*b)
     {
       // Ray origin is inside ellipsoid.
 

--- a/Renderers/src/artofillusion/raytracer/RTSphere.java
+++ b/Renderers/src/artofillusion/raytracer/RTSphere.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Editions copyright (C) by Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -28,6 +29,8 @@ public class RTSphere extends RTObject
 
   public static final double TOL = 1e-12;
 
+  private double sphereTol;
+
   public RTSphere(Sphere sphere, Mat4 fromLocal, Mat4 toLocal, double param[])
   {
     theSphere = sphere;
@@ -41,6 +44,8 @@ public class RTSphere extends RTObject
     if (bumpMapped)
       this.fromLocal = fromLocal;
     this.toLocal = toLocal;
+    sphereTol = Math.max(Math.max(Math.abs(fromLocal.m14), Math.abs(fromLocal.m24)), Math.abs(fromLocal.m34))+r;
+    sphereTol = Math.max(sphereTol, r2)*TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -72,7 +77,7 @@ public class RTSphere extends RTObject
     v1.set(cx-orig.x, cy-orig.y, cz-orig.z);
     b = dir.x*v1.x + dir.y*v1.y + dir.z*v1.z;
     c = v1.x*v1.x + v1.y*v1.y + v1.z*v1.z - r2;
-    if (c > TOL)
+    if (c > sphereTol)
     {
       // Ray origin is outside sphere.
 
@@ -88,7 +93,7 @@ public class RTSphere extends RTObject
       v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
       projectPoint(v2);
     }
-    else if (c < -TOL)
+    else if (c < -sphereTol)
     {
       // Ray origin is inside sphere.
 

--- a/Renderers/src/artofillusion/raytracer/RTSphere.java
+++ b/Renderers/src/artofillusion/raytracer/RTSphere.java
@@ -73,43 +73,43 @@ public class RTSphere extends RTObject
     b = dir.x*v1.x + dir.y*v1.y + dir.z*v1.z;
     c = v1.x*v1.x + v1.y*v1.y + v1.z*v1.z - r2;
     if (c > TOL)
-      {
-        // Ray origin is outside sphere.
+    {
+      // Ray origin is outside sphere.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 2;
-        root = Math.sqrt(d);
-        t = b - root;
-        t2 = b + root;
-        v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
-        projectPoint(v2);
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 2;
+      root = Math.sqrt(d);
+      t = b - root;
+      t2 = b + root;
+      v2.set(orig.x+t2*dir.x, orig.y+t2*dir.y, orig.z+t2*dir.z);
+      projectPoint(v2);
+    }
     else if (c < -TOL)
-      {
-        // Ray origin is inside sphere.
+    {
+      // Ray origin is inside sphere.
 
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        t = b + Math.sqrt(d);
-      }
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      t = b + Math.sqrt(d);
+    }
     else
-      {
-        // Ray origin is on the surface of the sphere.
+    {
+      // Ray origin is on the surface of the sphere.
 
-        if (b <= 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
-        d = b*b - c;
-        if (d < 0.0)
-          return SurfaceIntersection.NO_INTERSECTION;
-        numIntersections = 1;
-        t = b + Math.sqrt(d);
-      }
+      if (b <= 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from center of sphere.
+      d = b*b - c;
+      if (d < 0.0)
+        return SurfaceIntersection.NO_INTERSECTION;
+      numIntersections = 1;
+      t = b + Math.sqrt(d);
+    }
     v1.set(orig.x+t*dir.x, orig.y+t*dir.y, orig.z+t*dir.z);
     projectPoint(v1);
     return new SphereIntersection(this, numIntersections, v1, v2, t, t2);

--- a/Renderers/src/artofillusion/raytracer/RTTriangle.java
+++ b/Renderers/src/artofillusion/raytracer/RTTriangle.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1999-2013 by Peter Eastman
+   Editions copyright (C) by Petri Ihalainen 2020
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -30,9 +31,10 @@ public class RTTriangle extends RTObject
   double d, edge2d1x, edge2d1y, edge2d2x, edge2d2y;
 
   public static final double TOL = 1e-12;
-
   private static final short BUMP_MAPPED = 1;
   private static final short INTERP_NORMALS = 2;
+
+  private double triangleTol;
 
   public RTTriangle(RenderingMesh mesh, int which, Mat4 fromLocal, Mat4 toLocal)
   {
@@ -101,6 +103,12 @@ public class RTTriangle extends RTObject
     edge2d2y *= denom;
     if (tri.theMesh.mapping.getTexture().hasComponent(Texture.BUMP_COMPONENT))
       flags |= BUMP_MAPPED;
+
+    triangleTol = (Math.max(Math.max(Math.abs(fromLocal.m14), Math.abs(fromLocal.m24)), Math.abs(fromLocal.m34)) +
+                   Math.max(Math.max(Math.max(Math.max(vert1.x, vert2.x), vert3.x) - Math.min(Math.min(vert1.x, vert2.x), vert3.x),
+                                     Math.max(Math.max(vert1.y, vert2.y), vert3.y) - Math.min(Math.min(vert1.y, vert2.y), vert3.y)),
+                                     Math.max(Math.max(vert1.z, vert2.z), vert3.z) - Math.min(Math.min(vert1.z, vert2.z), vert3.z))
+                  )*TOL;
   }
 
   /** Get the TextureMapping for this object. */
@@ -132,7 +140,7 @@ public class RTTriangle extends RTObject
       return SurfaceIntersection.NO_INTERSECTION;  // The ray is parallel to the plane.
     v0 = -(trueNorm.dot(orig)+d);
     double t = v0/vd;
-    if (t < TOL)
+    if (t < triangleTol)
       return SurfaceIntersection.NO_INTERSECTION;  // Ray points away from plane of triangle.
 
     // Determine whether the intersection point is inside the triangle.

--- a/Renderers/src/artofillusion/raytracer/RTTriangle.java
+++ b/Renderers/src/artofillusion/raytracer/RTTriangle.java
@@ -272,83 +272,83 @@ public class RTTriangle extends RTObject
     double dirx = p2.x-p1.x, diry = p2.y-p1.y, dirz = p2.z-p1.z;
     double len = Math.sqrt(dirx*dirx + diry*diry + dirz*dirz);
     if (dirx == 0.0)
-      {
-        if (p1.x < node.minx || p1.x > node.maxx)
-          return false;
-      }
+    {
+      if (p1.x < node.minx || p1.x > node.maxx)
+        return false;
+    }
     else
+    {
+      t1 = (node.minx-p1.x)*len/dirx;
+      t2 = (node.maxx-p1.x)*len/dirx;
+      if (t1 < t2)
       {
-        t1 = (node.minx-p1.x)*len/dirx;
-        t2 = (node.maxx-p1.x)*len/dirx;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (diry == 0.0)
-      {
-        if (p1.y < node.miny || p1.y > node.maxy)
-          return false;
-      }
+    {
+      if (p1.y < node.miny || p1.y > node.maxy)
+        return false;
+    }
     else
+    {
+      t1 = (node.miny-p1.y)*len/diry;
+      t2 = (node.maxy-p1.y)*len/diry;
+      if (t1 < t2)
       {
-        t1 = (node.miny-p1.y)*len/diry;
-        t2 = (node.maxy-p1.y)*len/diry;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (dirz == 0.0)
-      {
-        if (p1.z < node.minz || p1.z > node.maxz)
-          return false;
-      }
+    {
+      if (p1.z < node.minz || p1.z > node.maxz)
+        return false;
+    }
     else
+    {
+      t1 = (node.minz-p1.z)*len/dirz;
+      t2 = (node.maxz-p1.z)*len/dirz;
+      if (t1 < t2)
       {
-        t1 = (node.minz-p1.z)*len/dirz;
-        t2 = (node.maxz-p1.z)*len/dirz;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     return true;
   }
 
@@ -423,24 +423,24 @@ public class RTTriangle extends RTObject
       if ((rtTri.flags&INTERP_NORMALS) == 0)
         n.set(rtTri.trueNorm);
       else
-        {
-          Vec3 normals[] = rtTri.tri.theMesh.norm;
-          Vec3 norm1 = normals[rtTri.tri.n1];
-          Vec3 norm2 = normals[rtTri.tri.n2];
-          Vec3 norm3 = normals[rtTri.tri.n3];
-          n.x = u*norm1.x + v*norm2.x + w*norm3.x;
-          n.y = u*norm1.y + v*norm2.y + w*norm3.y;
-          n.z = u*norm1.z + v*norm2.z + w*norm3.z;
-          n.normalize();
-        }
+      {
+        Vec3 normals[] = rtTri.tri.theMesh.norm;
+        Vec3 norm1 = normals[rtTri.tri.n1];
+        Vec3 norm2 = normals[rtTri.tri.n2];
+        Vec3 norm3 = normals[rtTri.tri.n3];
+        n.x = u*norm1.x + v*norm2.x + w*norm3.x;
+        n.y = u*norm1.y + v*norm2.y + w*norm3.y;
+        n.z = u*norm1.z + v*norm2.z + w*norm3.z;
+        n.normalize();
+      }
       rtTri.tri.getTextureSpec(spec, -n.dot(viewDir), u, v, w, size, time);
       if ((rtTri.flags&BUMP_MAPPED) != 0)
-        {
-          rtTri.fromLocal.transformDirection(spec.bumpGrad);
-          n.scale(spec.bumpGrad.dot(n)+1.0);
-          n.subtract(spec.bumpGrad);
-          n.normalize();
-        }
+      {
+        rtTri.fromLocal.transformDirection(spec.bumpGrad);
+        n.scale(spec.bumpGrad.dot(n)+1.0);
+        n.subtract(spec.bumpGrad);
+        n.normalize();
+      }
     }
 
     @Override

--- a/Renderers/src/artofillusion/raytracer/RTTriangleLowMemory.java
+++ b/Renderers/src/artofillusion/raytracer/RTTriangleLowMemory.java
@@ -264,83 +264,83 @@ public class RTTriangleLowMemory extends RTObject
     double dirx = p2.x-p1.x, diry = p2.y-p1.y, dirz = p2.z-p1.z;
     double len = Math.sqrt(dirx*dirx + diry*diry + dirz*dirz);
     if (dirx == 0.0)
-      {
-        if (p1.x < node.minx || p1.x > node.maxx)
-          return false;
-      }
+    {
+      if (p1.x < node.minx || p1.x > node.maxx)
+        return false;
+    }
     else
+    {
+      t1 = (node.minx-p1.x)*len/dirx;
+      t2 = (node.maxx-p1.x)*len/dirx;
+      if (t1 < t2)
       {
-        t1 = (node.minx-p1.x)*len/dirx;
-        t2 = (node.maxx-p1.x)*len/dirx;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (diry == 0.0)
-      {
-        if (p1.y < node.miny || p1.y > node.maxy)
-          return false;
-      }
+    {
+      if (p1.y < node.miny || p1.y > node.maxy)
+        return false;
+    }
     else
+    {
+      t1 = (node.miny-p1.y)*len/diry;
+      t2 = (node.maxy-p1.y)*len/diry;
+      if (t1 < t2)
       {
-        t1 = (node.miny-p1.y)*len/diry;
-        t2 = (node.maxy-p1.y)*len/diry;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     if (dirz == 0.0)
-      {
-        if (p1.z < node.minz || p1.z > node.maxz)
-          return false;
-      }
+    {
+      if (p1.z < node.minz || p1.z > node.maxz)
+        return false;
+    }
     else
+    {
+      t1 = (node.minz-p1.z)*len/dirz;
+      t2 = (node.maxz-p1.z)*len/dirz;
+      if (t1 < t2)
       {
-        t1 = (node.minz-p1.z)*len/dirz;
-        t2 = (node.maxz-p1.z)*len/dirz;
-        if (t1 < t2)
-          {
-            if (t1 > mint)
-              mint = t1;
-            if (t2 < maxt)
-              maxt = t2;
-          }
-        else
-          {
-            if (t2 > mint)
-              mint = t2;
-            if (t1 < maxt)
-              maxt = t1;
-          }
-        if (mint > maxt || mint > len || maxt < 0.0)
-          return false;
+        if (t1 > mint)
+          mint = t1;
+        if (t2 < maxt)
+          maxt = t2;
       }
+      else
+      {
+        if (t2 > mint)
+          mint = t2;
+        if (t1 < maxt)
+          maxt = t1;
+      }
+      if (mint > maxt || mint > len || maxt < 0.0)
+        return false;
+    }
     return true;
   }
 
@@ -415,24 +415,24 @@ public class RTTriangleLowMemory extends RTObject
       if ((rtTri.flags&INTERP_NORMALS) == 0)
         n.set(rtTri.tri.theMesh.faceNorm[rtTri.tri.index]);
       else
-        {
-          Vec3 normals[] = rtTri.tri.theMesh.norm;
-          Vec3 norm1 = normals[rtTri.tri.n1];
-          Vec3 norm2 = normals[rtTri.tri.n2];
-          Vec3 norm3 = normals[rtTri.tri.n3];
-          n.x = u*norm1.x + v*norm2.x + w*norm3.x;
-          n.y = u*norm1.y + v*norm2.y + w*norm3.y;
-          n.z = u*norm1.z + v*norm2.z + w*norm3.z;
-          n.normalize();
-        }
+      {
+        Vec3 normals[] = rtTri.tri.theMesh.norm;
+        Vec3 norm1 = normals[rtTri.tri.n1];
+        Vec3 norm2 = normals[rtTri.tri.n2];
+        Vec3 norm3 = normals[rtTri.tri.n3];
+        n.x = u*norm1.x + v*norm2.x + w*norm3.x;
+        n.y = u*norm1.y + v*norm2.y + w*norm3.y;
+        n.z = u*norm1.z + v*norm2.z + w*norm3.z;
+        n.normalize();
+      }
       rtTri.tri.getTextureSpec(spec, -n.dot(viewDir), u, v, w, size, time);
       if ((rtTri.flags&BUMP_MAPPED) != 0)
-        {
-          rtTri.fromLocal.transformDirection(spec.bumpGrad);
-          n.scale(spec.bumpGrad.dot(n)+1.0);
-          n.subtract(spec.bumpGrad);
-          n.normalize();
-        }
+      {
+        rtTri.fromLocal.transformDirection(spec.bumpGrad);
+        n.scale(spec.bumpGrad.dot(n)+1.0);
+        n.subtract(spec.bumpGrad);
+        n.normalize();
+      }
     }
 
     @Override


### PR DESCRIPTION
The light ray issue fix for actual primitives, `Sphere`, `Ellipsoid`, `Cube` and `Cylinder`.

I think the solution is now simpler than before. No fields needes to be and only one variable in one method.

I tested `Math.max/min` vs. `if( < > )` with a plugin. It turned out that the `max` and `min` functions in real Java (as in comparison to Groovy) are faster than `if`. It is hard to say exactly how much faster as results in Windows vary quite a bit, but significantly. For comparison I added a set of multiplying and dividing to the test set. The `max` and `min` seem to be speed wise just as good a those. 

I may have a look at `RTTriangle` too and add it to this if I can get the implementation simplified and also see what, if anything, to do with `RTImplicitObject`.
