### PR TITLE
Fix AIOB in ExecuteScript Window

### DIFF
--- a/ArtOfIllusion/src/artofillusion/script/ExecuteScriptWindow.java
+++ b/ArtOfIllusion/src/artofillusion/script/ExecuteScriptWindow.java
@@ -69,8 +69,7 @@ public class ExecuteScriptWindow extends BFrame
       for (String recentFile : recentFiles) 
         if (!recentFile.equals(filePath)) // If the current file already has a timestamp it will be updated below
           newRecentFiles.add (recentFile);
-      pref.put("recentFiles", String.join (File.pathSeparator, 
-        (String []) newRecentFiles.subList(0, 10).toArray(new String[0])));
+      pref.put("recentFiles", String.join (File.pathSeparator, newRecentFiles.subList(0, java.lang.Math.min(newRecentFiles.size(), 10))));
     }
     
     public static String [] getRecentScripts()


### PR DESCRIPTION
Fix IndexOutOfBounds exception when actual newRecentFiles list size less than hardcoded 10 value. Also removed unnesessary convert and cast to String array