### PR TITLE
Comma as alternate decimal separator

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ui/ValueField.java
+++ b/ArtOfIllusion/src/artofillusion/ui/ValueField.java
@@ -75,16 +75,16 @@ public class ValueField extends BTextField
     double val = value;
 
     try
-      {
-        if ((constraints & INTEGER) != 0)
-          val = (double) Integer.parseInt(getText());
-        else
-          val = new Double(getText());
-      }
+    {
+      if ((constraints & INTEGER) != 0)
+        val = (double) Integer.parseInt(getText());
+      else
+        val = new Double(getText());
+    }
     catch (NumberFormatException ex)
-      {
-        return false;
-      }
+    {
+      return false;
+    }
     return isValid(val);
   }
 
@@ -188,13 +188,13 @@ public class ValueField extends BTextField
     else if (val == 0.0 || val == -0.0)
       return "0.0";
     else
-      {
-        // Make sure at least three significant digits are visible.
+    {
+      // Make sure at least three significant digits are visible.
 
-        int digits = (int) Math.floor(Math.log(Math.abs(val))/Math.log(10.0));
-        double scale = Math.pow(10.0, digits < 0 ? decimalPlaces-1-digits : decimalPlaces);
-        return Double.toString(Math.round(val*scale)/scale);
-      }
+      int digits = (int) Math.floor(Math.log(Math.abs(val))/Math.log(10.0));
+      double scale = Math.pow(10.0, digits < 0 ? decimalPlaces-1-digits : decimalPlaces);
+      return Double.toString(Math.round(val*scale)/scale);
+    }
   }
 
   /** Set the minimum number of decimal places to display. */


### PR DESCRIPTION
A fix to a 20 year annoyance ... : ) Resolves #129

`ValueField` and `ValueSlider` can now handle comma as decimal separator. I'd expect this to be a very welcome tweak to most European users at least.

The function is that, while the field is being edited, it treats a single comma as a decimal separator just like a point. When the field loses focus, the comma is replaced by a point. The traditional computing- and American style of using point for the purpose is not affected.

If there are any other numbers fields I missed, let me know. _(Occasionally I have used software where some fields can handle comma and some not, which is again one of those quality things I don't like to leave behind.)_
