### PR TITLE
Rendered mode can do parallel

### DIFF
--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2008 by Peter Eastman
-   Modifications copyright (C) 2017-2019 Petri Ihalainen
+   Modifications copyright (C) 2017-2024 Petri Ihalainen
    Changes copyright (C) 2017-2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -28,6 +28,7 @@ import java.util.*;
 public abstract class ObjectViewer extends ViewerCanvas
 {
   protected MeshEditController controller;
+  protected SceneCamera renderedModeCamera;
   protected boolean showScene, useWorldCoords, freehandSelection, draggingBox, squareBox, sentClick;
   protected Point clickPoint, dragPoint;
   protected Vector<Point> selectBoundsPoints;
@@ -39,6 +40,7 @@ public abstract class ObjectViewer extends ViewerCanvas
   {
     super(ArtOfIllusion.getPreferences().getUseOpenGL() && isOpenGLAvailable());
     this.controller = controller;
+    renderedModeCamera = null;
     buildChoices(p);
   }
 
@@ -107,7 +109,6 @@ public abstract class ObjectViewer extends ViewerCanvas
       Renderer rend = ArtOfIllusion.getPreferences().getObjectPreviewRenderer();
       if (rend == null)
         return;
-      adjustCamera(true);
       Scene sc;
       Camera cam = theCamera.duplicate();
       if (showScene && theScene != null)
@@ -147,9 +148,13 @@ public abstract class ObjectViewer extends ViewerCanvas
         sc.addObject(obj, null);
       }
       rend.configurePreview();
-      Rectangle bounds = getBounds();
-      SceneCamera sceneCamera = new SceneCamera();
-      sceneCamera.setFieldOfView(Math.atan(0.5*bounds.height/(cam.getDistToScreen()*getScale()))*360.0/Math.PI);
+      int h = getBounds().height;
+      if (renderedModeCamera == null)
+        renderedModeCamera = new SceneCamera();
+      renderedModeCamera.setDistToPlane(distToPlane);
+      renderedModeCamera.setFocalDistance(distToPlane);
+      renderedModeCamera.setFieldOfView(2.0*Math.toDegrees(Math.atan(0.5*h/100.0/cam.getDistToScreen())));
+      renderedModeCamera.setPerspective(isPerspective());
       adjustCamera(isPerspective());
       RenderListener listener = new RenderListener()
       {
@@ -168,8 +173,10 @@ public abstract class ObjectViewer extends ViewerCanvas
           repaint();
         }
       };
-      rend.renderScene(sc, cam, listener, sceneCamera);
+      rend.renderScene(sc, cam, listener, renderedModeCamera);
     }
+    else
+      renderedModeCamera = null;
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/ObjectViewer.java
+++ b/ArtOfIllusion/src/artofillusion/ObjectViewer.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2008 by Peter Eastman
-   Modifications copyright (C) 2017-2024 Petri Ihalainen
+   Changes copyright (C) 2017-2026 Petri Ihalainen
    Changes copyright (C) 2017-2020 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -29,6 +29,7 @@ public abstract class ObjectViewer extends ViewerCanvas
 {
   protected MeshEditController controller;
   protected SceneCamera renderedModeCamera;
+  protected Renderer viewRenderer;
   protected boolean showScene, useWorldCoords, freehandSelection, draggingBox, squareBox, sentClick;
   protected Point clickPoint, dragPoint;
   protected Vector<Point> selectBoundsPoints;
@@ -39,7 +40,8 @@ public abstract class ObjectViewer extends ViewerCanvas
   public ObjectViewer(MeshEditController controller, RowContainer p)
   {
     super(ArtOfIllusion.getPreferences().getUseOpenGL() && isOpenGLAvailable());
-    this.controller = controller;
+    this.controller    = controller;
+    viewRenderer       = null;
     renderedModeCamera = null;
     buildChoices(p);
   }
@@ -106,9 +108,17 @@ public abstract class ObjectViewer extends ViewerCanvas
     {
       // Re-render the image.
 
-      Renderer rend = ArtOfIllusion.getPreferences().getObjectPreviewRenderer();
-      if (rend == null)
-        return;
+      if (viewRenderer == null)
+        try
+        {
+          viewRenderer = ArtOfIllusion.getPreferences().getDefaultRenderer().getClass().newInstance();
+        }
+        catch(Exception i)
+        {
+          return;
+        }
+      //if (viewRenderer == null)
+      //  return;
       Scene sc;
       Camera cam = theCamera.duplicate();
       if (showScene && theScene != null)
@@ -147,7 +157,7 @@ public abstract class ObjectViewer extends ViewerCanvas
         obj.getCoords().transformCoordinates(getDisplayCoordinates().fromLocal());
         sc.addObject(obj, null);
       }
-      rend.configurePreview();
+      viewRenderer.configurePreview();
       int h = getBounds().height;
       if (renderedModeCamera == null)
         renderedModeCamera = new SceneCamera();
@@ -173,10 +183,14 @@ public abstract class ObjectViewer extends ViewerCanvas
           repaint();
         }
       };
-      rend.renderScene(sc, cam, listener, renderedModeCamera);
+      viewRenderer.renderScene(sc, cam, listener, renderedModeCamera);
     }
-    else
+    else if (viewRenderer != null)
+    {
+      viewRenderer = null;
       renderedModeCamera = null;
+      System.gc();
+    }
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -1,6 +1,6 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
    Changes copyright (C) 2016-2020 by Maksim Khramov
-   Changes copyright (C) 2017-2019 by Petri Ihalainen
+   Changes copyright (C) 2017-2026 by Petri Ihalainen
 
    This program is free software; you can redistribute it and/or modify it under the
    terms of the GNU General Public License as published by the Free Software
@@ -29,6 +29,7 @@ public class SceneViewer extends ViewerCanvas
 {
   Scene theScene;
   EditingWindow parentFrame;
+  SceneCamera renderedModeCamera;
   private Vector<ObjectInfo> cameras;
   boolean draggingBox, draggingSelectionBox, squareBox, sentClick, dragging;
   Point clickPoint, dragPoint;
@@ -45,6 +46,7 @@ public class SceneViewer extends ViewerCanvas
     super(ArtOfIllusion.getPreferences().getUseOpenGL() && isOpenGLAvailable() && !forceSoftwareRendering);
     theScene = s;
     parentFrame = fr;
+    renderedModeCamera = null;
     addEventLink(MouseClickedEvent.class, this, "mouseClicked");
     draggingBox = draggingSelectionBox = false;
     cameras = new Vector<ObjectInfo>();
@@ -216,12 +218,18 @@ public class SceneViewer extends ViewerCanvas
       Renderer rend = ArtOfIllusion.getPreferences().getObjectPreviewRenderer();
       if (rend == null)
         return;
-      adjustCamera(true);
       Camera cam = theCamera.duplicate();
       rend.configurePreview();
-      Rectangle bounds = getBounds();
-      SceneCamera sceneCamera = new SceneCamera();
-      sceneCamera.setFieldOfView(Math.atan(0.5*bounds.height/cam.getViewToScreen().m33)*360.0/Math.PI);
+      int h = getBounds().height;
+      if (renderedModeCamera == null)
+        renderedModeCamera = new SceneCamera();
+      renderedModeCamera.setDistToPlane(distToPlane);
+      renderedModeCamera.setFocalDistance(distToPlane);
+      renderedModeCamera.setPerspective(isPerspective());
+      if (boundCamera != null && boundCamera.getObject() instanceof SceneCamera)
+        renderedModeCamera.setFieldOfView(((SceneCamera)boundCamera.getObject()).getFieldOfView());
+      else
+        renderedModeCamera.setFieldOfView(2.0*Math.toDegrees(Math.atan(0.5*h/100.0/cam.getDistToScreen())));
       adjustCamera(isPerspective());
       RenderListener listener = new RenderListener()
       {
@@ -240,8 +248,10 @@ public class SceneViewer extends ViewerCanvas
           repaint();
         }
       };
-      rend.renderScene(theScene, cam, listener, sceneCamera);
+      rend.renderScene(theScene, cam, listener, renderedModeCamera);
     }
+    else
+      renderedModeCamera = null;
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/SceneViewer.java
+++ b/ArtOfIllusion/src/artofillusion/SceneViewer.java
@@ -29,6 +29,7 @@ public class SceneViewer extends ViewerCanvas
 {
   Scene theScene;
   EditingWindow parentFrame;
+  Renderer viewRenderer;
   SceneCamera renderedModeCamera;
   private Vector<ObjectInfo> cameras;
   boolean draggingBox, draggingSelectionBox, squareBox, sentClick, dragging;
@@ -46,6 +47,7 @@ public class SceneViewer extends ViewerCanvas
     super(ArtOfIllusion.getPreferences().getUseOpenGL() && isOpenGLAvailable() && !forceSoftwareRendering);
     theScene = s;
     parentFrame = fr;
+    viewRenderer = null;
     renderedModeCamera = null;
     addEventLink(MouseClickedEvent.class, this, "mouseClicked");
     draggingBox = draggingSelectionBox = false;
@@ -213,13 +215,19 @@ public class SceneViewer extends ViewerCanvas
     super.viewChanged(selectionOnly);
     if (renderMode == RENDER_RENDERED && !selectionOnly)
     {
-      // Re-render the image.
-
-      Renderer rend = ArtOfIllusion.getPreferences().getObjectPreviewRenderer();
-      if (rend == null)
-        return;
+      if (viewRenderer == null)
+        try
+        {
+          viewRenderer = ArtOfIllusion.getPreferences().getDefaultRenderer().getClass().newInstance();
+        }
+        catch(Exception i)
+        {
+          return;
+        };
+      //if (viewRenderer == null)
+      //  return;
       Camera cam = theCamera.duplicate();
-      rend.configurePreview();
+      viewRenderer.configurePreview();
       int h = getBounds().height;
       if (renderedModeCamera == null)
         renderedModeCamera = new SceneCamera();
@@ -248,10 +256,14 @@ public class SceneViewer extends ViewerCanvas
           repaint();
         }
       };
-      rend.renderScene(theScene, cam, listener, renderedModeCamera);
+      viewRenderer.renderScene(theScene, cam, listener, renderedModeCamera);
     }
-    else
+    else if (viewRenderer != null)
+    {
+      viewRenderer = null;
       renderedModeCamera = null;
+      System.gc();
+    }
   }
 
   @Override

--- a/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
+++ b/ArtOfIllusion/src/artofillusion/ViewerCanvas.java
@@ -1,5 +1,5 @@
 /* Copyright (C) 1999-2011 by Peter Eastman
-   Changes Copyrignt (C) 2016-2020 Petri Ihalainen
+   Changes Copyrignt (C) 2016-2026 Petri Ihalainen
    Changes copyright (C) 2016-2022 by Maksim Khramov
 
    This program is free software; you can redistribute it and/or modify it under the
@@ -1321,15 +1321,6 @@ public abstract class ViewerCanvas extends CustomWidget
 
   public void setRenderMode(int mode)
   {
-    if (mode == RENDER_RENDERED && currentTool != null)
-    {
-      for (ViewerCanvas view : currentTool.getWindow().getAllViews())
-        if (view != this && view.getRenderMode() == RENDER_RENDERED)
-        {
-          new BStandardDialog("", Translate.text("renderedModeMultipleViews"), BStandardDialog.ERROR).showMessageDialog(UIUtilities.findWindow(this));
-          return;
-        }
-    }
     renderMode = mode;
     renderedImage = null;
     viewChanged(false);

--- a/ArtOfIllusion/src/artofillusion/view/ViewerPerspectiveControl.java
+++ b/ArtOfIllusion/src/artofillusion/view/ViewerPerspectiveControl.java
@@ -40,8 +40,6 @@ public class ViewerPerspectiveControl implements ViewerControl
           view.setPerspective(((SceneCamera)view.getBoundCamera().getObject()).isPerspective());
           perspectiveChoice.setSelectedIndex(view.isPerspectiveSwitch() ? 0 : 1);
         }
-        else if (view.getRenderMode() == ViewerCanvas.RENDER_RENDERED)
-          perspectiveChoice.setEnabled(false);
         else
         {
           perspectiveChoice.setEnabled(view.perspectiveControlEnabled);


### PR DESCRIPTION
Perspective and parallel work in rendered mode the same way they do in other modes.

I also tried to remove the limit that only one view can be rendered at a time but a problem emerged: The change was an easy one itself but for some reason, if more than one view was in rendered mode, some of them did not respond to changes in the scene or in the object. Have to look at that some time later.
