### PR TITLE
Dispose of unmodified windows after delay courtesy of Runic

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
+++ b/ArtOfIllusion/src/artofillusion/ArtOfIllusion.java
@@ -307,15 +307,13 @@ public class ArtOfIllusion
               System.out.println(ex);
             }
 
-            if (windows.size() > 1)
+            for (EditingWindow window : windows)
             {
-              for (EditingWindow window : windows)
-              {
-                if (window instanceof LayoutWindow 
+              if (window instanceof LayoutWindow
+                  && window != fr  
                   && ((LayoutWindow)window).getScene().getName() == null
                   && ((LayoutWindow)window).isModified() == false
                   ) closeWindow(window);
-              }
             }
             return true;
           }


### PR DESCRIPTION
Workaround for a (weird) timing issue when disposing of GLJPanels on (some) macs. This should hold until the underlying issue is fixed in the JOGL libraries.

Needs testing on windows.