### PR TITLE
Prototype for preventing multiple editors on the same object.

### DIFF
--- a/ArtOfIllusion/src/artofillusion/LayoutWindow.java
+++ b/ArtOfIllusion/src/artofillusion/LayoutWindow.java
@@ -71,6 +71,8 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
   private List<ModellingTool> modellingTools;
   protected Preferences preferences;
 
+  public OpenEditorsList editor;
+
   /** Create a new LayoutWindow for editing a Scene.  Usually, you will not use this constructor directly.
       Instead, call ModellingApp.newWindow(Scene s). */
 
@@ -83,8 +85,10 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     undoStack = new UndoStack();
     sceneChangedEvent = new SceneChangedEvent(this);
     uiEventProcessor = new ActionProcessor();
+    editor = new OpenEditorsList();
     createItemList();
     objectListShown = true;
+
 
     // Create the four SceneViewer panels.
 
@@ -3042,5 +3046,54 @@ public class LayoutWindow extends BFrame implements EditingWindow, PopupMenuMana
     }
     updateImage();
     dispatchSceneChangedEvent(); // To be safe, since we can't rely on scripts to set undo records or call setModified().
+  }
+
+  public static class OpenEditorsList extends ArrayList<Object[]>
+  {
+    OpenEditorsList()
+    {
+      super();
+    }
+    
+    public boolean add(Object editor, Object editee)
+    {
+      for(int i = 0; i < this.size(); i++)
+        if (get(i)[1] == editee)
+        {
+          try
+          {
+             // This should help if the editor crashed and therefore was not removed from the list
+             // The editors are expected to be buoy WundowWidgets
+             // For other types you need to use 'remove' and what ever it takes to terminate the tool.
+
+             WindowWidget e = (WindowWidget)get(i)[0];
+             remove(e);
+             e.dispose();
+          }
+          catch (Exception x){}
+        }
+      add(new Object[]{editor, editee});
+      return true;
+    }
+
+    @Override
+    public boolean remove(Object editor)
+    {
+      for(int i = 0; i < this.size(); i++)
+        if (get(i)[0] == editor)
+        {
+          super.remove(i);
+          return true;
+        }
+      return false;
+    }
+
+    public Object existing(Object editee)
+    {
+      for(int i = 0; i < this.size(); i++)
+        if (get(i)[1] == editee)
+          return(get(i)[0]);
+      return null;
+    }
   }
 }

--- a/ArtOfIllusion/src/artofillusion/script/ScriptedObject.java
+++ b/ArtOfIllusion/src/artofillusion/script/ScriptedObject.java
@@ -319,12 +319,23 @@ public class ScriptedObject extends ObjectCollection
     return true;
   }
 
-  /** Allow the user to edit the script. */
+  /** Allow the user to edit the script. If an editor is already open, bring it to front*/
 
   @Override
   public void edit(EditingWindow parent, ObjectInfo info, Runnable cb)
   {
-    new ScriptedObjectEditorWindow(parent, info, cb);
+    ScriptedObjectEditorWindow currentEditor = (ScriptedObjectEditorWindow)((LayoutWindow)parent).editor.existing(this);
+
+    // The '!isVisible()' happens if the editor was diposed but not removed from the list
+    // The 'add' method removes non-visible WindowWidgets, but other types need 'remove'
+
+    if (currentEditor == null || !currentEditor.isVisible())
+    {
+      if (parent instanceof LayoutWindow)
+        ((LayoutWindow)parent).editor.add(new ScriptedObjectEditorWindow(parent, info, cb), this);
+    }
+    else
+      currentEditor.toFront(); // 'toFront()' does not work from LayouWinodow: After the call LW 'toFronts' itself.
   }
 
   /** This constructor reconstructs a ScriptedObject from an input stream. */

--- a/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
@@ -27,7 +27,7 @@ import org.fife.ui.rtextarea.RTextScrollPane;
 
 /** This class presents a user interface for entering object scripts. */
 
-public class ScriptedObjectEditorWindow extends BFrame
+public class ScriptedObjectEditorWindow extends BDialog
 {
   private EditingWindow window;
   private ObjectInfo info;

--- a/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
+++ b/ArtOfIllusion/src/artofillusion/script/ScriptedObjectEditorWindow.java
@@ -13,6 +13,7 @@ package artofillusion.script;
 import artofillusion.*;
 import artofillusion.object.*;
 import artofillusion.ui.*;
+
 import buoy.event.*;
 import buoy.widget.*;
 import java.awt.*;
@@ -75,7 +76,7 @@ public class ScriptedObjectEditorWindow extends BFrame
     buttons.add(Translate.button("Save", "...", this, "saveScript"));
     buttons.add(Translate.button("scriptParameters", this, "editParameters"));
     buttons.add(Translate.button("cancel", this, "dispose"));
-    addEventLink(WindowClosingEvent.class, this, "commitChanges");
+    addEventLink(WindowClosingEvent.class, this, "dispose");
     languageChoice.addEventLink(ValueChangedEvent.class, this, "updateLanguage");
     scriptText.setCaretPosition(0);
     pack();
@@ -206,6 +207,14 @@ public class ScriptedObjectEditorWindow extends BFrame
     window.updateImage();
     setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
     dispose();
+  }
+  
+  @Override
+  public void dispose()
+  {
+    if (window != null && window instanceof LayoutWindow)
+      ((LayoutWindow)window).editor.remove(this);
+    super.dispose();
   }
 
   /** This is an inner class for editing the list of parameters on the object. */


### PR DESCRIPTION
As discussed on #266.

- The prototype works on ScriptedObjects and the editor list is in the LayoutWindow. Now the editor list is an inner class, but as any EditingWindow can be a parent to sub-editors, it should be made a Java file of it's own.
- I also made the ScriptedObjectEditor a BDialog instead of BFrame. The difference is that now, when I have several objects open simultaneously they all appear on the front of the parent window, when one is activated. To me this actually seemed like a huge improvement into the situation where want compare two objects.
  - Now there still is that annoyance that new editors are always placed exactly on the same pixels right in the middle of the screen. AoI does not remember where the window (for that object) was the last time (though the user probably moved it for a reason) and also it does not bother to check where the last one of the similar kind was opened. A basic functionality from the beginning of graphic UI, that when several child windows are created they appear "cascaded".

