### PR TITLE
Ray aim

### DIFF
--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -1244,6 +1244,7 @@ public class RaytracerRenderer implements Renderer, Runnable
     Vec3 orig = ray.getOrigin(), dir = ray.getDirection();
     double h = i-rtWidth*0.5+0.5, v = j-rtHeight*0.5+0.5;
     Random random = workspace.context.random;
+    int imgHeight = height;
 
     if (antialiasLevel > 0)
     {
@@ -1254,6 +1255,13 @@ public class RaytracerRenderer implements Renderer, Runnable
       int col = num-row*cols;
       h += (col+random.nextDouble())/cols-0.5;
       v += (row+random.nextDouble())/rows-0.5;
+
+      // To aim the rays correctly we need to use the height of 
+      // the actual image area, not the rendering area with the 
+      // extra antialiasing pixels around the edges. The value is 
+      // the rendering time height in pixels.
+
+      imgHeight = height*2;
     }
     double dof1 = 0.0, dof2 = 0.0;
     if (depth)
@@ -1261,7 +1269,7 @@ public class RaytracerRenderer implements Renderer, Runnable
       dof1 = 0.25*(random.nextDouble()+distrib1[number&15]);
       dof2 = 0.25*(random.nextDouble()+distrib2[number&15]);
     }
-    sceneCamera.getRayFromCamera(h/rtHeight, v/rtHeight, dof1, dof2, orig, dir);
+    sceneCamera.getRayFromCamera(h/imgHeight, v/imgHeight, dof1, dof2, orig, dir);
     theCamera.getCameraCoordinates().fromLocal().transform(orig);
     theCamera.getCameraCoordinates().fromLocal().transformDirection(dir);
     ray.newID();

--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2014 by Peter Eastman
-   Modifications copyright © 2020 by Petri Ihalainen
+   Modifications copyright © 2020-2024 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -870,11 +870,17 @@ public class RaytracerRenderer implements Renderer, Runnable
         int col = index-row*currentWidth[0];
         if (!isFirstPass[0] && row%2 == 0 && col%2 == 0)
           return;
-        int subsample = (finalMinRays > 1 ? 2 : 1);
+        int subsample = 1;
+        int extraedge = 0;
+        if (finalMinRays > 1)
+        {
+            subsample = 2;
+            extraedge = 1;
+        }
         RenderWorkspace workspace = getWorkspace();
         PixelInfo pixel = workspace.tempPixel;
         pixel.clear();
-        pixel.depth = (float) spawnEyeRay(workspace, col*subsample*currentScale[0], row*subsample*currentScale[0], 4, finalMinRays);
+        pixel.depth = (float) spawnEyeRay(workspace, col*subsample*currentScale[0]+extraedge, row*subsample*currentScale[0]+extraedge, 4, finalMinRays);
         pixel.object = (workspace.firstObjectHit == null ? 0.0f : Float.intBitsToFloat(workspace.firstObjectHit.getObject().hashCode()));
         pixel.add(workspace.color[0], (float) workspace.transparency[0]);
         recordPixel(col*currentScale[0], row*currentScale[0], currentScale[0], pixel);
@@ -930,9 +936,9 @@ public class RaytracerRenderer implements Renderer, Runnable
     for (int i = 0; i < pix.length; i++)
       for (int j = 0; j < pix[i].length; j++)
         pix[i][j] = new PixelInfo();
-    loadRow(pix[0], 0, tempColor);
-    loadRow(pix[2], 1, tempColor);
-    loadRow(pix[4], 2, tempColor);
+    loadRow(pix[1], 0, tempColor);
+    loadRow(pix[3], 1, tempColor);
+    loadRow(pix[5], 2, tempColor);
     int minPerSubpixel = minRaysInUse/4, maxPerSubpixel = maxRaysInUse/4;
     final int currentRow[] = new int [1];
     final int currentCount[] = new int [1];

--- a/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
+++ b/Renderers/src/artofillusion/raytracer/RaytracerRenderer.java
@@ -859,8 +859,9 @@ public class RaytracerRenderer implements Renderer, Runnable
     final int currentScale[] = new int [1];
     final int currentWidth[] = new int [1];
     final boolean isFirstPass[] = new boolean[] {true};
-    ThreadManager threads = new ThreadManager(width, new ThreadManager.Task() {
-          @Override
+    ThreadManager threads = new ThreadManager(width, new ThreadManager.Task()
+    {
+      @Override
       public void execute(int index)
       {
         if (renderThread != thisThread)
@@ -878,7 +879,7 @@ public class RaytracerRenderer implements Renderer, Runnable
         pixel.add(workspace.color[0], (float) workspace.transparency[0]);
         recordPixel(col*currentScale[0], row*currentScale[0], currentScale[0], pixel);
       }
-          @Override
+      @Override
       public void cleanup()
       {
         getWorkspace().cleanup();
@@ -935,8 +936,9 @@ public class RaytracerRenderer implements Renderer, Runnable
     int minPerSubpixel = minRaysInUse/4, maxPerSubpixel = maxRaysInUse/4;
     final int currentRow[] = new int [1];
     final int currentCount[] = new int [1];
-    threads = new ThreadManager(rtWidth, new ThreadManager.Task() {
-          @Override
+    threads = new ThreadManager(rtWidth, new ThreadManager.Task()
+    {
+      @Override
       public void execute(int index)
       {
         RenderWorkspace workspace = getWorkspace();
@@ -978,7 +980,7 @@ public class RaytracerRenderer implements Renderer, Runnable
           }
         }
       }
-          @Override
+      @Override
       public void cleanup()
       {
         getWorkspace().cleanup();


### PR DESCRIPTION
Resolves #239

There were two problems:
- The aim of the 1st set of rays in anti-aliasing
- The perceivable difference in FoV, when comparing a single-ray render to an anti-aliased one. 

It turned out that the pixel shift issue was actually a combination of two different miscalculations, which threw me off course in 2020: 

1. The firts set of rays was shot too much right and up
2. For the latter rays the positions _(= affected sub-pixels)_ of the first set were calculated wrong. 

The picture below presents what happened in the rendering space of a 2×2 pixel image. -- So there are 6×6 sub-pixels and 4/4 anti-aliasing, randomization ignored.

![Aim](https://github.com/ArtOfIllusion/ArtOfIllusion/assets/22843957/e08d9fd4-680d-4e9c-bb07-79f586bcfeab)

This is how the fix affects rendering _(FoV fix included)_ : 

![Before-After](https://github.com/ArtOfIllusion/ArtOfIllusion/assets/22843957/56a9f6fe-f152-4386-af1d-24c68c31bf1c)

The FoV issue was just the mistake of using the size of the rendering space as the reference size of the image. The rendering space _(that never exists as such but as a calculation method)_ is larger than the actual image.

These before and after images compare a single-ray render to an anti-aliased one. The object looks like changing size in the Before-case. Really it is the FoV that is changing.

![FoV before](https://github.com/ArtOfIllusion/ArtOfIllusion/assets/22843957/98ebb05f-27b0-4f0b-a502-170f9713c60b) 
![FoV after](https://github.com/ArtOfIllusion/ArtOfIllusion/assets/22843957/af6651a9-affe-4bd9-8a05-ee0db69ea584)

