### PR TITLE
Scene camera focus/magnification glitch

### DIFF
--- a/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
+++ b/ArtOfIllusion/src/artofillusion/object/SceneCamera.java
@@ -265,14 +265,14 @@ public class SceneCamera extends Object3D
   {
     if (perspective)
     {
-      double scale = 0.5*height/Math.tan(getFieldOfView()*Math.PI/360.0);
+      double scale = 0.5*height/Math.tan(fov*Math.PI/360.0);
       Mat4 screenTransform = Mat4.scale(-scale, -scale, scale).times(Mat4.perspective(0.0));
       screenTransform = Mat4.translation((double) width/2.0, (double) height/2.0, 0.0).times(screenTransform);
       return screenTransform;
     }
     else
     {
-      double scale = 0.5*height/(Math.tan(getFieldOfView()*Math.PI/360.0)*getFocalDistance());
+      double scale = 0.5*height/(Math.tan(fov*Math.PI/360.0)*distToPlane);
       Mat4 screenTransform = Mat4.scale(-scale, -scale, scale).times(Mat4.identity());
       screenTransform = Mat4.translation((double) width/2.0, (double) height/2.0, 0.0).times(screenTransform);
       return screenTransform;
@@ -296,7 +296,7 @@ public class SceneCamera extends Object3D
     if (perspective)
     {
       origin.set(0.0, 0.0, 0.0);
-      double scale = focalDist*2.0*Math.tan(getFieldOfView()*Math.PI/360.0);
+      double scale = focalDist*2.0*Math.tan(fov*Math.PI/360.0);
       if (dof1 != 0.0)
       {
         double angle = dof1*2.0*Math.PI;
@@ -309,7 +309,7 @@ public class SceneCamera extends Object3D
     }
     else
     {
-      double scale = focalDist*2.0*Math.tan(getFieldOfView()*Math.PI/360.0);
+      double scale = distToPlane*2.0*Math.tan(fov*Math.PI/360.0);
       origin.set(-scale*x, -scale*y, 0);
       if (dof1 != 0.0)
       {


### PR DESCRIPTION
"Focus distance" and "focal length" confusion. I separated these anywhere I could find many years ago, but I missed this one and it has bee haunting me ever since.

The issue:
- Focus distance _("Focal distance" in AoI terms)_ is the distance from camera lens to the depth in scene that it is looking at.
- Focal length _("Distance to plane", sorry for the name...)_ is the distance from the camera lens to the film or projection plane that generates the is image show to the user.

These two don't exist in the same space and are fully independent of each other. Sadly many sources that talk about 3D-graphics don't make the distinction between them and present as if the image of the scene was actually drawn in the scene... That was the case with AoI too.

A renaming PR would be in order, but bug fix first!
