### PR TITLE
Grid timing

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -469,8 +469,8 @@ public abstract class ViewerCanvas extends CustomWidget
 
   /**
     ViewAnimation calls this when the animation is finished, so the orientation menu
-    will be up to date and the perspective is set to it's value without launched
-    launcing a new animation sequence.
+    will be up to date and the perspective is set to it's value without
+    launching a new animation sequence.
   */
 
   public void finishAnimation(int which, boolean persp, int navi)
@@ -623,7 +623,7 @@ public abstract class ViewerCanvas extends CustomWidget
     Set the distance from drawing plane to view camera. <p>
 
     Depending on the view action this may be used to recalculate
-    the positon of the camera or the rotationCenter or it may be
+    the position of the camera or the rotationCenter. Conversely, it may be
     recalculated from the rotationCenter and camera position.
    */
   public void setDistToPlane(double dist)

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1211,7 +1211,7 @@ public abstract class ViewerCanvas extends CustomWidget
 
     // Draw the grid, if necessary.
 
-    if (showGrid)
+    if (showGrid && !animation.animatingMove() && !animation.changingPerspective())
     {
       float scale1 = 0.75f/255.0f;
       float scale2 = 0.25f/255.0f;

--- a/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
@@ -58,7 +58,7 @@ public class ViewAnimation
   double   rotSlope = 1.5, moveSlope = 1.5, scaleSlope = .1, distSlope = .1,  perspSlope = 3.0;;
   int      endOrientation, endNavigation;
   long     msStart, msEnd, ms1st=0, msLast, msLatest;
-  boolean  endPerspective,changingPerspective, animatingMove, endShowGrid;
+  boolean  endPerspective, changingPerspective, animatingMove;
   int      viewH, viewW;
 
   /** A new view animation engine. Each view need's it's own.*/
@@ -130,9 +130,6 @@ public class ViewAnimation
       endAnimation(); // Go directly to the last frame
       return;
     }
-
-    endShowGrid = view.getShowGrid();
-    view.setShowGrid(false);
 
     this.refDistToPlane = refDistToPlane;
     startCoords = camera.getCameraCoordinates().duplicate();
@@ -208,7 +205,6 @@ public class ViewAnimation
     else
       this.endPerspective = view.isPerspectiveSwitch();
     this.endNavigation = nextNavigation;
-    this.endShowGrid = view.getShowGrid();
     camera = view.getCamera();
     endDistToScreen = camera.getDistToScreen();
 
@@ -395,7 +391,6 @@ public class ViewAnimation
     view.setScale(endScale);
     view.setRotationCenter(endRotationCenter);
     view.setDistToPlane(endCoords.getOrigin().minus(endRotationCenter).length()); // It seemed to work without this too... But not with SceneCamera
-    view.setShowGrid(endShowGrid);
     view.finishAnimation(endOrientation, endPerspective, endNavigation); // using set-methods for these would loop back to animation
     if (boundCamera != null)
         updateBoundCamera();

--- a/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewAnimation.java
@@ -213,8 +213,8 @@ public class ViewAnimation
     endDistToScreen = camera.getDistToScreen();
 
     checkPreferences(); // This only works for the 'animate'
-        if (! animate)
-        {
+    if (! animate)
+    {
       endAnimation(); // Go directly to the last frame
       return;
     }
@@ -397,16 +397,16 @@ public class ViewAnimation
     view.setDistToPlane(endCoords.getOrigin().minus(endRotationCenter).length()); // It seemed to work without this too... But not with SceneCamera
     view.setShowGrid(endShowGrid);
     view.finishAnimation(endOrientation, endPerspective, endNavigation); // using set-methods for these would loop back to animation
-        if (boundCamera != null)
-            updateBoundCamera();
-        else
-        {
+    if (boundCamera != null)
+        updateBoundCamera();
+    else
+    {
       view.viewChanged(false);
       view.repaint();
     }
     changingPerspective = false;
     animatingMove = false;
-    }
+  }
 
   /**
    * Check if there is anything that should move.


### PR DESCRIPTION
Fix to the disappearing grids issue mentioned [here](https://sourceforge.net/p/aoi/discussion/47783/thread/db8076ee17/). 

One way to could have been been to draw the grid always, when it is on. In many cases it would not hurt, but if there is a large move or a strong scaling happening, the flashing can be rather disturbing.

There were a couple of minor comment typo fixes in the last commit included, I hope those are not too disturbing. I could not just scroll past them when they hit my eye. :)
