### PR TITLE
Horizontal wheel scroll

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
+++ b/ArtOfIllusion/src/artofillusion/ScrollViewTool.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 by Petri Ihalainen
+/* Copyright (C) 2017-2022 by Petri Ihalainen
    Changes copyright (C) 2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -31,7 +31,7 @@ public class ScrollViewTool
   private Camera camera;
   private double distToPlane, scale;
   private double scrollRadius, scrollBlend, scrollBlendX, scrollBlendY;
-  private int navigationMode, scrollSteps, startOrientation;
+  private int navigationMode, startOrientation;
   private Vec3 startZ, startUp;
   private Rectangle bounds;
   private Point mousePoint;
@@ -46,10 +46,19 @@ public class ScrollViewTool
 
   protected void mouseScrolled(MouseScrolledEvent e, ViewerCanvas v)
   {
-    scrollSteps = v.scrollBuffer;
-    v.scrollBuffer = 0;
-    v.mouseMoving = false;
+    // Igore wheel while processing other mouse events
+
+    if (v.mouseDown || v.rotating || v.moving || v.tilting)
+      return;
+
+    // If the wheel event is a horizontal click, ignore it
+    // The mask, 64 was not mentioned in Java documentation.
+
+    if ((e.getModifiersEx() & 64) > 0)
+      return;
+
     view = v;
+    view.mouseMoving = false;
     view.scrolling = true;
     scale = view.getScale();
     distToPlane = view.getDistToPlane();
@@ -69,7 +78,7 @@ public class ScrollViewTool
     startUp = new Vec3(coords.getUpDirection());
     view.setRotationCenter(coords.getOrigin().plus(startZ.times(distToPlane)));
     mousePoint = view.mousePoint = e.getPoint();
-    scrollTimer.restart(); // The timer takes case of the graphics and updating the children of a camera object
+    scrollTimer.restart(); // The timer takes care of the graphics and updating the children of a camera object
 
     // This could be cleaser if the scrollMoveModel and scrollMoveTravel weres 
     // divided to methods, dedicated to one action only

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
-   Changes Copyrignt (C) 2016-2020 Petri Ihalainen
+   Changes Copyrignt (C) 2016-2022 Petri Ihalainen
    Changes copyright (C) 2016-2022 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -39,8 +39,8 @@ public abstract class ViewerCanvas extends CustomWidget
   protected EditingTool currentTool, activeTool, metaTool, altTool;
   protected ScrollViewTool scrollTool;
   protected PopupMenuManager popupManager;
-  protected int renderMode, gridSubdivisions, orientation, navigation, scrollBuffer;
-  protected double gridSpacing, scale, distToPlane, scrollRadius, scrollX, scrollY, scrollBlend, scrollBlendX, scrollBlendY;
+  protected int renderMode, gridSubdivisions, orientation, navigation;
+  protected double gridSpacing, scale, distToPlane;
   protected boolean perspective, perspectiveSwitch, hideBackfaces, showGrid, snapToGrid, drawFocus, showTemplate, showAxes;
   protected boolean lastModelPerspective;
   protected ActionProcessor mouseProcessor;
@@ -266,12 +266,8 @@ public abstract class ViewerCanvas extends CustomWidget
 
     if (mouseProcessor != null)
       mouseProcessor.stopProcessing();
-
     mouseProcessor = new ActionProcessor();
-    if (e.isAltDown())
-        scrollBuffer += e.getWheelRotation();
-    else
-        scrollBuffer += e.getWheelRotation()*10;
+
     final ViewerCanvas viewToProcess = this;
     final MouseScrolledEvent scrollEvent = e;
     mouseProcessor.addEvent(new Runnable() {


### PR DESCRIPTION
Java 11 adaptation to handle horizontal scroll and prevent unwanted zooming while rotating the view.

So far tested with a Gigabyte mouse, that had "oversensitive" left/right clicks in the scroll wheel. This does not entirely tame down the unwanted twitches, but seems reasonably good. I tested one "smarter" approach to detect accidental multiple inputs but that one was not working as well as I had hoped.

Edit: Tested with MX Master 2S, with a thumb wheel for horzontal scroll. Works quite nicely. :)

The view frustum drawing seems to have a minor bug. The bug clears itself in use and does not appear again but I'll have a look if I can figure it out. Looks like a  parameter missing a value in the beginning.

Also by a bit of stress testing (pressing multiple mouse buttons in random sequences) it may be possible to drive the parameters to a state where the wheel appears partly or fully disabled. However I could not systematically repeat that.

The logic with the directions is that by default all wheel actions move you in the model space. The horizontal move can be reversed separate of zoom or it can be disabled entirely.
