### PR TITLE
Default renderers are separate instances. Resolves #331

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
+++ b/ArtOfIllusion/src/artofillusion/ApplicationPreferences.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 2002-2009 by Peter Eastman
    Changes Copyright (C) 2016-2019 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
+   Changes Copyright (C) 2026 by Lucas Stanek
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -259,7 +260,10 @@ public class ApplicationPreferences
     }
   }
 
-  /** Look up a renderer by name. */
+  /** Look up a renderer by name.
+   *  This returns a new instance of the named render type, to prevent
+   *  the different default render settings from walking over each other.
+   **/
 
   private Renderer getNamedRenderer(String name)
   {
@@ -268,8 +272,17 @@ public class ApplicationPreferences
       return null;
     for (Renderer r : renderers)
       if (r.getName().equals(name))
-        return r;
-    return renderers.get(renderers.size()-1);
+      try //hacky, should not be possible to fail
+      {
+        return r.getClass().newInstance();
+      }
+      catch (Exception e) {}
+    try
+    {  
+      return renderers.get(renderers.size()-1).getClass().newInstance();
+    }
+    catch (Exception e) {}
+    return null;
   }
 
   /** Get the default renderer. */

--- a/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
+++ b/ArtOfIllusion/src/artofillusion/PreferencesWindow.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 2002-2009 by Peter Eastman
    Changes Copyright (C) 2016-2019 by Petri Ihalainen
    Changes copyright (C) 2017 by Maksim Khramov
+   Changes Copyright (C) 2026 by Lucas Stanek
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -63,11 +64,13 @@ public class PreferencesWindow
     Locale languages[] = Translate.getAvailableLocales();
     List<Renderer> renderers = PluginRegistry.getPlugins(Renderer.class);
     if (renderers.size() > 0)
+    try //hacky, should not be possible to fail.
     {
-      prefs.setDefaultRenderer(renderers.get(defaultRendChoice.getSelectedIndex()));
-      prefs.setObjectPreviewRenderer(renderers.get(objectRendChoice.getSelectedIndex()));
-      prefs.setTexturePreviewRenderer(renderers.get(texRendChoice.getSelectedIndex()));
+      prefs.setDefaultRenderer(renderers.get(defaultRendChoice.getSelectedIndex()).getClass().newInstance());
+      prefs.setObjectPreviewRenderer(renderers.get(objectRendChoice.getSelectedIndex()).getClass().newInstance());
+      prefs.setTexturePreviewRenderer(renderers.get(texRendChoice.getSelectedIndex()).getClass().newInstance());
     }
+    catch (Exception e) {}
     prefs.setInteractiveSurfaceError(interactiveTolField.getValue());
     prefs.setUndoLevels((int) undoField.getValue());
     if (!prefs.getLocale().equals(languages[localeChoice.getSelectedIndex()]))


### PR DESCRIPTION
@peteihis Can you test and confirm that this fixes the issues that you found?

Alternative to #333, that should avoid having to teach the renderer setup dialogs about `ViewerCanvas` and its states.

Just makes sure that the default renderers for each type of preview are different instances, and that changing the preferred render type doesn't break that. It's still possible for scripts, etc. to override through the `ApplicationPreferences` API, but if you do that, hopefully you know what you are doing.

Long term, I'd like to avoid the Plugin system carrying around instances in the first place, but that's not for today.